### PR TITLE
README: add Scoop install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Tinta is a **fast, lightweight markdown viewer and reader for Windows**, built w
 
 Grab [the latest release](https://github.com/oipoistar/tinta/releases/latest) — a single portable `tinta.exe`, no installation required. Run it, open a markdown file, done.
 
+Or install with [Scoop](https://scoop.sh):
+
+```pwsh
+scoop bucket add tinta https://github.com/oipoistar/scoop-bucket
+scoop install tinta
+```
+
 ## Why Tinta?
 
 Most markdown apps ship an entire browser to render text. Tinta uses the GPU-accelerated text stack already built into Windows:


### PR DESCRIPTION
Tinta is now installable via the [oipoistar/scoop-bucket](https://github.com/oipoistar/scoop-bucket) Scoop bucket (personal bucket — Extras requires 100+ stars, we'll resubmit there once Tinta qualifies). Adds the two-line install to the Download section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)