### PR TITLE
Add help overlay and fix Debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,10 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
-# Compiler flags for performance
+# Compiler flags
 if(MSVC)
-    add_compile_options(/O2 /W4)
+    add_compile_options(/W4)
+    add_compile_options($<$<CONFIG:Release>:/O2>)
     add_compile_definitions(NOMINMAX _CRT_SECURE_NO_WARNINGS)
 endif()
 

--- a/include/app.h
+++ b/include/app.h
@@ -201,6 +201,17 @@ struct App {
     int hoveredFolderIndex = -1;
     float folderBrowserScroll = 0.0f;     // Scroll offset for folder list
 
+    // Help overlay
+    bool showHelp = false;
+    float helpAnimation = 0.0f;
+    float helpScroll = 0.0f;
+    float helpContentHeight = 0.0f;   // Total content height (set during render)
+    float helpVisibleHeight = 0.0f;   // Visible area height (set during render)
+    float helpScrollbarTop = 0.0f;    // Scrollbar track top Y (set during render)
+    bool helpScrollbarDragging = false;
+    float helpScrollbarDragStartY = 0;
+    float helpScrollbarDragStartScroll = 0;
+
     // Table of contents overlay
     bool showToc = false;
     float tocAnimation = 0.0f;  // 0 to 1 for slide-in from right

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -7,5 +7,6 @@ void renderSearchOverlay(App& app);
 void renderFolderBrowser(App& app);
 void renderToc(App& app);
 void renderThemeChooser(App& app);
+void renderHelpOverlay(App& app);
 
 #endif // TINTA_OVERLAYS_H

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -22,6 +22,14 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     bool ctrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
     float delta = (float)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
 
+    // Help overlay scroll
+    if (app.showHelp) {
+        app.helpScroll -= delta * dpi(app, 60.0f);
+        if (app.helpScroll < 0) app.helpScroll = 0;
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     // Edit mode: route scroll to editor or preview based on mouse X
     if (app.editMode) {
         float sepX = app.width * app.editorSplitRatio;
@@ -113,6 +121,23 @@ void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     app.mouseX = GET_X_LPARAM(lParam);
     app.mouseY = GET_Y_LPARAM(lParam);
+
+    // Help overlay scrollbar dragging
+    if (app.helpScrollbarDragging) {
+        float maxScroll = std::max(0.0f, app.helpContentHeight - app.helpVisibleHeight);
+        if (maxScroll > 0) {
+            float sbHeight = app.helpVisibleHeight / app.helpContentHeight * app.helpVisibleHeight;
+            sbHeight = std::max(sbHeight, dpi(app, 20.0f));
+            float trackHeight = app.helpVisibleHeight - sbHeight;
+
+            float deltaY = (float)app.mouseY - app.helpScrollbarDragStartY;
+            float scrollDelta = (trackHeight > 0) ? (deltaY / trackHeight) * maxScroll : 0;
+            app.helpScroll = app.helpScrollbarDragStartScroll + scrollDelta;
+            app.helpScroll = std::max(0.0f, std::min(app.helpScroll, maxScroll));
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
+        return;
+    }
 
     // Edit mode: handle separator drag, editor selection, cursor shape
     if (app.editMode) {
@@ -321,6 +346,41 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         // Fall through for preview pane clicks
     }
 
+    // Help overlay: check scrollbar click
+    if (app.showHelp) {
+        float maxScroll = std::max(0.0f, app.helpContentHeight - app.helpVisibleHeight);
+        if (maxScroll > 0) {
+            int clickX = GET_X_LPARAM(lParam);
+            int clickY = GET_Y_LPARAM(lParam);
+            // Scrollbar hit area: right edge of panel
+            float panelWidth = std::min(dpi(app, 520.0f), app.width - dpi(app, 40.0f));
+            float panelRight = (app.width + panelWidth) / 2;
+            float sbHitWidth = dpi(app, 16.0f);
+            if (clickX >= panelRight - sbHitWidth && clickX <= panelRight &&
+                clickY >= app.helpScrollbarTop && clickY <= app.helpScrollbarTop + app.helpVisibleHeight) {
+                app.helpScrollbarDragging = true;
+                app.helpScrollbarDragStartY = (float)clickY;
+                app.helpScrollbarDragStartScroll = app.helpScroll;
+                SetCapture(hwnd);
+
+                // Jump if clicked outside thumb
+                float sbHeight = app.helpVisibleHeight / app.helpContentHeight * app.helpVisibleHeight;
+                sbHeight = std::max(sbHeight, dpi(app, 20.0f));
+                float sbY = app.helpScrollbarTop + (app.helpScroll / maxScroll * (app.helpVisibleHeight - sbHeight));
+                if (clickY < sbY || clickY > sbY + sbHeight) {
+                    float trackHeight = app.helpVisibleHeight - sbHeight;
+                    float clickPos = (float)clickY - app.helpScrollbarTop - sbHeight / 2;
+                    clickPos = std::max(0.0f, std::min(clickPos, trackHeight));
+                    app.helpScroll = (trackHeight > 0) ? (clickPos / trackHeight) * maxScroll : 0;
+                    app.helpScrollbarDragStartScroll = app.helpScroll;
+                    app.helpScrollbarDragStartY = (float)clickY;
+                }
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+        }
+        return;
+    }
+
     // If theme chooser, folder browser, or TOC is open, don't start selection - just record for click handling
     if (app.showThemeChooser || app.showFolderBrowser || app.showToc) {
         return;
@@ -459,6 +519,14 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 }
 
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    // Help scrollbar release
+    if (app.helpScrollbarDragging) {
+        app.helpScrollbarDragging = false;
+        ReleaseCapture();
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     // Edit mode: route to editor
     if (app.editMode && (app.draggingSeparator || app.editorSelecting)) {
         int x = GET_X_LPARAM(lParam);
@@ -795,8 +863,11 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     } else {
         switch (wParam) {
             case VK_ESCAPE:
-                // Priority: Search > FolderBrowser > TOC > Theme chooser > Quit
-                if (app.showSearch) {
+                // Priority: Help > Search > FolderBrowser > TOC > Theme chooser > Quit
+                if (app.showHelp) {
+                    app.showHelp = false;
+                    app.helpAnimation = 0;
+                } else if (app.showSearch) {
                     app.showSearch = false;
                     app.searchActive = false;
                     app.searchQuery.clear();
@@ -920,11 +991,19 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
         return;
     }
 
-    // ':' to enter edit mode when no overlay is active
+    // ':' to enter edit mode, '?' to toggle help — when no overlay is active
     if (!app.showSearch && !app.showFolderBrowser && !app.showToc && !app.showThemeChooser) {
         wchar_t ch = (wchar_t)wParam;
-        if (ch == L':') {
+        if (ch == L':' && !app.showHelp) {
             enterEditMode(app);
+            return;
+        }
+        if (ch == L'?') {
+            app.showHelp = !app.showHelp;
+            if (app.showHelp) {
+                app.helpAnimation = 0;
+            }
+            InvalidateRect(app.hwnd, nullptr, FALSE);
             return;
         }
     }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -543,6 +543,7 @@ render_document:
     if (app.showFolderBrowser) renderFolderBrowser(app);
     if (app.showToc) renderToc(app);
     if (app.showThemeChooser) renderThemeChooser(app);
+    if (app.showHelp) renderHelpOverlay(app);
 
     // Close edit mode split view clipping
     if (app.editMode) {
@@ -682,12 +683,21 @@ static const char* sampleMarkdown = R"(# Welcome to Tinta
 
 **Tinta** is a fast, lightweight markdown reader for Windows.
 
+## Getting Started
+
+- **Drag & drop** a `.md` file onto this window
+- Press **B** to browse and open files from a folder
+- Or run `tinta.exe readme.md` from the command line
+- Press **?** for all available keyboard shortcuts
+
 ## Features
 
-- Lightning-fast startup with Direct2D
-- Hardware-accelerated text rendering via DirectWrite
-- Minimal dependencies
-- Small binary size
+- 10 beautiful themes — press **T** to choose
+- Edit mode with live preview — press **:**
+- Search — press **F**
+- Table of contents — press **Tab**
+- Text selection and copy
+- Syntax highlighting in code blocks for C/C++, Python, JavaScript, Rust, Go, and Bash
 
 ## Code Example
 
@@ -700,12 +710,37 @@ int main() {
 
 ## Keyboard Shortcuts
 
-- **F** or **Ctrl+F** - Open search
-- **T** - Open theme chooser
-- **S** - Toggle stats overlay
-- **Ctrl+C** - Copy text
+Press **?** at any time to see all shortcuts.
+
+### Navigation
+
+- **J / K** - Scroll down / up
+- **Space / PgDn** - Page down
+- **PgUp** - Page up
+- **Home / End** - Jump to start / end
+- **Ctrl+Scroll** - Zoom in / out
+
+### View
+
+- **F** or **Ctrl+F** - Search
+- **Enter** - Next search match
+- **B** - Toggle folder browser
+- **Tab** - Toggle table of contents
+- **T** - Theme chooser
+- **S** - Toggle stats
+
+### Editing
+
+- **:** - Enter edit mode
+- **Ctrl+S** - Save (in edit mode)
+- **ESC ESC** - Exit edit mode
+
+### General
+
 - **Ctrl+A** - Select all
-- **Q** or **ESC** - Quit
+- **Ctrl+C** - Copy selection
+- **ESC** - Close overlay / Quit
+- **Q** - Quit
 )";
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow) {

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -624,3 +624,181 @@ void renderThemeChooser(App& app) {
             D2D1::RectF(panelX + dpi(app, 40.0f) + cardWidth, gridStartY - dpi(app, 20.0f), panelX + dpi(app, 40.0f) + cardWidth * 2, gridStartY - dpi(app, 5.0f)), app.brush);
     }
 }
+
+void renderHelpOverlay(App& app) {
+    // Animate in
+    if (app.helpAnimation < 1.0f) {
+        float prev = app.helpAnimation;
+        app.helpAnimation = std::min(1.0f, app.helpAnimation + 0.15f);
+        if (app.helpAnimation != prev)
+            InvalidateRect(app.hwnd, nullptr, FALSE);
+    }
+    float anim = app.helpAnimation;
+
+    // Semi-transparent backdrop
+    app.brush->SetColor(D2D1::ColorF(0, 0, 0, 0.85f * anim));
+    app.renderTarget->FillRectangle(
+        D2D1::RectF(0, 0, (float)app.width, (float)app.height), app.brush);
+
+    // Panel dimensions — fit to window
+    float panelWidth = std::min(dpi(app, 520.0f), app.width - dpi(app, 40.0f));
+    float panelHeight = std::min(dpi(app, 700.0f), app.height - dpi(app, 40.0f));
+    float panelX = (app.width - panelWidth) / 2;
+    float panelY = (app.height - panelHeight) / 2 + (1 - anim) * dpi(app, 50.0f);
+
+    // Panel background
+    D2D1_ROUNDED_RECT panelRect = D2D1::RoundedRect(
+        D2D1::RectF(panelX, panelY, panelX + panelWidth, panelY + panelHeight),
+        dpi(app, 16.0f), dpi(app, 16.0f));
+    app.brush->SetColor(hexColor(0x1A1A1E, 0.98f * anim));
+    app.renderTarget->FillRoundedRectangle(panelRect, app.brush);
+
+    // Border
+    app.brush->SetColor(hexColor(0x3A3A40, 0.6f * anim));
+    app.renderTarget->DrawRoundedRectangle(panelRect, app.brush, 1.0f);
+
+    // Title (fixed, not scrolled)
+    float titleBottomY = panelY + dpi(app, 55.0f);
+    IDWriteTextFormat* titleFormat = app.themeTitleFormat;
+    if (titleFormat) {
+        titleFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+        app.brush->SetColor(D2D1::ColorF(1, 1, 1, anim));
+        app.renderTarget->DrawText(L"Keyboard Shortcuts", 18, titleFormat,
+            D2D1::RectF(panelX, panelY + dpi(app, 15.0f), panelX + panelWidth, titleBottomY), app.brush);
+    }
+
+    IDWriteTextFormat* boldFmt = app.tocFormatBold;
+    IDWriteTextFormat* normalFmt = app.tocFormat;
+    if (!boldFmt || !normalFmt) return;
+
+    // Shortcut entries
+    struct HelpEntry {
+        const wchar_t* key;
+        const wchar_t* desc;
+    };
+
+    const HelpEntry navEntries[] = {
+        {L"J / \x2193",   L"Scroll down"},
+        {L"K / \x2191",   L"Scroll up"},
+        {L"Space / PgDn", L"Page down"},
+        {L"PgUp",         L"Page up"},
+        {L"Home / End",   L"Jump to start / end"},
+        {L"Ctrl+Scroll",  L"Zoom in / out"},
+    };
+
+    const HelpEntry overlayEntries[] = {
+        {L"F / Ctrl+F",   L"Search"},
+        {L"Enter",        L"Next search match"},
+        {L"B",            L"Toggle folder browser"},
+        {L"Tab",          L"Toggle table of contents"},
+        {L"T",            L"Theme chooser"},
+        {L"S",            L"Toggle stats"},
+        {L"?",            L"This help"},
+    };
+
+    const HelpEntry editEntries[] = {
+        {L":",             L"Enter edit mode"},
+        {L"Ctrl+S",       L"Save (in edit mode)"},
+        {L"ESC ESC",      L"Exit edit mode"},
+    };
+
+    const HelpEntry generalEntries[] = {
+        {L"Ctrl+A",       L"Select all text"},
+        {L"Ctrl+C",       L"Copy selection"},
+        {L"ESC",          L"Close overlay / Quit"},
+        {L"Q",            L"Quit"},
+    };
+
+    float padding = dpi(app, 20.0f);
+    float keyColWidth = dpi(app, 150.0f);
+    float leftX = panelX + padding;
+    float descX = leftX + keyColWidth;
+    float rightEdge = panelX + panelWidth - padding;
+    float lineH = dpi(app, 22.0f);
+    float sectionGap = dpi(app, 10.0f);
+    float sectionHeaderExtra = dpi(app, 4.0f);
+
+    // Calculate total content height
+    auto sectionHeight = [&](int entryCount) {
+        return lineH + sectionHeaderExtra + entryCount * lineH + sectionGap;
+    };
+    float footerH = dpi(app, 35.0f);
+    float totalContentHeight = sectionHeight(6) + sectionHeight(7) + sectionHeight(3) + sectionHeight(4) + footerH;
+
+    // Scrollable area
+    float contentTopY = titleBottomY + dpi(app, 10.0f);
+    float contentBottomY = panelY + panelHeight;
+    float visibleHeight = contentBottomY - contentTopY;
+
+    // Store dimensions for input handling (scrollbar drag)
+    app.helpContentHeight = totalContentHeight;
+    app.helpVisibleHeight = visibleHeight;
+    app.helpScrollbarTop = contentTopY;
+
+    // Clamp scroll
+    float maxScroll = std::max(0.0f, totalContentHeight - visibleHeight);
+    app.helpScroll = std::max(0.0f, std::min(app.helpScroll, maxScroll));
+
+    // Push clip so content doesn't draw outside panel
+    app.renderTarget->PushAxisAlignedClip(
+        D2D1::RectF(panelX, contentTopY, panelX + panelWidth, contentBottomY),
+        D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
+
+    float y = contentTopY - app.helpScroll;
+
+    auto drawSection = [&](const wchar_t* title, const HelpEntry* entries, int count) {
+        // Section header
+        boldFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+        D2D1_COLOR_F headerColor = app.theme.accent;
+        headerColor.a = anim;
+        app.brush->SetColor(headerColor);
+        app.renderTarget->DrawText(title, (UINT32)wcslen(title), boldFmt,
+            D2D1::RectF(leftX, y, rightEdge, y + lineH), app.brush);
+        y += lineH + sectionHeaderExtra;
+
+        for (int i = 0; i < count; i++) {
+            // Key
+            boldFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+            app.brush->SetColor(D2D1::ColorF(1.0f, 1.0f, 1.0f, 0.9f * anim));
+            app.renderTarget->DrawText(entries[i].key, (UINT32)wcslen(entries[i].key), boldFmt,
+                D2D1::RectF(leftX + dpi(app, 8.0f), y, leftX + keyColWidth, y + lineH), app.brush);
+
+            // Description
+            normalFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+            app.brush->SetColor(D2D1::ColorF(0.7f, 0.7f, 0.7f, 0.9f * anim));
+            app.renderTarget->DrawText(entries[i].desc, (UINT32)wcslen(entries[i].desc), normalFmt,
+                D2D1::RectF(descX, y, rightEdge, y + lineH), app.brush);
+
+            y += lineH;
+        }
+        y += sectionGap;
+    };
+
+    drawSection(L"NAVIGATION", navEntries, 6);
+    drawSection(L"VIEW", overlayEntries, 7);
+    drawSection(L"EDITING", editEntries, 3);
+    drawSection(L"GENERAL", generalEntries, 4);
+
+    // Footer hint
+    normalFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+    app.brush->SetColor(D2D1::ColorF(0.5f, 0.5f, 0.5f, anim));
+    app.renderTarget->DrawText(L"Press ESC or ? to close", 23, normalFmt,
+        D2D1::RectF(panelX, y, panelX + panelWidth, y + lineH), app.brush);
+
+    app.renderTarget->PopAxisAlignedClip();
+
+    // Scrollbar if content overflows
+    if (maxScroll > 0) {
+        float sbHeight = visibleHeight / totalContentHeight * visibleHeight;
+        sbHeight = std::max(sbHeight, dpi(app, 20.0f));
+        float sbY = contentTopY + (app.helpScroll / maxScroll * (visibleHeight - sbHeight));
+
+        D2D1_COLOR_F sbColor = app.theme.text;
+        sbColor.a = 0.3f * anim;
+        app.brush->SetColor(sbColor);
+        app.renderTarget->FillRoundedRectangle(
+            D2D1::RoundedRect(D2D1::RectF(panelX + panelWidth - dpi(app, 12.0f), sbY,
+                                          panelX + panelWidth - dpi(app, 8.0f), sbY + sbHeight), 2, 2),
+            app.brush);
+    }
+}


### PR DESCRIPTION
## Summary
- **Fix Debug build**: `/O2` was applied to all configurations, conflicting with `/RTC1` in Debug mode. Now restricted to Release only.
- **Add help overlay**: Press `?` to see all keyboard shortcuts organized into sections (Navigation, View, Editing, General). Supports scrolling via mouse wheel and scrollbar drag for small windows.
- **Improve welcome screen**: Added a "Getting Started" section showing how to open files, reorganized keyboard shortcuts into sections, and added supported syntax highlighting languages.

## Test plan
- [ ] Build in both Debug and Release configurations
- [ ] Press `?` to open help overlay, verify all shortcuts are listed
- [ ] Press `ESC` or `?` again to close it
- [ ] Resize window to be small and verify scrolling works (mouse wheel + scrollbar drag)
- [ ] Launch Tinta without a file and verify the updated welcome screen