### PR TITLE
Add native Mermaid diagram support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Build
         run: cmake --build build --config Release
 
+      - name: Test
+        run: ctest --test-dir build -C Release --output-on-failure
+
       - name: Get version from tag
         id: version
         shell: bash
@@ -36,16 +39,17 @@ jobs:
 
             **Markdown, distilled.**
 
-            A fast, lightweight markdown reader for Windows.
+            A fast, lightweight Markdown and Mermaid reader for Windows.
 
             ### Installation
             1. Download `tinta.exe` below
             2. Run it (you may need to click "More info" → "Run anyway" on SmartScreen)
-            3. Optionally run `tinta.exe /register` to set as default .md viewer
+            3. Optionally run `tinta.exe /register` to register Markdown and Mermaid files
 
             ### What's included
             - 10 beautiful themes (5 light, 5 dark)
             - Hardware-accelerated rendering via Direct2D
+            - Native Mermaid flowchart rendering
             - ~270KB single executable, no dependencies
           files: build/Release/tinta.exe
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Native Mermaid `flowchart`/`graph` rendering for `.mmd` files and fenced `mermaid` blocks
+- `.mmd` support in the folder browser, drag-and-drop, live edit preview, file watching, and Windows file association registration
+
 ## [v2.0.1] - 2026-07-08
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 
+include(CTest)
+
 # Build type
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
@@ -42,6 +44,8 @@ set(SOURCES
     src/overlays.cpp
     src/input.cpp
     src/editor.cpp
+    src/mermaid.cpp
+    src/document.cpp
 )
 
 set(HEADERS
@@ -58,6 +62,8 @@ set(HEADERS
     include/overlays.h
     include/input.h
     include/editor.h
+    include/mermaid.h
+    include/document.h
 )
 
 # Windows resource file (icon)
@@ -85,6 +91,29 @@ target_link_libraries(tinta PRIVATE
 )
 
 target_compile_definitions(tinta PRIVATE UNICODE _UNICODE)
+
+if(BUILD_TESTING)
+    add_executable(mermaid_tests
+        tests/mermaid_tests.cpp
+        src/mermaid.cpp
+    )
+    target_include_directories(mermaid_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    add_test(NAME mermaid_parser COMMAND mermaid_tests)
+
+    add_executable(document_tests
+        tests/document_tests.cpp
+        src/document.cpp
+        src/markdown.cpp
+    )
+    target_include_directories(document_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${md4c_SOURCE_DIR}/src
+    )
+    target_link_libraries(document_tests PRIVATE md4c)
+    add_test(NAME document_types COMMAND document_tests)
+endif()
 
 # Install
 install(TARGETS tinta RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="resources/tinta.ico" width="80">
   <h1>Tinta</h1>
   <p><em>Markdown, distilled.</em></p>
-  <p>A fast, lightweight markdown viewer for Windows</p>
+  <p>A fast, lightweight Markdown and Mermaid viewer for Windows</p>
 
   <a href="https://github.com/oipoistar/tinta/releases/latest">
     <img src="https://img.shields.io/github/v/release/oipoistar/tinta?label=Download&style=for-the-badge&color=1a1a2e" alt="Download">
@@ -17,7 +17,7 @@
 
 <br>
 
-Tinta is a **fast, lightweight markdown viewer and reader for Windows**, built with Direct2D and DirectWrite for hardware-accelerated rendering. A single native executable under 1 MB that opens instantly — no Electron, no web engine, no installer.
+Tinta is a **fast, lightweight Markdown and Mermaid viewer for Windows**, built with Direct2D and DirectWrite for hardware-accelerated rendering. A single native executable under 1 MB that opens instantly — no Electron, no web engine, no installer.
 
 <p align="center">
   <img src="https://tinta.cc/img/screenshots/paper.png" width="49%" alt="Tinta markdown viewer on Windows — Paper light theme">
@@ -26,7 +26,7 @@ Tinta is a **fast, lightweight markdown viewer and reader for Windows**, built w
 
 ## Download
 
-Grab [the latest release](https://github.com/oipoistar/tinta/releases/latest) — a single portable `tinta.exe`, no installation required. Run it, open a markdown file, done.
+Grab [the latest release](https://github.com/oipoistar/tinta/releases/latest) — a single portable `tinta.exe`, no installation required. Run it and open a Markdown or Mermaid file.
 
 Or install with [Scoop](https://scoop.sh):
 
@@ -45,22 +45,23 @@ Most markdown apps ship an entire browser to render text. Tinta uses the GPU-acc
 | Install size | **< 1 MB** | ~90 MB | ~250 MB | ~350 MB |
 | Runtime | **Native Direct2D** | Electron | Electron | Electron |
 
-It's a viewer first: perfect as the double-click default for `.md` files, for reading READMEs, notes, and documentation — with an edit mode when you need it.
+It's a viewer first: perfect as the double-click default for `.md` and `.mmd` files, for reading documentation and diagrams — with an edit mode when you need it.
 
 ## Features
 
 - **Lightning-fast startup** - Direct2D rendering, no web engine overhead
 - **10 beautiful themes** - 5 light and 5 dark themes to choose from
 - **Hardware-accelerated** - Smooth text rendering via DirectWrite
+- **Native Mermaid flowcharts** - Render `.mmd` files and fenced `mermaid` blocks without a web engine
 - **Rich tables** - Tables with bold, italic, code, and clickable links in cells
-- **Folder browser** - Press B to browse and open markdown files
+- **Folder browser** - Press B to browse and open Markdown or Mermaid files
 - **Table of contents** - Press Tab to see document headings, click to jump
 - **Edit mode** - Press `:` to edit markdown with live preview, search works in editor too
 - **Search** - Find text with F or Ctrl+F, cycle through matches with Enter
 - **Persistent settings** - Remembers your theme, zoom level, and window position
 - **Text selection & copy** - Select text and copy to clipboard
 - **Zoom support** - Ctrl+scroll to zoom in/out
-- **Drag & drop** - Drop any markdown file to view it
+- **Drag & drop** - Drop any Markdown or Mermaid file to view it
 - **Minimal footprint** - Small binary, minimal dependencies
 
 ## Keyboard Shortcuts
@@ -101,8 +102,11 @@ The executable will be at `build/Release/tinta.exe`.
 ## Usage
 
 ```bash
-# Open a markdown file
+# Open a Markdown file
 tinta.exe document.md
+
+# Open a Mermaid flowchart
+tinta.exe diagram.mmd
 
 # Open with light theme
 tinta.exe -l document.md
@@ -110,22 +114,26 @@ tinta.exe -l document.md
 # Show stats on startup
 tinta.exe -s document.md
 
-# Register as default .md viewer
+# Register for Markdown and Mermaid files
 tinta.exe /register
 ```
 
-Or simply drag and drop a `.md` file onto the window.
+Or simply drag and drop a `.md` or `.mmd` file onto the window.
 
 ## File Association
 
-On first launch, Tinta will ask if you want to set it as the default viewer for `.md` files. If you choose "No", you won't be asked again.
+On first launch, Tinta will ask if you want to set it as the default viewer for Markdown and Mermaid files. If you choose "No", you won't be asked again.
 
 To register Tinta as the default viewer later, run:
 ```bash
 tinta.exe /register
 ```
 
-This sets up the file association in the Windows registry so you can double-click any `.md` file to open it in Tinta.
+This registers `.md`, `.markdown`, and `.mmd` so you can select Tinta as their default app in Windows Settings.
+
+## Mermaid Support
+
+Tinta natively renders Mermaid `flowchart` and `graph` diagrams in `.mmd` files and fenced `mermaid` code blocks. It supports TB/TD, BT, LR, and RL layouts; common node shapes; directed and labeled edges; `classDef`, `class`, and `style` styling. Unsupported Mermaid diagram families fall back to readable source code.
 
 ## Themes
 

--- a/include/app.h
+++ b/include/app.h
@@ -177,6 +177,7 @@ struct App {
     MarkdownParser parser;
     ElementPtr root;
     std::string currentFile;
+    bool focusMermaidOnNextLayout = false;
     size_t parseTimeUs = 0;
     float contentHeight = 0;
     float contentWidth = 0;
@@ -341,9 +342,36 @@ struct App {
         D2D1_COLOR_F color{};
         float stroke = 1.0f;
     };
+    enum class LayoutShapeType {
+        Rectangle,
+        RoundedRectangle,
+        Diamond,
+        Stadium,
+        Ellipse,
+        Hexagon,
+    };
+    struct LayoutShape {
+        LayoutShapeType type = LayoutShapeType::Rectangle;
+        D2D1_RECT_F rect{};
+        D2D1_COLOR_F fill{};
+        D2D1_COLOR_F stroke{};
+        float strokeWidth = 1.0f;
+        float radius = 0.0f;
+    };
+    struct LayoutConnector {
+        std::vector<D2D1_POINT_2F> points;
+        D2D1_RECT_F bounds{};
+        D2D1_COLOR_F color{};
+        float stroke = 1.0f;
+        float arrowSize = 8.0f;
+        bool directed = true;
+        bool dashed = false;
+    };
     std::vector<LayoutTextRun> layoutTextRuns;
     std::vector<LayoutRect> layoutRects;
     std::vector<LayoutLine> layoutLines;
+    std::vector<LayoutShape> layoutShapes;
+    std::vector<LayoutConnector> layoutConnectors;
     bool layoutDirty = true;
 
     // Incremental layout: the first paint lays out ~2 viewports, the rest
@@ -363,8 +391,6 @@ struct App {
     std::vector<ScrollAnchor> scrollAnchors;
     std::vector<size_t> editorLineByteOffsets;  // UTF-8 byte offset per editor line
 
-    // Search match layout mapping (document Y for each match)
-    std::vector<float> searchMatchYs;
     size_t searchMatchCursor = 0;
 
     // Copied notification (fades out over 2 seconds)
@@ -460,6 +486,8 @@ struct App {
         layoutTextRuns.clear();
         layoutRects.clear();
         layoutLines.clear();
+        layoutShapes.clear();
+        layoutConnectors.clear();
         layoutBitmaps.clear();
         linkRects.clear();
         codeBlocks.clear();
@@ -519,6 +547,17 @@ struct App {
 
 inline float dpi(const App& app, float value) {
     return value * app.contentScale;
+}
+
+inline float documentViewportX(const App& app) {
+    return app.editMode ? app.width * app.editorSplitRatio + 3.0f : 0.0f;
+}
+
+inline float documentViewportWidth(const App& app) {
+    float width = app.editMode
+        ? static_cast<float>(app.width) - documentViewportX(app)
+        : static_cast<float>(app.width);
+    return width > 0.0f ? width : 0.0f;
 }
 
 // Cursor blink runs on a timer instead of per-frame InvalidateRect so the

--- a/include/document.h
+++ b/include/document.h
@@ -1,0 +1,29 @@
+#ifndef TINTA_DOCUMENT_H
+#define TINTA_DOCUMENT_H
+
+#include "markdown.h"
+
+#include <array>
+#include <string>
+#include <string_view>
+
+inline constexpr std::array<std::wstring_view, 3> DOCUMENT_FILE_EXTENSIONS = {
+    L".md",
+    L".markdown",
+    L".mmd",
+};
+
+bool isMermaidDocumentPath(std::string_view path);
+bool isMermaidDocumentPath(std::wstring_view path);
+bool isSupportedDocumentPath(std::string_view path);
+bool isSupportedDocumentPath(std::wstring_view path);
+bool isSupportedDropPath(std::wstring_view path);
+
+qmd::ParseResult parseDocument(qmd::MarkdownParser& parser,
+                               const std::string& content,
+                               std::string_view path);
+qmd::ParseResult parseDocument(qmd::MarkdownParser& parser,
+                               const std::string& content,
+                               std::wstring_view path);
+
+#endif // TINTA_DOCUMENT_H

--- a/include/markdown.h
+++ b/include/markdown.h
@@ -16,6 +16,7 @@ enum class ElementType {
     Paragraph,
     Heading,
     CodeBlock,
+    MermaidDiagram,
     BlockQuote,
     List,
     ListItem,

--- a/include/mermaid.h
+++ b/include/mermaid.h
@@ -1,0 +1,101 @@
+#ifndef TINTA_MERMAID_H
+#define TINTA_MERMAID_H
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace mermaid {
+
+enum class Direction {
+    TopToBottom,
+    BottomToTop,
+    LeftToRight,
+    RightToLeft,
+};
+
+enum class NodeShape {
+    Rectangle,
+    RoundedRectangle,
+    Diamond,
+    Stadium,
+    Circle,
+    Hexagon,
+};
+
+struct Color {
+    uint32_t rgb = 0;
+    float alpha = 1.0f;
+};
+
+struct Style {
+    bool hasFill = false;
+    bool hasStroke = false;
+    bool hasText = false;
+    bool hasStrokeWidth = false;
+    Color fill;
+    Color stroke;
+    Color text;
+    float strokeWidth = 1.0f;
+};
+
+struct Node {
+    std::string id;
+    std::string label;
+    NodeShape shape = NodeShape::Rectangle;
+    std::string className;
+    Style style;
+    size_t sourceOffset = 0;
+};
+
+struct Edge {
+    size_t from = 0;
+    size_t to = 0;
+    std::string label;
+    bool directed = true;
+    bool dashed = false;
+    float strokeScale = 1.0f;
+};
+
+struct Diagram {
+    Direction direction = Direction::TopToBottom;
+    std::vector<Node> nodes;
+    std::vector<Edge> edges;
+    std::unordered_map<std::string, Style> classStyles;
+};
+
+struct ParseResult {
+    Diagram diagram;
+    bool success = false;
+    size_t errorLine = 0;
+    std::string error;
+};
+
+struct Size {
+    float width = 0.0f;
+    float height = 0.0f;
+};
+
+struct Rect {
+    float left = 0.0f;
+    float top = 0.0f;
+    float right = 0.0f;
+    float bottom = 0.0f;
+};
+
+struct Layout {
+    std::vector<Rect> nodes;
+    float width = 0.0f;
+    float height = 0.0f;
+};
+
+ParseResult parse(std::string_view source);
+Layout layout(const Diagram& diagram, const std::vector<Size>& nodeSizes,
+              float nodeGap, float rankGap);
+
+} // namespace mermaid
+
+#endif // TINTA_MERMAID_H

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -1,0 +1,117 @@
+#include "document.h"
+
+#include <chrono>
+#include <memory>
+
+namespace {
+
+template <typename Character>
+Character lowerAscii(Character c) {
+    const Character upperA = static_cast<Character>('A');
+    const Character upperZ = static_cast<Character>('Z');
+    if (c >= upperA && c <= upperZ) {
+        return static_cast<Character>(c - upperA + static_cast<Character>('a'));
+    }
+    return c;
+}
+
+template <typename Character>
+bool hasExtension(std::basic_string_view<Character> path,
+                  std::basic_string_view<Character> expected) {
+    size_t dot = path.find_last_of(static_cast<Character>('.'));
+    if (dot == std::basic_string_view<Character>::npos) return false;
+
+    std::basic_string_view<Character> extension = path.substr(dot);
+    if (extension.size() != expected.size()) return false;
+    for (size_t i = 0; i < extension.size(); i++) {
+        if (lowerAscii(extension[i]) != lowerAscii(expected[i])) return false;
+    }
+    return true;
+}
+
+template <typename Character>
+bool isMermaidPath(std::basic_string_view<Character> path) {
+    const Character extension[] = {
+        static_cast<Character>('.'),
+        static_cast<Character>('m'),
+        static_cast<Character>('m'),
+        static_cast<Character>('d'),
+    };
+    return hasExtension(path, std::basic_string_view<Character>(extension, 4));
+}
+
+template <typename Character>
+bool isSupportedPath(std::basic_string_view<Character> path) {
+    const Character md[] = {
+        static_cast<Character>('.'),
+        static_cast<Character>('m'),
+        static_cast<Character>('d'),
+    };
+    const Character markdown[] = {
+        static_cast<Character>('.'),
+        static_cast<Character>('m'),
+        static_cast<Character>('a'),
+        static_cast<Character>('r'),
+        static_cast<Character>('k'),
+        static_cast<Character>('d'),
+        static_cast<Character>('o'),
+        static_cast<Character>('w'),
+        static_cast<Character>('n'),
+    };
+    return hasExtension(path, std::basic_string_view<Character>(md, 3)) ||
+        hasExtension(path, std::basic_string_view<Character>(markdown, 9)) ||
+        isMermaidPath(path);
+}
+
+qmd::ParseResult createMermaidDocument(const std::string& content) {
+    auto start = std::chrono::high_resolution_clock::now();
+
+    qmd::ParseResult result;
+    result.root = std::make_shared<qmd::Element>(qmd::ElementType::Document);
+    auto diagram = std::make_shared<qmd::Element>(qmd::ElementType::MermaidDiagram);
+    diagram->text = content;
+    diagram->sourceOffset = 0;
+    diagram->parent = result.root.get();
+    result.root->children.push_back(std::move(diagram));
+    result.success = true;
+    result.parseTimeUs = static_cast<size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::high_resolution_clock::now() - start).count());
+    return result;
+}
+
+} // namespace
+
+bool isMermaidDocumentPath(std::string_view path) {
+    return isMermaidPath(path);
+}
+
+bool isMermaidDocumentPath(std::wstring_view path) {
+    return isMermaidPath(path);
+}
+
+bool isSupportedDocumentPath(std::string_view path) {
+    return isSupportedPath(path);
+}
+
+bool isSupportedDocumentPath(std::wstring_view path) {
+    return isSupportedPath(path);
+}
+
+bool isSupportedDropPath(std::wstring_view path) {
+    return isSupportedDocumentPath(path) || hasExtension(path, std::wstring_view(L".txt"));
+}
+
+qmd::ParseResult parseDocument(qmd::MarkdownParser& parser,
+                               const std::string& content,
+                               std::string_view path) {
+    if (isMermaidDocumentPath(path)) return createMermaidDocument(content);
+    return parser.parse(content);
+}
+
+qmd::ParseResult parseDocument(qmd::MarkdownParser& parser,
+                               const std::string& content,
+                               std::wstring_view path) {
+    if (isMermaidDocumentPath(path)) return createMermaidDocument(content);
+    return parser.parse(content);
+}

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -1,4 +1,5 @@
 #include "editor.h"
+#include "document.h"
 #include "utils.h"
 #include "file_utils.h"
 #include "render.h"
@@ -403,7 +404,7 @@ void editorReparse(App& app) {
         }
     }
 
-    auto result = app.parser.parse(utf8);
+    auto result = parseDocument(app.parser, utf8, app.currentFile);
     if (result.success) {
         app.root = result.root;
         app.parseTimeUs = result.parseTimeUs;
@@ -475,6 +476,7 @@ void enterEditMode(App& app) {
     updateBlinkTimer(app);
 
     // Force layout at new width
+    app.focusMermaidOnNextLayout = isMermaidDocumentPath(app.currentFile);
     app.layoutDirty = true;
     InvalidateRect(app.hwnd, nullptr, FALSE);
 }
@@ -519,7 +521,7 @@ void exitEditMode(App& app) {
     if (file) {
         std::stringstream buf;
         buf << file.rdbuf();
-        auto result = app.parser.parse(buf.str());
+        auto result = parseDocument(app.parser, buf.str(), app.currentFile);
         if (result.success) {
             app.root = result.root;
             app.parseTimeUs = result.parseTimeUs;
@@ -529,6 +531,7 @@ void exitEditMode(App& app) {
     // Update window title (remove dirty marker)
     updateWindowTitle(app);
 
+    app.focusMermaidOnNextLayout = isMermaidDocumentPath(app.currentFile);
     app.layoutDirty = true;
     InvalidateRect(app.hwnd, nullptr, FALSE);
 }

--- a/src/file_utils.cpp
+++ b/src/file_utils.cpp
@@ -1,4 +1,5 @@
 #include "file_utils.h"
+#include "document.h"
 #include "utils.h"
 
 #include <algorithm>
@@ -80,17 +81,8 @@ void populateFolderItems(App& app) {
 
         if (findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
             folders.push_back({name, true});
-        } else {
-            // Check file extension
-            size_t dotPos = name.rfind(L'.');
-            if (dotPos != std::wstring::npos) {
-                std::wstring ext = name.substr(dotPos);
-                // Convert to lowercase for comparison
-                for (auto& c : ext) c = towlower(c);
-                if (ext == L".md" || ext == L".markdown") {
-                    files.push_back({name, false});
-                }
-            }
+        } else if (isSupportedDocumentPath(name)) {
+            files.push_back({name, false});
         }
     } while (FindNextFileW(hFind, &findData));
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,4 +1,5 @@
 #include "input.h"
+#include "document.h"
 #include "editor.h"
 #include "file_utils.h"
 #include "utils.h"
@@ -116,7 +117,8 @@ void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     float delta = (float)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA * dpi(app, 60.0f);
     app.targetScrollX += delta;
 
-    float maxScrollX = std::max(0.0f, app.contentWidth - app.width);
+    float maxScrollX = std::max(
+        0.0f, app.contentWidth - documentViewportWidth(app));
     app.targetScrollX = std::max(0.0f, std::min(app.targetScrollX, maxScrollX));
     app.scrollX = app.targetScrollX;
 
@@ -154,7 +156,7 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         // but we leave the existing code to work with document coordinates
     }
 
-    float previewOffsetX = app.editMode ? (app.width * app.editorSplitRatio + 3) : 0;
+    float previewOffsetX = documentViewportX(app);
     float docX = (app.mouseX - previewOffsetX) + app.scrollX;
     float docY = app.mouseY + app.scrollY;
 
@@ -215,11 +217,12 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
 
     // Horizontal scrollbar dragging
     if (app.hScrollbarDragging) {
-        float maxScroll = std::max(0.0f, app.contentWidth - app.width);
-        if (maxScroll > 0 && app.contentWidth > app.width) {
-            float sbWidth = (float)app.width / app.contentWidth * app.width;
+        float viewportWidth = documentViewportWidth(app);
+        float maxScroll = std::max(0.0f, app.contentWidth - viewportWidth);
+        if (maxScroll > 0 && app.contentWidth > viewportWidth) {
+            float sbWidth = viewportWidth / app.contentWidth * viewportWidth;
             sbWidth = std::max(sbWidth, 30.0f);
-            float trackWidth = app.width - sbWidth;
+            float trackWidth = viewportWidth - sbWidth;
 
             float deltaX = (float)app.mouseX - app.hScrollbarDragStartX;
             float scrollDelta = (deltaX / trackWidth) * maxScroll;
@@ -244,9 +247,13 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     // Check horizontal scrollbar hover
     bool wasHHovered = app.hScrollbarHovered;
     app.hScrollbarHovered = false;
-    if (app.contentWidth > app.width) {
+    float viewportX = documentViewportX(app);
+    float viewportWidth = documentViewportWidth(app);
+    if (app.contentWidth > viewportWidth) {
         float sbHeight = dpi(app, 14.0f);  // hit area
-        if (app.mouseY >= app.height - sbHeight) {
+        if (app.mouseY >= app.height - sbHeight &&
+            app.mouseX >= viewportX &&
+            app.mouseX <= viewportX + viewportWidth) {
             app.hScrollbarHovered = true;
         }
     }
@@ -395,7 +402,7 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     app.mouseX = GET_X_LPARAM(lParam);
     app.mouseY = GET_Y_LPARAM(lParam);
     SetCapture(hwnd);
-    float previewOffsetX = app.editMode ? (app.width * app.editorSplitRatio + 3) : 0;
+    float previewOffsetX = documentViewportX(app);
     float docX = (app.mouseX - previewOffsetX) + app.scrollX;
     float docY = app.mouseY + app.scrollY;
 
@@ -424,21 +431,27 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         InvalidateRect(hwnd, nullptr, FALSE);
     }
     // Check if clicking horizontal scrollbar
-    else if (app.hScrollbarHovered && app.contentWidth > app.width) {
+    else if (app.hScrollbarHovered &&
+             app.contentWidth > documentViewportWidth(app)) {
         app.hScrollbarDragging = true;
         app.hScrollbarDragStartX = (float)app.mouseX;
         app.hScrollbarDragStartScroll = app.scrollX;
 
         // Check if clicking in track (not thumb) - jump to position
-        float maxScroll = std::max(0.0f, app.contentWidth - app.width);
-        float sbWidth = (float)app.width / app.contentWidth * app.width;
+        float viewportX = documentViewportX(app);
+        float viewportWidth = documentViewportWidth(app);
+        float localMouseX = app.mouseX - viewportX;
+        float maxScroll = std::max(0.0f, app.contentWidth - viewportWidth);
+        float sbWidth = viewportWidth / app.contentWidth * viewportWidth;
         sbWidth = std::max(sbWidth, 30.0f);
-        float sbX = (maxScroll > 0) ? (app.scrollX / maxScroll * (app.width - sbWidth)) : 0;
+        float sbX = (maxScroll > 0)
+            ? (app.scrollX / maxScroll * (viewportWidth - sbWidth))
+            : 0;
 
         // If clicked outside thumb, jump
-        if (app.mouseX < sbX || app.mouseX > sbX + sbWidth) {
-            float trackWidth = app.width - sbWidth;
-            float clickPos = (float)app.mouseX - sbWidth / 2;
+        if (localMouseX < sbX || localMouseX > sbX + sbWidth) {
+            float trackWidth = viewportWidth - sbWidth;
+            float clickPos = localMouseX - sbWidth / 2;
             clickPos = std::max(0.0f, std::min(clickPos, trackWidth));
             app.scrollX = (clickPos / trackWidth) * maxScroll;
             app.targetScrollX = app.scrollX;
@@ -601,7 +614,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                     }
                     populateFolderItems(app);
                 } else {
-                    // Open .md file
+                    // Open document
                     std::wstring fullPath = app.folderBrowserPath;
                     if (fullPath.back() != L'\\' && fullPath.back() != L'/') {
                         fullPath += L'\\';
@@ -613,7 +626,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                     if (file) {
                         std::stringstream buffer;
                         buffer << file.rdbuf();
-                        auto result = app.parser.parse(buffer.str());
+                        auto result = parseDocument(app.parser, buffer.str(), fullPath);
                         if (result.success) {
                             app.root = result.root;
                             app.parseTimeUs = result.parseTimeUs;
@@ -622,12 +635,14 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                             app.currentFile.resize(utf8Len - 1);
                             WideCharToMultiByte(CP_UTF8, 0, fullPath.c_str(), -1, &app.currentFile[0], utf8Len, nullptr, nullptr);
                             app.scrollY = 0;
+                            app.scrollX = 0;
                             app.targetScrollY = 0;
+                            app.targetScrollX = 0;
+                            app.focusMermaidOnNextLayout = isMermaidDocumentPath(fullPath);
                             app.contentHeight = 0;
                             app.docText.clear();
                             app.docTextLower.clear();
                             app.searchMatches.clear();
-                            app.searchMatchYs.clear();
                             app.layoutDirty = true;
                             updateFileWriteTime(app);
                             updateWindowTitle(app);
@@ -707,7 +722,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     } else if (app.hoveredCodeBlock >= 0 && app.hoveredCodeBlock < (int)app.codeBlocks.size()) {
         // Check if click was on the copy button (top-right corner of code block)
         const auto& cb = app.codeBlocks[app.hoveredCodeBlock];
-        float previewOffsetX = app.editMode ? (app.width * app.editorSplitRatio + 3) : 0;
+        float previewOffsetX = documentViewportX(app);
         float clickDocX = (app.mouseX - previewOffsetX) + app.scrollX;
         float clickDocY = app.mouseY + app.scrollY;
         float btnW = dpi(app, 52.0f);
@@ -733,7 +748,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             // hasSelection was already set to true in WM_LBUTTONDOWN
         } else {
             // Normal selection: finalize with current mouse position (document coordinates)
-            float previewOffsetX = app.editMode ? (app.width * app.editorSplitRatio + 3) : 0;
+            float previewOffsetX = documentViewportX(app);
             float docX = (app.mouseX - previewOffsetX) + app.scrollX;
             float docY = app.mouseY + app.scrollY;
             app.selEndX = (int)docX;
@@ -1049,41 +1064,38 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
 void handleDropFiles(App& app, HWND hwnd, WPARAM wParam) {
     HDROP hDrop = (HDROP)wParam;
     wchar_t wpath[MAX_PATH];
-    if (DragQueryFileW(hDrop, 0, wpath, MAX_PATH)) {
+    if (DragQueryFileW(hDrop, 0, wpath, MAX_PATH) &&
+        isSupportedDropPath(wpath)) {
         // Convert wide path to UTF-8 for std::string usage
         int utf8Len = WideCharToMultiByte(CP_UTF8, 0, wpath, -1, nullptr, 0, nullptr, nullptr);
         std::string filepath(utf8Len - 1, '\0');
         WideCharToMultiByte(CP_UTF8, 0, wpath, -1, &filepath[0], utf8Len, nullptr, nullptr);
-        size_t dotPos = filepath.rfind('.');
-        if (dotPos != std::string::npos) {
-            std::string ext = filepath.substr(dotPos);
-            std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-            if (ext == ".md" || ext == ".markdown" || ext == ".txt") {
-                // Load file - use wide path for non-ASCII support
-                std::ifstream file(wpath);
-                if (file) {
-                    std::stringstream buffer;
-                    buffer << file.rdbuf();
-                    auto result = app.parser.parse(buffer.str());
-                    if (result.success) {
-                        app.root = result.root;
-                        app.parseTimeUs = result.parseTimeUs;
-                        app.currentFile = filepath;
-                        app.scrollY = 0;
-                        app.targetScrollY = 0;
-                        app.contentHeight = 0;
-                        app.docText.clear();
-                        app.docTextLower.clear();
-                        app.searchMatches.clear();
-                        app.searchMatchYs.clear();
-                        app.layoutDirty = true;
-                        updateFileWriteTime(app);
-                        updateWindowTitle(app);
-                    }
-                }
-                InvalidateRect(hwnd, nullptr, FALSE);
+
+        // Load file - use wide path for non-ASCII support
+        std::ifstream file(wpath);
+        if (file) {
+            std::stringstream buffer;
+            buffer << file.rdbuf();
+            auto result = parseDocument(app.parser, buffer.str(), wpath);
+            if (result.success) {
+                app.root = result.root;
+                app.parseTimeUs = result.parseTimeUs;
+                app.currentFile = filepath;
+                app.scrollY = 0;
+                app.scrollX = 0;
+                app.targetScrollY = 0;
+                app.targetScrollX = 0;
+                app.focusMermaidOnNextLayout = isMermaidDocumentPath(wpath);
+                app.contentHeight = 0;
+                app.docText.clear();
+                app.docTextLower.clear();
+                app.searchMatches.clear();
+                app.layoutDirty = true;
+                updateFileWriteTime(app);
+                updateWindowTitle(app);
             }
         }
+        InvalidateRect(hwnd, nullptr, FALSE);
     }
     DragFinish(hDrop);
 }
@@ -1105,7 +1117,7 @@ void handleFileWatchTimer(App& app, HWND hwnd) {
             if (file) {
                 std::stringstream buffer;
                 buffer << file.rdbuf();
-                auto result = app.parser.parse(buffer.str());
+                auto result = parseDocument(app.parser, buffer.str(), app.currentFile);
                 if (result.success) {
                     float savedScroll = app.scrollY;
                     float savedTargetScroll = app.targetScrollY;

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -11,9 +11,11 @@
 #include <fstream>
 #include <sstream>
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <functional>
 #include "settings.h"
+#include "document.h"
 #include "d2d_init.h"
 #include "utils.h"
 #include "syntax.h"
@@ -99,8 +101,8 @@ void render(App& app) {
         app.renderTarget->Clear(app.theme.background);
 
         float editorWidth = app.width * app.editorSplitRatio - 3;
-        float previewX = app.width * app.editorSplitRatio + 3;
-        float previewWidth = app.width - previewX;
+        float previewX = documentViewportX(app);
+        float previewWidth = documentViewportWidth(app);
 
         // Render editor (left pane)
         renderEditor(app, editorWidth);
@@ -133,7 +135,8 @@ void render(App& app) {
 render_document:
 
     // Clamp scroll values
-    float maxScrollX = std::max(0.0f, app.contentWidth - app.width);
+    float documentWidth = documentViewportWidth(app);
+    float maxScrollX = std::max(0.0f, app.contentWidth - documentWidth);
     float maxScrollY = std::max(0.0f, app.contentHeight - app.height);
     app.scrollX = std::max(0.0f, std::min(app.scrollX, maxScrollX));
     app.scrollY = std::max(0.0f, std::min(app.scrollY, maxScrollY));
@@ -142,7 +145,7 @@ render_document:
     const float viewportTop = app.scrollY;
     const float viewportBottom = app.scrollY + app.height;
     const float viewportLeft = app.scrollX;
-    const float viewportRight = app.scrollX + app.width;
+    const float viewportRight = app.scrollX + documentWidth;
     const float cullMargin = 100.0f;
 
     for (const auto& rect : app.layoutRects) {
@@ -160,6 +163,200 @@ render_document:
                        rect.rect.right - app.scrollX, rect.rect.bottom - app.scrollY),
             app.brush);
         app.drawCalls++;
+    }
+
+    ID2D1StrokeStyle* dashedStrokeStyle = nullptr;
+    if (std::any_of(
+            app.layoutConnectors.begin(), app.layoutConnectors.end(),
+            [](const App::LayoutConnector& connector) { return connector.dashed; })) {
+        D2D1_STROKE_STYLE_PROPERTIES properties = {
+            D2D1_CAP_STYLE_FLAT,
+            D2D1_CAP_STYLE_FLAT,
+            D2D1_CAP_STYLE_FLAT,
+            D2D1_LINE_JOIN_MITER,
+            10.0f,
+            D2D1_DASH_STYLE_DASH,
+            0.0f,
+        };
+        app.d2dFactory->CreateStrokeStyle(
+            properties, nullptr, 0, &dashedStrokeStyle);
+    }
+
+    for (const auto& connector : app.layoutConnectors) {
+        if (connector.bounds.bottom < viewportTop - cullMargin ||
+            connector.bounds.top > viewportBottom + cullMargin ||
+            connector.bounds.right < viewportLeft - cullMargin ||
+            connector.bounds.left > viewportRight + cullMargin ||
+            connector.points.size() < 2) {
+            continue;
+        }
+
+        app.brush->SetColor(connector.color);
+        for (size_t i = 1; i < connector.points.size(); i++) {
+            const auto& from = connector.points[i - 1];
+            const auto& to = connector.points[i];
+            app.renderTarget->DrawLine(
+                D2D1::Point2F(from.x - app.scrollX, from.y - app.scrollY),
+                D2D1::Point2F(to.x - app.scrollX, to.y - app.scrollY),
+                app.brush, connector.stroke,
+                connector.dashed ? dashedStrokeStyle : nullptr);
+            app.drawCalls++;
+        }
+
+        if (connector.directed) {
+            const auto& tip = connector.points.back();
+            const auto& previous = connector.points[connector.points.size() - 2];
+            float dx = tip.x - previous.x;
+            float dy = tip.y - previous.y;
+            float length = std::sqrt(dx * dx + dy * dy);
+            if (length > 0.001f) {
+                dx /= length;
+                dy /= length;
+                float wing = connector.arrowSize * 0.5f;
+                D2D1_POINT_2F left = D2D1::Point2F(
+                    tip.x - dx * connector.arrowSize + dy * wing,
+                    tip.y - dy * connector.arrowSize - dx * wing);
+                D2D1_POINT_2F right = D2D1::Point2F(
+                    tip.x - dx * connector.arrowSize - dy * wing,
+                    tip.y - dy * connector.arrowSize + dx * wing);
+                D2D1_POINT_2F screenTip =
+                    D2D1::Point2F(tip.x - app.scrollX, tip.y - app.scrollY);
+                app.renderTarget->DrawLine(
+                    screenTip,
+                    D2D1::Point2F(left.x - app.scrollX, left.y - app.scrollY),
+                    app.brush, connector.stroke);
+                app.renderTarget->DrawLine(
+                    screenTip,
+                    D2D1::Point2F(right.x - app.scrollX, right.y - app.scrollY),
+                    app.brush, connector.stroke);
+                app.drawCalls += 2;
+            }
+        }
+    }
+    if (dashedStrokeStyle) dashedStrokeStyle->Release();
+
+    auto drawPolygon = [&](const D2D1_POINT_2F* points, size_t count,
+                           const App::LayoutShape& shape) {
+        if (count < 3) return;
+
+        ID2D1PathGeometry* geometry = nullptr;
+        if (FAILED(app.d2dFactory->CreatePathGeometry(&geometry)) || !geometry) return;
+
+        ID2D1GeometrySink* sink = nullptr;
+        if (SUCCEEDED(geometry->Open(&sink)) && sink) {
+            sink->BeginFigure(points[0], D2D1_FIGURE_BEGIN_FILLED);
+            sink->AddLines(points + 1, static_cast<UINT32>(count - 1));
+            sink->EndFigure(D2D1_FIGURE_END_CLOSED);
+            sink->Close();
+            sink->Release();
+
+            if (shape.fill.a > 0.0f) {
+                app.brush->SetColor(shape.fill);
+                app.renderTarget->FillGeometry(geometry, app.brush);
+                app.drawCalls++;
+            }
+            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                app.brush->SetColor(shape.stroke);
+                app.renderTarget->DrawGeometry(
+                    geometry, app.brush, shape.strokeWidth);
+                app.drawCalls++;
+            }
+        }
+        geometry->Release();
+    };
+
+    for (const auto& shape : app.layoutShapes) {
+        if (shape.rect.bottom < viewportTop - cullMargin ||
+            shape.rect.top > viewportBottom + cullMargin ||
+            shape.rect.right < viewportLeft - cullMargin ||
+            shape.rect.left > viewportRight + cullMargin) {
+            continue;
+        }
+
+        D2D1_RECT_F rect = D2D1::RectF(
+            shape.rect.left - app.scrollX,
+            shape.rect.top - app.scrollY,
+            shape.rect.right - app.scrollX,
+            shape.rect.bottom - app.scrollY);
+
+        if (shape.type == App::LayoutShapeType::Diamond) {
+            float centerX = (rect.left + rect.right) * 0.5f;
+            float centerY = (rect.top + rect.bottom) * 0.5f;
+            D2D1_POINT_2F points[] = {
+                D2D1::Point2F(centerX, rect.top),
+                D2D1::Point2F(rect.right, centerY),
+                D2D1::Point2F(centerX, rect.bottom),
+                D2D1::Point2F(rect.left, centerY),
+            };
+            drawPolygon(points, 4, shape);
+            continue;
+        }
+
+        if (shape.type == App::LayoutShapeType::Hexagon) {
+            float inset = (rect.right - rect.left) * 0.18f;
+            float centerY = (rect.top + rect.bottom) * 0.5f;
+            D2D1_POINT_2F points[] = {
+                D2D1::Point2F(rect.left + inset, rect.top),
+                D2D1::Point2F(rect.right - inset, rect.top),
+                D2D1::Point2F(rect.right, centerY),
+                D2D1::Point2F(rect.right - inset, rect.bottom),
+                D2D1::Point2F(rect.left + inset, rect.bottom),
+                D2D1::Point2F(rect.left, centerY),
+            };
+            drawPolygon(points, 6, shape);
+            continue;
+        }
+
+        app.brush->SetColor(shape.fill);
+        if (shape.type == App::LayoutShapeType::Ellipse) {
+            D2D1_ELLIPSE ellipse = D2D1::Ellipse(
+                D2D1::Point2F(
+                    (rect.left + rect.right) * 0.5f,
+                    (rect.top + rect.bottom) * 0.5f),
+                (rect.right - rect.left) * 0.5f,
+                (rect.bottom - rect.top) * 0.5f);
+            if (shape.fill.a > 0.0f) {
+                app.renderTarget->FillEllipse(ellipse, app.brush);
+                app.drawCalls++;
+            }
+            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                app.brush->SetColor(shape.stroke);
+                app.renderTarget->DrawEllipse(
+                    ellipse, app.brush, shape.strokeWidth);
+                app.drawCalls++;
+            }
+            continue;
+        }
+
+        if (shape.type == App::LayoutShapeType::RoundedRectangle ||
+            shape.type == App::LayoutShapeType::Stadium) {
+            float radius = shape.type == App::LayoutShapeType::Stadium
+                ? (rect.bottom - rect.top) * 0.5f
+                : shape.radius;
+            D2D1_ROUNDED_RECT rounded = D2D1::RoundedRect(rect, radius, radius);
+            if (shape.fill.a > 0.0f) {
+                app.renderTarget->FillRoundedRectangle(rounded, app.brush);
+                app.drawCalls++;
+            }
+            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                app.brush->SetColor(shape.stroke);
+                app.renderTarget->DrawRoundedRectangle(
+                    rounded, app.brush, shape.strokeWidth);
+                app.drawCalls++;
+            }
+            continue;
+        }
+
+        if (shape.fill.a > 0.0f) {
+            app.renderTarget->FillRectangle(rect, app.brush);
+            app.drawCalls++;
+        }
+        if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+            app.brush->SetColor(shape.stroke);
+            app.renderTarget->DrawRectangle(
+                rect, app.brush, shape.strokeWidth);
+            app.drawCalls++;
+        }
     }
 
     // Render images (bitmaps)
@@ -254,7 +451,7 @@ render_document:
 
     // Determine scrollbar visibility
     bool needsVScroll = app.contentHeight > app.height;
-    bool needsHScroll = app.contentWidth > app.width;
+    bool needsHScroll = app.contentWidth > documentWidth;
     float scrollbarSize = dpi(app, 14.0f);
 
     // Scrollbar color: dark on light themes, light on dark themes
@@ -273,16 +470,16 @@ render_document:
 
         app.brush->SetColor(D2D1::ColorF(sbColorValue, sbColorValue, sbColorValue, sbAlpha));
         app.renderTarget->FillRoundedRectangle(
-            D2D1::RoundedRect(D2D1::RectF(app.width - sbWidth - dpi(app, 4.0f), sbY,
-                                          app.width - dpi(app, 4.0f), sbY + sbHeight), 3, 3),
+            D2D1::RoundedRect(D2D1::RectF(documentWidth - sbWidth - dpi(app, 4.0f), sbY,
+                                          documentWidth - dpi(app, 4.0f), sbY + sbHeight), 3, 3),
             app.brush);
         app.drawCalls++;
     }
 
     // Draw horizontal scrollbar
     if (needsHScroll) {
-        float maxScrollX = std::max(0.0f, app.contentWidth - app.width);
-        float trackWidth = app.width - (needsVScroll ? scrollbarSize : 0);
+        float maxScrollX = std::max(0.0f, app.contentWidth - documentWidth);
+        float trackWidth = documentWidth - (needsVScroll ? scrollbarSize : 0);
         float sbWidth = trackWidth / app.contentWidth * trackWidth;
         sbWidth = std::max(sbWidth, dpi(app, 30.0f));
         float sbX = (maxScrollX > 0) ? (app.scrollX / maxScrollX * (trackWidth - sbWidth)) : 0;
@@ -736,11 +933,11 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
 static const char* sampleMarkdown = R"(# Welcome to Tinta
 
-**Tinta** is a fast, lightweight markdown reader for Windows.
+**Tinta** is a fast, lightweight Markdown and Mermaid viewer for Windows.
 
 ## Getting Started
 
-- **Drag & drop** a `.md` file onto this window
+- **Drag & drop** a `.md` or `.mmd` file onto this window
 - Press **B** to browse and open files from a folder
 - Or run `tinta.exe readme.md` from the command line
 - Press **?** for all available keyboard shortcuts
@@ -748,6 +945,7 @@ static const char* sampleMarkdown = R"(# Welcome to Tinta
 ## Features
 
 - 10 beautiful themes — press **T** to choose
+- Native Mermaid flowchart rendering for `.mmd` files
 - Edit mode with live preview — press **:**
 - Search — press **F**
 - Table of contents — press **Tab**
@@ -845,7 +1043,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
             MessageBoxW(nullptr,
                        L"Tinta has been registered.\n\n"
                        L"In the Settings window that opens:\n"
-                       L"1. Search for '.md'\n"
+                       L"1. Search for '.md' or '.mmd'\n"
                        L"2. Click on the current default app\n"
                        L"3. Select 'Tinta' from the list",
                        L"Almost done!", MB_OK | MB_ICONINFORMATION);
@@ -922,12 +1120,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     // Load document
     t0 = Clock::now();
 
-    auto loadMarkdown = [&](const std::string& content) {
-        auto result = app.parser.parse(content);
+    auto loadDocumentContent = [&](const std::string& content, std::string_view path) {
+        auto result = parseDocument(app.parser, content, path);
         if (result.success) {
             app.root = result.root;
             app.parseTimeUs = result.parseTimeUs;
         }
+        return result.success;
     };
 
     auto loadFile = [&](const std::string& path) -> bool {
@@ -937,19 +1136,22 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
         if (!file) return false;
         std::stringstream buffer;
         buffer << file.rdbuf();
-        loadMarkdown(buffer.str());
-        return true;
+        return loadDocumentContent(buffer.str(), path);
     };
 
     if (!inputFile.empty()) {
-        loadFile(inputFile);
-        app.currentFile = inputFile;
+        if (loadFile(inputFile)) {
+            app.currentFile = inputFile;
+            app.focusMermaidOnNextLayout = isMermaidDocumentPath(inputFile);
+        } else {
+            loadDocumentContent(sampleMarkdown, {});
+        }
     } else {
         // Try syntax.md
         if (loadFile("syntax.md")) {
             app.currentFile = "syntax.md";
         } else {
-            loadMarkdown(sampleMarkdown);
+            loadDocumentContent(sampleMarkdown, {});
         }
     }
 

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -384,6 +384,7 @@ std::string elementTypeToString(ElementType type) {
         case ElementType::Paragraph: return "Paragraph";
         case ElementType::Heading: return "Heading";
         case ElementType::CodeBlock: return "CodeBlock";
+        case ElementType::MermaidDiagram: return "MermaidDiagram";
         case ElementType::BlockQuote: return "BlockQuote";
         case ElementType::List: return "List";
         case ElementType::ListItem: return "ListItem";

--- a/src/mermaid.cpp
+++ b/src/mermaid.cpp
@@ -1,0 +1,888 @@
+#include "mermaid.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <deque>
+#include <limits>
+#include <numeric>
+#include <unordered_map>
+
+namespace mermaid {
+namespace {
+
+struct NodeSpec {
+    std::string id;
+    std::string label;
+    NodeShape shape = NodeShape::Rectangle;
+    std::string className;
+    bool hasDefinition = false;
+    size_t sourceOffset = 0;
+};
+
+struct ArrowSpec {
+    bool directed = true;
+    bool dashed = false;
+    float strokeScale = 1.0f;
+    std::string label;
+};
+
+struct Delimiter {
+    std::string_view open;
+    std::string_view close;
+    NodeShape shape;
+};
+
+constexpr Delimiter kDelimiters[] = {
+    { "((", "))", NodeShape::Circle },
+    { "([", "])", NodeShape::Stadium },
+    { "[(", ")]", NodeShape::RoundedRectangle },
+    { "[[", "]]", NodeShape::Rectangle },
+    { "{{", "}}", NodeShape::Hexagon },
+    { "[/", "/]", NodeShape::Rectangle },
+    { "[\\", "\\]", NodeShape::Rectangle },
+    { "(", ")", NodeShape::RoundedRectangle },
+    { "{", "}", NodeShape::Diamond },
+    { "[", "]", NodeShape::Rectangle },
+};
+
+bool isSpace(char c) {
+    return std::isspace(static_cast<unsigned char>(c)) != 0;
+}
+
+char lowerAscii(char c) {
+    if (c >= 'A' && c <= 'Z') return static_cast<char>(c - 'A' + 'a');
+    return c;
+}
+
+std::string_view trim(std::string_view value) {
+    while (!value.empty() && isSpace(value.front())) value.remove_prefix(1);
+    while (!value.empty() && isSpace(value.back())) value.remove_suffix(1);
+    return value;
+}
+
+bool equalsIgnoreCase(std::string_view left, std::string_view right) {
+    if (left.size() != right.size()) return false;
+    for (size_t i = 0; i < left.size(); i++) {
+        if (lowerAscii(left[i]) != lowerAscii(right[i])) return false;
+    }
+    return true;
+}
+
+bool startsWithIgnoreCase(std::string_view value, std::string_view prefix) {
+    return value.size() >= prefix.size() &&
+        equalsIgnoreCase(value.substr(0, prefix.size()), prefix);
+}
+
+bool startsWithAt(std::string_view value, size_t position, std::string_view prefix) {
+    return position <= value.size() &&
+        value.size() - position >= prefix.size() &&
+        value.substr(position, prefix.size()) == prefix;
+}
+
+void skipSpaces(std::string_view value, size_t& position) {
+    while (position < value.size() && isSpace(value[position])) position++;
+}
+
+std::string_view readWord(std::string_view value, size_t& position) {
+    skipSpaces(value, position);
+    size_t start = position;
+    while (position < value.size() && !isSpace(value[position])) position++;
+    return value.substr(start, position - start);
+}
+
+bool isArrowAt(std::string_view value, size_t position) {
+    return startsWithAt(value, position, "-->") ||
+        startsWithAt(value, position, "---") ||
+        startsWithAt(value, position, "-.->") ||
+        startsWithAt(value, position, "==>");
+}
+
+std::string decodeLabel(std::string_view encoded) {
+    std::string decoded;
+    decoded.reserve(encoded.size());
+
+    for (size_t i = 0; i < encoded.size();) {
+        if (encoded[i] == '\\' && i + 1 < encoded.size()) {
+            char next = encoded[i + 1];
+            if (next == '"' || next == '\'' || next == '\\') {
+                decoded.push_back(next);
+                i += 2;
+                continue;
+            }
+        }
+
+        if (encoded[i] == '<') {
+            size_t close = encoded.find('>', i + 1);
+            if (close != std::string_view::npos) {
+                std::string_view tag = trim(encoded.substr(i + 1, close - i - 1));
+                if (!tag.empty() && tag.back() == '/') {
+                    tag.remove_suffix(1);
+                    tag = trim(tag);
+                }
+                if (equalsIgnoreCase(tag, "br")) {
+                    decoded.push_back('\n');
+                    i = close + 1;
+                    continue;
+                }
+            }
+        }
+
+        struct Entity {
+            std::string_view encoded;
+            std::string_view decoded;
+        };
+        constexpr Entity entities[] = {
+            { "&amp;", "&" },
+            { "&lt;", "<" },
+            { "&gt;", ">" },
+            { "&quot;", "\"" },
+            { "&#39;", "'" },
+        };
+
+        bool matchedEntity = false;
+        for (const auto& entity : entities) {
+            if (startsWithAt(encoded, i, entity.encoded)) {
+                decoded.append(entity.decoded);
+                i += entity.encoded.size();
+                matchedEntity = true;
+                break;
+            }
+        }
+        if (matchedEntity) continue;
+
+        decoded.push_back(encoded[i]);
+        i++;
+    }
+
+    return decoded;
+}
+
+bool parseHexDigit(char c, uint32_t& value) {
+    if (c >= '0' && c <= '9') {
+        value = static_cast<uint32_t>(c - '0');
+        return true;
+    }
+    c = lowerAscii(c);
+    if (c >= 'a' && c <= 'f') {
+        value = static_cast<uint32_t>(c - 'a' + 10);
+        return true;
+    }
+    return false;
+}
+
+bool parseColor(std::string_view value, Color& color) {
+    value = trim(value);
+    if (equalsIgnoreCase(value, "transparent") || equalsIgnoreCase(value, "none")) {
+        color = {0, 0.0f};
+        return true;
+    }
+
+    struct NamedColor {
+        std::string_view name;
+        uint32_t rgb;
+    };
+    constexpr NamedColor namedColors[] = {
+        { "black", 0x000000 },
+        { "white", 0xFFFFFF },
+        { "red", 0xFF0000 },
+        { "green", 0x008000 },
+        { "blue", 0x0000FF },
+        { "gray", 0x808080 },
+        { "grey", 0x808080 },
+        { "yellow", 0xFFFF00 },
+        { "orange", 0xFFA500 },
+        { "purple", 0x800080 },
+    };
+    for (const auto& named : namedColors) {
+        if (equalsIgnoreCase(value, named.name)) {
+            color = {named.rgb, 1.0f};
+            return true;
+        }
+    }
+
+    if (value.empty() || value.front() != '#') return false;
+    value.remove_prefix(1);
+
+    if (value.size() == 3 || value.size() == 4) {
+        uint32_t components[4] = {};
+        for (size_t i = 0; i < value.size(); i++) {
+            if (!parseHexDigit(value[i], components[i])) return false;
+            components[i] = components[i] * 17;
+        }
+        color.rgb = (components[0] << 16) | (components[1] << 8) | components[2];
+        color.alpha = value.size() == 4 ? components[3] / 255.0f : 1.0f;
+        return true;
+    }
+
+    if (value.size() == 6 || value.size() == 8) {
+        uint32_t components[8] = {};
+        for (size_t i = 0; i < value.size(); i++) {
+            if (!parseHexDigit(value[i], components[i])) return false;
+        }
+        auto byteAt = [&](size_t index) {
+            return (components[index] << 4) | components[index + 1];
+        };
+        color.rgb = (byteAt(0) << 16) | (byteAt(2) << 8) | byteAt(4);
+        color.alpha = value.size() == 8 ? byteAt(6) / 255.0f : 1.0f;
+        return true;
+    }
+
+    return false;
+}
+
+bool parseStrokeWidth(std::string_view value, float& width) {
+    std::string text(trim(value));
+    if (text.empty()) return false;
+
+    errno = 0;
+    char* end = nullptr;
+    float parsed = std::strtof(text.c_str(), &end);
+    if (end == text.c_str() || errno == ERANGE || !std::isfinite(parsed) || parsed < 0.0f) {
+        return false;
+    }
+    while (*end != '\0' && isSpace(*end)) end++;
+    if (*end != '\0' && std::string_view(end) != "px") return false;
+
+    width = parsed;
+    return true;
+}
+
+void mergeStyle(Style& target, const Style& source) {
+    if (source.hasFill) {
+        target.hasFill = true;
+        target.fill = source.fill;
+    }
+    if (source.hasStroke) {
+        target.hasStroke = true;
+        target.stroke = source.stroke;
+    }
+    if (source.hasText) {
+        target.hasText = true;
+        target.text = source.text;
+    }
+    if (source.hasStrokeWidth) {
+        target.hasStrokeWidth = true;
+        target.strokeWidth = source.strokeWidth;
+    }
+}
+
+bool parseStyleList(std::string_view value, Style& style, std::string& error) {
+    size_t position = 0;
+    while (position <= value.size()) {
+        size_t comma = value.find(',', position);
+        if (comma == std::string_view::npos) comma = value.size();
+        std::string_view item = trim(value.substr(position, comma - position));
+        if (!item.empty()) {
+            size_t colon = item.find(':');
+            if (colon == std::string_view::npos) {
+                error = "Expected ':' in style declaration";
+                return false;
+            }
+
+            std::string_view key = trim(item.substr(0, colon));
+            std::string_view styleValue = trim(item.substr(colon + 1));
+            Color color;
+
+            if (equalsIgnoreCase(key, "fill")) {
+                if (!parseColor(styleValue, color)) {
+                    error = "Invalid fill color";
+                    return false;
+                }
+                style.hasFill = true;
+                style.fill = color;
+            } else if (equalsIgnoreCase(key, "stroke")) {
+                if (!parseColor(styleValue, color)) {
+                    error = "Invalid stroke color";
+                    return false;
+                }
+                style.hasStroke = true;
+                style.stroke = color;
+            } else if (equalsIgnoreCase(key, "color")) {
+                if (!parseColor(styleValue, color)) {
+                    error = "Invalid text color";
+                    return false;
+                }
+                style.hasText = true;
+                style.text = color;
+            } else if (equalsIgnoreCase(key, "stroke-width")) {
+                if (!parseStrokeWidth(styleValue, style.strokeWidth)) {
+                    error = "Invalid stroke width";
+                    return false;
+                }
+                style.hasStrokeWidth = true;
+            }
+        }
+
+        if (comma == value.size()) break;
+        position = comma + 1;
+    }
+    return true;
+}
+
+bool parseNodeSpec(std::string_view line, size_t& position, size_t sourceOffset,
+                   NodeSpec& spec, std::string& error) {
+    skipSpaces(line, position);
+    size_t idStart = position;
+
+    while (position < line.size()) {
+        char c = line[position];
+        if (isSpace(c) || c == '[' || c == '(' || c == '{' ||
+            c == ':' || c == ';' || c == ',') {
+            break;
+        }
+        if (isArrowAt(line, position)) break;
+        position++;
+    }
+
+    if (position == idStart) {
+        error = "Expected a node identifier";
+        return false;
+    }
+
+    spec.id = std::string(line.substr(idStart, position - idStart));
+    spec.label = spec.id;
+    spec.sourceOffset = sourceOffset + idStart;
+    skipSpaces(line, position);
+
+    const Delimiter* delimiter = nullptr;
+    for (const auto& candidate : kDelimiters) {
+        if (startsWithAt(line, position, candidate.open)) {
+            delimiter = &candidate;
+            break;
+        }
+    }
+
+    if (delimiter) {
+        spec.hasDefinition = true;
+        spec.shape = delimiter->shape;
+        position += delimiter->open.size();
+        skipSpaces(line, position);
+
+        std::string_view encodedLabel;
+        if (position < line.size() && (line[position] == '"' || line[position] == '\'')) {
+            char quote = line[position++];
+            size_t labelStart = position;
+            bool escaped = false;
+            while (position < line.size()) {
+                char c = line[position];
+                if (c == quote && !escaped) break;
+                if (c == '\\' && !escaped) {
+                    escaped = true;
+                } else {
+                    escaped = false;
+                }
+                position++;
+            }
+            if (position >= line.size()) {
+                error = "Unterminated quoted node label";
+                return false;
+            }
+            encodedLabel = line.substr(labelStart, position - labelStart);
+            position++;
+            skipSpaces(line, position);
+            if (!startsWithAt(line, position, delimiter->close)) {
+                error = "Expected closing node delimiter";
+                return false;
+            }
+            position += delimiter->close.size();
+        } else {
+            size_t close = line.find(delimiter->close, position);
+            if (close == std::string_view::npos) {
+                error = "Unterminated node label";
+                return false;
+            }
+            encodedLabel = trim(line.substr(position, close - position));
+            position = close + delimiter->close.size();
+        }
+        spec.label = decodeLabel(encodedLabel);
+    }
+
+    skipSpaces(line, position);
+    if (startsWithAt(line, position, ":::")) {
+        position += 3;
+        size_t classStart = position;
+        while (position < line.size() && !isSpace(line[position]) &&
+               line[position] != ';' && !isArrowAt(line, position)) {
+            position++;
+        }
+        if (position == classStart) {
+            error = "Expected a class name after ':::'";
+            return false;
+        }
+        spec.className = std::string(line.substr(classStart, position - classStart));
+    }
+
+    return true;
+}
+
+bool parseArrow(std::string_view line, size_t& position, ArrowSpec& arrow,
+                std::string& error) {
+    skipSpaces(line, position);
+
+    if (startsWithAt(line, position, "-.->")) {
+        arrow.directed = true;
+        arrow.dashed = true;
+        position += 4;
+    } else if (startsWithAt(line, position, "==>")) {
+        arrow.directed = true;
+        arrow.strokeScale = 2.0f;
+        position += 3;
+    } else if (startsWithAt(line, position, "-->")) {
+        arrow.directed = true;
+        position += 3;
+    } else if (startsWithAt(line, position, "---")) {
+        arrow.directed = false;
+        position += 3;
+    } else if (startsWithAt(line, position, "--")) {
+        size_t endArrow = line.find("-->", position + 2);
+        if (endArrow == std::string_view::npos) {
+            error = "Unsupported edge syntax";
+            return false;
+        }
+        arrow.directed = true;
+        arrow.label = std::string(trim(line.substr(position + 2, endArrow - position - 2)));
+        position = endArrow + 3;
+    } else {
+        error = "Expected a Mermaid edge";
+        return false;
+    }
+
+    skipSpaces(line, position);
+    if (position < line.size() && line[position] == '|') {
+        size_t labelEnd = line.find('|', position + 1);
+        if (labelEnd == std::string_view::npos) {
+            error = "Unterminated edge label";
+            return false;
+        }
+        arrow.label = decodeLabel(line.substr(position + 1, labelEnd - position - 1));
+        position = labelEnd + 1;
+    }
+    return true;
+}
+
+size_t ensureNode(Diagram& diagram, std::unordered_map<std::string, size_t>& nodeIds,
+                  const NodeSpec& spec) {
+    auto existing = nodeIds.find(spec.id);
+    if (existing == nodeIds.end()) {
+        size_t index = diagram.nodes.size();
+        Node node;
+        node.id = spec.id;
+        node.label = spec.label;
+        node.shape = spec.shape;
+        node.className = spec.className;
+        node.sourceOffset = spec.sourceOffset;
+        diagram.nodes.push_back(std::move(node));
+        nodeIds.emplace(spec.id, index);
+        return index;
+    }
+
+    Node& node = diagram.nodes[existing->second];
+    if (spec.hasDefinition) {
+        node.label = spec.label;
+        node.shape = spec.shape;
+    }
+    if (!spec.className.empty()) node.className = spec.className;
+    node.sourceOffset = std::min(node.sourceOffset, spec.sourceOffset);
+    return existing->second;
+}
+
+bool parseDirection(std::string_view value, Direction& direction) {
+    if (equalsIgnoreCase(value, "TB") || equalsIgnoreCase(value, "TD")) {
+        direction = Direction::TopToBottom;
+    } else if (equalsIgnoreCase(value, "BT")) {
+        direction = Direction::BottomToTop;
+    } else if (equalsIgnoreCase(value, "LR")) {
+        direction = Direction::LeftToRight;
+    } else if (equalsIgnoreCase(value, "RL")) {
+        direction = Direction::RightToLeft;
+    } else {
+        return false;
+    }
+    return true;
+}
+
+ParseResult fail(ParseResult result, size_t line, std::string message) {
+    result.success = false;
+    result.errorLine = line;
+    result.error = std::move(message);
+    return result;
+}
+
+} // namespace
+
+ParseResult parse(std::string_view source) {
+    std::string normalized(source);
+    if (normalized.size() >= 3 &&
+        static_cast<unsigned char>(normalized[0]) == 0xEF &&
+        static_cast<unsigned char>(normalized[1]) == 0xBB &&
+        static_cast<unsigned char>(normalized[2]) == 0xBF) {
+        normalized[0] = ' ';
+        normalized[1] = ' ';
+        normalized[2] = ' ';
+    }
+
+    char quote = '\0';
+    bool escaped = false;
+    bool comment = false;
+    bool pipeLabel = false;
+    int squareDepth = 0;
+    int roundDepth = 0;
+    int curlyDepth = 0;
+    for (size_t i = 0; i < normalized.size(); i++) {
+        char& c = normalized[i];
+        if (c == '\n') {
+            comment = false;
+            pipeLabel = false;
+            continue;
+        }
+        if (comment) continue;
+        if (quote != '\0') {
+            if (c == quote && !escaped) quote = '\0';
+            if (c == '\\' && !escaped) {
+                escaped = true;
+            } else {
+                escaped = false;
+            }
+            continue;
+        }
+        if (pipeLabel) {
+            if (c == '|') pipeLabel = false;
+            continue;
+        }
+        if (c == '"' || c == '\'') {
+            quote = c;
+            escaped = false;
+            continue;
+        }
+        if (c == '%' && i + 1 < normalized.size() &&
+            normalized[i + 1] == '%' &&
+            squareDepth == 0 && roundDepth == 0 && curlyDepth == 0) {
+            comment = true;
+            continue;
+        }
+        if (c == '|' && squareDepth == 0 && roundDepth == 0 && curlyDepth == 0) {
+            pipeLabel = true;
+        } else if (c == '[') squareDepth++;
+        else if (c == ']' && squareDepth > 0) squareDepth--;
+        else if (c == '(') roundDepth++;
+        else if (c == ')' && roundDepth > 0) roundDepth--;
+        else if (c == '{') curlyDepth++;
+        else if (c == '}' && curlyDepth > 0) curlyDepth--;
+        else if (c == ';' && squareDepth == 0 && roundDepth == 0 && curlyDepth == 0) {
+            c = '\n';
+        }
+    }
+    source = normalized;
+
+    ParseResult result;
+    std::unordered_map<std::string, size_t> nodeIds;
+    bool foundHeader = false;
+
+    size_t lineNumber = 0;
+    size_t lineOffset = 0;
+    while (lineOffset <= source.size()) {
+        lineNumber++;
+        size_t lineEnd = source.find('\n', lineOffset);
+        if (lineEnd == std::string_view::npos) lineEnd = source.size();
+
+        std::string_view line = source.substr(lineOffset, lineEnd - lineOffset);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        line = trim(line);
+        if (!line.empty() && line.back() == ';') {
+            line.remove_suffix(1);
+            line = trim(line);
+        }
+
+        if (!line.empty() && !startsWithAt(line, 0, "%%")) {
+            size_t position = 0;
+            std::string_view keyword = readWord(line, position);
+
+            if (!foundHeader) {
+                if (!equalsIgnoreCase(keyword, "flowchart") &&
+                    !equalsIgnoreCase(keyword, "graph")) {
+                    return fail(std::move(result), lineNumber,
+                                "Only Mermaid flowchart and graph diagrams are supported");
+                }
+
+                std::string_view direction = readWord(line, position);
+                if (!direction.empty() && !parseDirection(direction, result.diagram.direction)) {
+                    return fail(std::move(result), lineNumber,
+                                "Unsupported flowchart direction");
+                }
+                foundHeader = true;
+            } else if (equalsIgnoreCase(keyword, "classDef")) {
+                std::string_view className = readWord(line, position);
+                if (className.empty()) {
+                    return fail(std::move(result), lineNumber,
+                                "Expected a class name after classDef");
+                }
+                Style style;
+                std::string error;
+                if (!parseStyleList(trim(line.substr(position)), style, error)) {
+                    return fail(std::move(result), lineNumber, std::move(error));
+                }
+                result.diagram.classStyles[std::string(className)] = style;
+            } else if (equalsIgnoreCase(keyword, "class")) {
+                std::string_view ids = readWord(line, position);
+                std::string_view className = readWord(line, position);
+                if (ids.empty() || className.empty()) {
+                    return fail(std::move(result), lineNumber,
+                                "Expected node IDs and a class name");
+                }
+
+                size_t idPosition = 0;
+                while (idPosition <= ids.size()) {
+                    size_t comma = ids.find(',', idPosition);
+                    if (comma == std::string_view::npos) comma = ids.size();
+                    std::string_view id = trim(ids.substr(idPosition, comma - idPosition));
+                    if (!id.empty()) {
+                        NodeSpec spec;
+                        spec.id = std::string(id);
+                        spec.label = spec.id;
+                        spec.className = std::string(className);
+                        spec.sourceOffset = lineOffset;
+                        ensureNode(result.diagram, nodeIds, spec);
+                    }
+                    if (comma == ids.size()) break;
+                    idPosition = comma + 1;
+                }
+            } else if (equalsIgnoreCase(keyword, "style")) {
+                std::string_view id = readWord(line, position);
+                if (id.empty()) {
+                    return fail(std::move(result), lineNumber,
+                                "Expected a node ID after style");
+                }
+                Style style;
+                std::string error;
+                if (!parseStyleList(trim(line.substr(position)), style, error)) {
+                    return fail(std::move(result), lineNumber, std::move(error));
+                }
+                NodeSpec spec;
+                spec.id = std::string(id);
+                spec.label = spec.id;
+                spec.sourceOffset = lineOffset;
+                size_t nodeIndex = ensureNode(result.diagram, nodeIds, spec);
+                mergeStyle(result.diagram.nodes[nodeIndex].style, style);
+            } else if (equalsIgnoreCase(keyword, "subgraph") ||
+                       equalsIgnoreCase(keyword, "end") ||
+                       equalsIgnoreCase(keyword, "click") ||
+                       equalsIgnoreCase(keyword, "linkStyle")) {
+                return fail(std::move(result), lineNumber,
+                            "This Mermaid flowchart statement is not supported");
+            } else {
+                position = 0;
+                NodeSpec currentSpec;
+                std::string error;
+                if (!parseNodeSpec(line, position, lineOffset, currentSpec, error)) {
+                    return fail(std::move(result), lineNumber, std::move(error));
+                }
+                size_t currentNode = ensureNode(result.diagram, nodeIds, currentSpec);
+
+                while (true) {
+                    skipSpaces(line, position);
+                    if (position >= line.size()) break;
+
+                    ArrowSpec arrow;
+                    if (!parseArrow(line, position, arrow, error)) {
+                        return fail(std::move(result), lineNumber, std::move(error));
+                    }
+
+                    NodeSpec nextSpec;
+                    if (!parseNodeSpec(line, position, lineOffset, nextSpec, error)) {
+                        return fail(std::move(result), lineNumber, std::move(error));
+                    }
+                    size_t nextNode = ensureNode(result.diagram, nodeIds, nextSpec);
+                    result.diagram.edges.push_back({
+                        currentNode,
+                        nextNode,
+                        std::move(arrow.label),
+                        arrow.directed,
+                        arrow.dashed,
+                        arrow.strokeScale,
+                    });
+                    currentNode = nextNode;
+                }
+            }
+        }
+
+        if (lineEnd == source.size()) break;
+        lineOffset = lineEnd + 1;
+    }
+
+    if (!foundHeader) {
+        return fail(std::move(result), 0,
+                    "Only Mermaid flowchart and graph diagrams are supported");
+    }
+    if (result.diagram.nodes.empty()) {
+        return fail(std::move(result), 0, "The Mermaid flowchart has no nodes");
+    }
+
+    result.success = true;
+    return result;
+}
+
+Layout layout(const Diagram& diagram, const std::vector<Size>& nodeSizes,
+              float nodeGap, float rankGap) {
+    Layout result;
+    const size_t nodeCount = diagram.nodes.size();
+    if (nodeCount == 0 || nodeSizes.size() != nodeCount) return result;
+
+    nodeGap = std::max(0.0f, nodeGap);
+    rankGap = std::max(0.0f, rankGap);
+
+    std::vector<std::vector<size_t>> outgoing(nodeCount);
+    std::vector<std::vector<size_t>> incoming(nodeCount);
+    std::vector<size_t> indegree(nodeCount, 0);
+    for (const auto& edge : diagram.edges) {
+        if (edge.from >= nodeCount || edge.to >= nodeCount) continue;
+        outgoing[edge.from].push_back(edge.to);
+        incoming[edge.to].push_back(edge.from);
+        indegree[edge.to]++;
+    }
+
+    std::deque<size_t> ready;
+    for (size_t i = 0; i < nodeCount; i++) {
+        if (indegree[i] == 0) ready.push_back(i);
+    }
+
+    std::vector<size_t> rank(nodeCount, 0);
+    std::vector<bool> processed(nodeCount, false);
+    size_t maxRank = 0;
+    while (!ready.empty()) {
+        size_t node = ready.front();
+        ready.pop_front();
+        processed[node] = true;
+        maxRank = std::max(maxRank, rank[node]);
+
+        for (size_t target : outgoing[node]) {
+            rank[target] = std::max(rank[target], rank[node] + 1);
+            if (--indegree[target] == 0) ready.push_back(target);
+        }
+    }
+
+    bool processedAny = std::any_of(
+        processed.begin(), processed.end(), [](bool value) { return value; });
+    size_t nextRank = processedAny ? maxRank + 1 : 0;
+    for (size_t i = 0; i < nodeCount; i++) {
+        if (!processed[i]) rank[i] = nextRank++;
+    }
+    for (size_t value : rank) maxRank = std::max(maxRank, value);
+
+    std::vector<std::vector<size_t>> ranks(maxRank + 1);
+    for (size_t i = 0; i < nodeCount; i++) ranks[rank[i]].push_back(i);
+
+    std::vector<float> order(nodeCount, 0.0f);
+    for (size_t level = 0; level < ranks.size(); level++) {
+        if (level > 0) {
+            std::stable_sort(ranks[level].begin(), ranks[level].end(),
+                [&](size_t left, size_t right) {
+                    auto barycenter = [&](size_t node) {
+                        if (incoming[node].empty()) {
+                            return static_cast<float>(node);
+                        }
+                        float total = 0.0f;
+                        size_t count = 0;
+                        for (size_t parent : incoming[node]) {
+                            if (rank[parent] < level) {
+                                total += order[parent];
+                                count++;
+                            }
+                        }
+                        return count > 0 ? total / static_cast<float>(count)
+                                         : static_cast<float>(node);
+                    };
+                    return barycenter(left) < barycenter(right);
+                });
+        }
+        for (size_t i = 0; i < ranks[level].size(); i++) {
+            order[ranks[level][i]] = static_cast<float>(i);
+        }
+    }
+
+    result.nodes.resize(nodeCount);
+    bool vertical = diagram.direction == Direction::TopToBottom ||
+                    diagram.direction == Direction::BottomToTop;
+
+    if (vertical) {
+        std::vector<float> rankWidths(ranks.size(), 0.0f);
+        std::vector<float> rankHeights(ranks.size(), 0.0f);
+        for (size_t level = 0; level < ranks.size(); level++) {
+            for (size_t node : ranks[level]) {
+                rankWidths[level] += std::max(1.0f, nodeSizes[node].width);
+                rankHeights[level] = std::max(
+                    rankHeights[level], std::max(1.0f, nodeSizes[node].height));
+            }
+            if (ranks[level].size() > 1) {
+                rankWidths[level] += nodeGap * static_cast<float>(ranks[level].size() - 1);
+            }
+            result.width = std::max(result.width, rankWidths[level]);
+        }
+
+        float y = 0.0f;
+        for (size_t level = 0; level < ranks.size(); level++) {
+            float x = (result.width - rankWidths[level]) * 0.5f;
+            for (size_t node : ranks[level]) {
+                float width = std::max(1.0f, nodeSizes[node].width);
+                float height = std::max(1.0f, nodeSizes[node].height);
+                float nodeY = y + (rankHeights[level] - height) * 0.5f;
+                result.nodes[node] = {x, nodeY, x + width, nodeY + height};
+                x += width + nodeGap;
+            }
+            y += rankHeights[level];
+            if (level + 1 < ranks.size()) y += rankGap;
+        }
+        result.height = y;
+
+        if (diagram.direction == Direction::BottomToTop) {
+            for (auto& rect : result.nodes) {
+                float oldTop = rect.top;
+                rect.top = result.height - rect.bottom;
+                rect.bottom = result.height - oldTop;
+            }
+        }
+    } else {
+        std::vector<float> rankWidths(ranks.size(), 0.0f);
+        std::vector<float> rankHeights(ranks.size(), 0.0f);
+        for (size_t level = 0; level < ranks.size(); level++) {
+            for (size_t node : ranks[level]) {
+                rankWidths[level] = std::max(
+                    rankWidths[level], std::max(1.0f, nodeSizes[node].width));
+                rankHeights[level] += std::max(1.0f, nodeSizes[node].height);
+            }
+            if (ranks[level].size() > 1) {
+                rankHeights[level] += nodeGap * static_cast<float>(ranks[level].size() - 1);
+            }
+            result.height = std::max(result.height, rankHeights[level]);
+        }
+
+        float x = 0.0f;
+        for (size_t level = 0; level < ranks.size(); level++) {
+            float y = (result.height - rankHeights[level]) * 0.5f;
+            for (size_t node : ranks[level]) {
+                float width = std::max(1.0f, nodeSizes[node].width);
+                float height = std::max(1.0f, nodeSizes[node].height);
+                float nodeX = x + (rankWidths[level] - width) * 0.5f;
+                result.nodes[node] = {nodeX, y, nodeX + width, y + height};
+                y += height + nodeGap;
+            }
+            x += rankWidths[level];
+            if (level + 1 < ranks.size()) x += rankGap;
+        }
+        result.width = x;
+
+        if (diagram.direction == Direction::RightToLeft) {
+            for (auto& rect : result.nodes) {
+                float oldLeft = rect.left;
+                rect.left = result.width - rect.right;
+                rect.right = result.width - oldLeft;
+            }
+        }
+    }
+
+    return result;
+}
+
+} // namespace mermaid

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2,10 +2,13 @@
 #include "utils.h"
 #include "syntax.h"
 #include "search.h"
+#include "mermaid.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <functional>
+#include <limits>
 #include <string_view>
 #include <filesystem>
 #include <urlmon.h>
@@ -18,6 +21,7 @@ constexpr float kLineBucketTolerance = 5.0f;
 struct LayoutInfo {
     IDWriteTextLayout* layout = nullptr;
     float width = 0.0f;
+    float height = 0.0f;
 };
 
 static LayoutInfo createLayout(App& app, std::wstring_view text, IDWriteTextFormat* format,
@@ -43,6 +47,7 @@ static LayoutInfo createLayout(App& app, std::wstring_view text, IDWriteTextForm
         DWRITE_TEXT_METRICS metrics{};
         info.layout->GetMetrics(&metrics);
         info.width = metrics.widthIncludingTrailingWhitespace;
+        info.height = metrics.height;
     }
     return info;
 }
@@ -91,7 +96,8 @@ static void addTextRun(App& app, LayoutInfo&& info, const D2D1_POINT_2F& pos,
 }
 
 struct LayoutSnapshot {
-    size_t textRuns, rects, lines, links, textRects, lineBuckets, docTextLen;
+    size_t textRuns, rects, lines, shapes, connectors;
+    size_t links, textRects, lineBuckets, docTextLen;
 };
 
 static LayoutSnapshot takeSnapshot(App& app) {
@@ -99,6 +105,8 @@ static LayoutSnapshot takeSnapshot(App& app) {
         app.layoutTextRuns.size(),
         app.layoutRects.size(),
         app.layoutLines.size(),
+        app.layoutShapes.size(),
+        app.layoutConnectors.size(),
         app.linkRects.size(),
         app.textRects.size(),
         app.lineBuckets.size(),
@@ -115,6 +123,8 @@ static void rollbackTo(App& app, const LayoutSnapshot& s) {
     app.layoutTextRuns.resize(s.textRuns);
     app.layoutRects.resize(s.rects);
     app.layoutLines.resize(s.lines);
+    app.layoutShapes.resize(s.shapes);
+    app.layoutConnectors.resize(s.connectors);
     app.linkRects.resize(s.links);
     app.textRects.resize(s.textRects);
     app.lineBuckets.resize(s.lineBuckets);
@@ -138,6 +148,17 @@ static void shiftLayoutItems(App& app, const LayoutSnapshot& from, float dx) {
         auto& r = app.layoutLines[i];
         r.p1.x += dx;
         r.p2.x += dx;
+    }
+    for (size_t i = from.shapes; i < app.layoutShapes.size(); i++) {
+        auto& shape = app.layoutShapes[i];
+        shape.rect.left += dx;
+        shape.rect.right += dx;
+    }
+    for (size_t i = from.connectors; i < app.layoutConnectors.size(); i++) {
+        auto& connector = app.layoutConnectors[i];
+        connector.bounds.left += dx;
+        connector.bounds.right += dx;
+        for (auto& point : connector.points) point.x += dx;
     }
     for (size_t i = from.links; i < app.linkRects.size(); i++) {
         auto& r = app.linkRects[i];
@@ -540,11 +561,491 @@ static void layoutHeading(App& app, const ElementPtr& elem, float& y, float inde
     y += 12 * scale;
 }
 
+static LayoutInfo createWrappedLayout(App& app, std::wstring_view text,
+                                      IDWriteTextFormat* format,
+                                      float width, float height) {
+    LayoutInfo info;
+    if (!format || text.empty() || width <= 0.0f || height <= 0.0f) return info;
+
+    app.dwriteFactory->CreateTextLayout(
+        text.data(), static_cast<UINT32>(text.length()),
+        format, width, height, &info.layout);
+    if (!info.layout) return info;
+
+    info.layout->SetWordWrapping(DWRITE_WORD_WRAPPING_WRAP);
+    info.layout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+    info.layout->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+    if (app.fontFallback) {
+        IDWriteTextLayout2* layout2 = nullptr;
+        if (SUCCEEDED(info.layout->QueryInterface(
+                __uuidof(IDWriteTextLayout2),
+                reinterpret_cast<void**>(&layout2)))) {
+            layout2->SetFontFallback(app.fontFallback);
+            layout2->Release();
+        }
+    }
+
+    DWRITE_TEXT_METRICS metrics{};
+    info.layout->GetMetrics(&metrics);
+    info.width = metrics.widthIncludingTrailingWhitespace;
+    info.height = metrics.height;
+    return info;
+}
+
+static D2D1_COLOR_F mermaidColor(const mermaid::Color& color) {
+    return D2D1::ColorF(
+        ((color.rgb >> 16) & 0xFF) / 255.0f,
+        ((color.rgb >> 8) & 0xFF) / 255.0f,
+        (color.rgb & 0xFF) / 255.0f,
+        color.alpha);
+}
+
+struct ResolvedMermaidStyle {
+    D2D1_COLOR_F fill{};
+    D2D1_COLOR_F stroke{};
+    D2D1_COLOR_F text{};
+    float strokeWidth = 1.0f;
+};
+
+static ResolvedMermaidStyle resolveMermaidStyle(
+        const App& app, const mermaid::Diagram& diagram,
+        const mermaid::Node& node, float scale) {
+    ResolvedMermaidStyle resolved;
+    resolved.fill = app.theme.codeBackground;
+    resolved.stroke = app.theme.accent;
+    resolved.text = app.theme.text;
+    resolved.strokeWidth = 1.5f * scale;
+
+    auto apply = [&](const mermaid::Style& style) {
+        if (style.hasFill) resolved.fill = mermaidColor(style.fill);
+        if (style.hasStroke) resolved.stroke = mermaidColor(style.stroke);
+        if (style.hasText) resolved.text = mermaidColor(style.text);
+        if (style.hasStrokeWidth) {
+            resolved.strokeWidth = style.strokeWidth * scale;
+        }
+    };
+
+    auto defaultStyle = diagram.classStyles.find("default");
+    if (defaultStyle != diagram.classStyles.end()) apply(defaultStyle->second);
+    if (!node.className.empty()) {
+        auto classStyle = diagram.classStyles.find(node.className);
+        if (classStyle != diagram.classStyles.end()) apply(classStyle->second);
+    }
+    apply(node.style);
+    return resolved;
+}
+
+static App::LayoutShapeType mermaidShapeType(mermaid::NodeShape shape) {
+    switch (shape) {
+        case mermaid::NodeShape::RoundedRectangle:
+            return App::LayoutShapeType::RoundedRectangle;
+        case mermaid::NodeShape::Diamond:
+            return App::LayoutShapeType::Diamond;
+        case mermaid::NodeShape::Stadium:
+            return App::LayoutShapeType::Stadium;
+        case mermaid::NodeShape::Circle:
+            return App::LayoutShapeType::Ellipse;
+        case mermaid::NodeShape::Hexagon:
+            return App::LayoutShapeType::Hexagon;
+        case mermaid::NodeShape::Rectangle:
+        default:
+            return App::LayoutShapeType::Rectangle;
+    }
+}
+
+static bool layoutMermaidDiagram(App& app, const std::string& source,
+                                 size_t sourceOffset, float& y,
+                                 float indent, float maxWidth,
+                                 D2D1_RECT_F* renderedBounds = nullptr) {
+    auto parsed = mermaid::parse(source);
+    if (!parsed.success || parsed.diagram.nodes.empty()) return false;
+
+    const auto& diagram = parsed.diagram;
+    float scale = app.contentScale * app.zoomFactor;
+    float maxLabelWidth = 280.0f * scale;
+    float measureHeight = 10000.0f * scale;
+    float paddingX = 18.0f * scale;
+    float paddingY = 12.0f * scale;
+    float minimumWidth = 120.0f * scale;
+    float minimumHeight = 52.0f * scale;
+
+    std::vector<std::wstring> labels;
+    std::vector<mermaid::Size> nodeSizes;
+    std::vector<ResolvedMermaidStyle> styles;
+    labels.reserve(diagram.nodes.size());
+    nodeSizes.reserve(diagram.nodes.size());
+    styles.reserve(diagram.nodes.size());
+
+    for (const auto& node : diagram.nodes) {
+        std::wstring label = toWide(node.label.empty() ? node.id : node.label);
+        LayoutInfo measured = createWrappedLayout(
+            app, label, app.textFormat, maxLabelWidth, measureHeight);
+        float width = std::max(minimumWidth, measured.width + paddingX * 2.0f);
+        float height = std::max(minimumHeight, measured.height + paddingY * 2.0f);
+        if (measured.layout) measured.layout->Release();
+
+        if (node.shape == mermaid::NodeShape::Diamond) {
+            width = std::max(width * 1.28f, 150.0f * scale);
+            height = std::max(height * 1.45f, 82.0f * scale);
+        } else if (node.shape == mermaid::NodeShape::Hexagon) {
+            width += 40.0f * scale;
+        } else if (node.shape == mermaid::NodeShape::Circle) {
+            float diameter = std::max(width, height);
+            width = diameter;
+            height = diameter;
+        }
+
+        labels.push_back(std::move(label));
+        nodeSizes.push_back({width, height});
+        styles.push_back(resolveMermaidStyle(app, diagram, node, scale));
+    }
+
+    struct MeasuredMermaidEdgeLabel {
+        std::wstring text;
+        float width = 0.0f;
+        float height = 0.0f;
+    };
+    bool vertical = diagram.direction == mermaid::Direction::TopToBottom ||
+                    diagram.direction == mermaid::Direction::BottomToTop;
+    float labelPaddingX = 6.0f * scale;
+    float labelPaddingY = 4.0f * scale;
+    float rankGap = 78.0f * scale;
+    std::vector<MeasuredMermaidEdgeLabel> edgeLabels(diagram.edges.size());
+    for (size_t i = 0; i < diagram.edges.size(); i++) {
+        if (diagram.edges[i].label.empty()) continue;
+
+        auto& edgeLabel = edgeLabels[i];
+        edgeLabel.text = toWide(diagram.edges[i].label);
+        edgeLabel.width = std::min(
+            180.0f * scale,
+            std::max(60.0f * scale,
+                     measureText(app, edgeLabel.text, app.textFormat) +
+                         labelPaddingX * 2.0f));
+        LayoutInfo measured = createWrappedLayout(
+            app, edgeLabel.text, app.textFormat,
+            edgeLabel.width - labelPaddingX * 2.0f, measureHeight);
+        edgeLabel.height = std::max(
+            28.0f * scale, measured.height + labelPaddingY * 2.0f);
+        if (measured.layout) measured.layout->Release();
+
+        float labelExtent = vertical ? edgeLabel.height : edgeLabel.width;
+        rankGap = std::max(rankGap, labelExtent + 20.0f * scale);
+    }
+
+    mermaid::Layout graphLayout = mermaid::layout(
+        diagram, nodeSizes, 32.0f * scale, rankGap);
+    if (graphLayout.nodes.size() != diagram.nodes.size()) return false;
+
+    float baseX = indent;
+    if (graphLayout.width < maxWidth) {
+        baseX += (maxWidth - graphLayout.width) * 0.5f;
+    }
+    float baseY = y + 10.0f * scale;
+    float diagramLeft = baseX;
+    float diagramTop = baseY;
+    float diagramRight = baseX + graphLayout.width;
+    float diagramBottom = baseY + graphLayout.height;
+
+    std::vector<D2D1_RECT_F> nodeRects;
+    nodeRects.reserve(graphLayout.nodes.size());
+    for (const auto& rect : graphLayout.nodes) {
+        nodeRects.push_back(D2D1::RectF(
+            baseX + rect.left,
+            baseY + rect.top,
+            baseX + rect.right,
+            baseY + rect.bottom));
+    }
+
+    struct MermaidTextItem {
+        std::wstring text;
+        D2D1_RECT_F rect{};
+        D2D1_COLOR_F color{};
+    };
+    std::vector<MermaidTextItem> textItems;
+    textItems.reserve(diagram.nodes.size() + diagram.edges.size());
+
+    D2D1_COLOR_F connectorColor = app.theme.text;
+    connectorColor.a = app.theme.isDark ? 0.7f : 0.6f;
+
+    app.layoutConnectors.reserve(
+        app.layoutConnectors.size() + diagram.edges.size());
+    size_t exteriorLane = 0;
+    for (size_t edgeIndex = 0; edgeIndex < diagram.edges.size(); edgeIndex++) {
+        const auto& edge = diagram.edges[edgeIndex];
+        if (edge.from >= nodeRects.size() || edge.to >= nodeRects.size()) continue;
+
+        const auto& from = nodeRects[edge.from];
+        const auto& to = nodeRects[edge.to];
+        App::LayoutConnector connector;
+        connector.color = connectorColor;
+        connector.stroke = 1.4f * scale * edge.strokeScale;
+        connector.arrowSize = 8.0f * scale;
+        connector.directed = edge.directed;
+        connector.dashed = edge.dashed;
+
+        float fromCenterX = (from.left + from.right) * 0.5f;
+        float fromCenterY = (from.top + from.bottom) * 0.5f;
+        float toCenterX = (to.left + to.right) * 0.5f;
+        float toCenterY = (to.top + to.bottom) * 0.5f;
+        bool selfLoop = edge.from == edge.to;
+
+        if (vertical) {
+            bool topToBottom =
+                diagram.direction == mermaid::Direction::TopToBottom;
+            bool forward = !selfLoop &&
+                (topToBottom ? toCenterY > fromCenterY : toCenterY < fromCenterY);
+            if (selfLoop) {
+                float lane = (36.0f + exteriorLane++ * 14.0f) * scale;
+                D2D1_POINT_2F start = D2D1::Point2F(from.right, fromCenterY);
+                D2D1_POINT_2F end = D2D1::Point2F(fromCenterX, from.bottom);
+                float laneX = from.right + lane;
+                float laneY = from.bottom + lane;
+                connector.points = {
+                    start,
+                    D2D1::Point2F(laneX, start.y),
+                    D2D1::Point2F(laneX, laneY),
+                    D2D1::Point2F(end.x, laneY),
+                    end,
+                };
+            } else if (forward) {
+                D2D1_POINT_2F start = D2D1::Point2F(
+                    fromCenterX, topToBottom ? from.bottom : from.top);
+                D2D1_POINT_2F end = D2D1::Point2F(
+                    toCenterX, topToBottom ? to.top : to.bottom);
+                float middleY = (start.y + end.y) * 0.5f;
+                connector.points = {
+                    start,
+                    D2D1::Point2F(start.x, middleY),
+                    D2D1::Point2F(end.x, middleY),
+                    end,
+                };
+            } else {
+                float lane = (36.0f + exteriorLane++ * 14.0f) * scale;
+                D2D1_POINT_2F start = D2D1::Point2F(from.right, fromCenterY);
+                D2D1_POINT_2F end = D2D1::Point2F(to.right, toCenterY);
+                float laneX = std::max(from.right, to.right) + lane;
+                connector.points = {
+                    start,
+                    D2D1::Point2F(laneX, start.y),
+                    D2D1::Point2F(laneX, end.y),
+                    end,
+                };
+            }
+        } else {
+            bool leftToRight =
+                diagram.direction == mermaid::Direction::LeftToRight;
+            bool forward = !selfLoop &&
+                (leftToRight ? toCenterX > fromCenterX : toCenterX < fromCenterX);
+            if (selfLoop) {
+                float lane = (36.0f + exteriorLane++ * 14.0f) * scale;
+                D2D1_POINT_2F start = D2D1::Point2F(fromCenterX, from.bottom);
+                D2D1_POINT_2F end = D2D1::Point2F(from.right, fromCenterY);
+                float laneX = from.right + lane;
+                float laneY = from.bottom + lane;
+                connector.points = {
+                    start,
+                    D2D1::Point2F(start.x, laneY),
+                    D2D1::Point2F(laneX, laneY),
+                    D2D1::Point2F(laneX, end.y),
+                    end,
+                };
+            } else if (forward) {
+                D2D1_POINT_2F start = D2D1::Point2F(
+                    leftToRight ? from.right : from.left, fromCenterY);
+                D2D1_POINT_2F end = D2D1::Point2F(
+                    leftToRight ? to.left : to.right, toCenterY);
+                float middleX = (start.x + end.x) * 0.5f;
+                connector.points = {
+                    start,
+                    D2D1::Point2F(middleX, start.y),
+                    D2D1::Point2F(middleX, end.y),
+                    end,
+                };
+            } else {
+                float lane = (36.0f + exteriorLane++ * 14.0f) * scale;
+                D2D1_POINT_2F start = D2D1::Point2F(fromCenterX, from.bottom);
+                D2D1_POINT_2F end = D2D1::Point2F(toCenterX, to.bottom);
+                float laneY = std::max(from.bottom, to.bottom) + lane;
+                connector.points = {
+                    start,
+                    D2D1::Point2F(start.x, laneY),
+                    D2D1::Point2F(end.x, laneY),
+                    end,
+                };
+            }
+        }
+
+        connector.bounds = D2D1::RectF(
+            std::numeric_limits<float>::max(),
+            std::numeric_limits<float>::max(),
+            std::numeric_limits<float>::lowest(),
+            std::numeric_limits<float>::lowest());
+        for (const auto& point : connector.points) {
+            connector.bounds.left = std::min(connector.bounds.left, point.x);
+            connector.bounds.top = std::min(connector.bounds.top, point.y);
+            connector.bounds.right = std::max(connector.bounds.right, point.x);
+            connector.bounds.bottom = std::max(connector.bounds.bottom, point.y);
+        }
+        connector.bounds.left -= connector.arrowSize;
+        connector.bounds.top -= connector.arrowSize;
+        connector.bounds.right += connector.arrowSize;
+        connector.bounds.bottom += connector.arrowSize;
+        diagramLeft = std::min(diagramLeft, connector.bounds.left);
+        diagramTop = std::min(diagramTop, connector.bounds.top);
+        diagramRight = std::max(diagramRight, connector.bounds.right);
+        diagramBottom = std::max(diagramBottom, connector.bounds.bottom);
+        app.layoutConnectors.push_back(std::move(connector));
+
+        if (!edge.label.empty()) {
+            const auto& edgeLabel = edgeLabels[edgeIndex];
+            const auto& points = app.layoutConnectors.back().points;
+            size_t middle = points.size() / 2;
+            const auto& middleStart = points[middle - 1];
+            const auto& middleEnd = points[middle];
+            float centerX = (middleStart.x + middleEnd.x) * 0.5f;
+            float centerY = (middleStart.y + middleEnd.y) * 0.5f;
+            D2D1_RECT_F labelRect = D2D1::RectF(
+                centerX - edgeLabel.width * 0.5f,
+                centerY - edgeLabel.height * 0.5f,
+                centerX + edgeLabel.width * 0.5f,
+                centerY + edgeLabel.height * 0.5f);
+            D2D1_COLOR_F transparent = app.theme.background;
+            transparent.a = 0.0f;
+            app.layoutShapes.push_back({
+                App::LayoutShapeType::RoundedRectangle,
+                labelRect,
+                app.theme.background,
+                transparent,
+                0.0f,
+                4.0f * scale,
+            });
+            diagramLeft = std::min(diagramLeft, labelRect.left);
+            diagramTop = std::min(diagramTop, labelRect.top);
+            diagramRight = std::max(diagramRight, labelRect.right);
+            diagramBottom = std::max(diagramBottom, labelRect.bottom);
+            D2D1_RECT_F textRect = D2D1::RectF(
+                labelRect.left + labelPaddingX,
+                labelRect.top + labelPaddingY,
+                labelRect.right - labelPaddingX,
+                labelRect.bottom - labelPaddingY);
+            textItems.push_back({edgeLabel.text, textRect, app.theme.text});
+        }
+    }
+
+    app.layoutShapes.reserve(app.layoutShapes.size() + diagram.nodes.size());
+    for (size_t i = 0; i < diagram.nodes.size(); i++) {
+        const auto& node = diagram.nodes[i];
+        const auto& rect = nodeRects[i];
+        const auto& style = styles[i];
+
+        app.layoutShapes.push_back({
+            mermaidShapeType(node.shape),
+            rect,
+            style.fill,
+            style.stroke,
+            style.strokeWidth,
+            8.0f * scale,
+        });
+
+        float insetX = paddingX;
+        float insetY = paddingY;
+        if (node.shape == mermaid::NodeShape::Diamond) {
+            insetX = (rect.right - rect.left) * 0.18f;
+            insetY = (rect.bottom - rect.top) * 0.18f;
+        } else if (node.shape == mermaid::NodeShape::Hexagon) {
+            insetX = (rect.right - rect.left) * 0.18f;
+        }
+
+        D2D1_RECT_F textRect = D2D1::RectF(
+            rect.left + insetX,
+            rect.top + insetY,
+            rect.right - insetX,
+            rect.bottom - insetY);
+        textItems.push_back({labels[i], textRect, style.text});
+
+        if (sourceOffset != SIZE_MAX) {
+            size_t anchorOffset = sourceOffset + node.sourceOffset;
+            if (app.scrollAnchors.empty() ||
+                app.scrollAnchors.back().sourceOffset < anchorOffset) {
+                app.scrollAnchors.push_back({anchorOffset, rect.top});
+            }
+        }
+    }
+
+    std::stable_sort(
+        textItems.begin(), textItems.end(),
+        [](const MermaidTextItem& left, const MermaidTextItem& right) {
+            if (std::abs(left.rect.top - right.rect.top) > kLineBucketTolerance) {
+                return left.rect.top < right.rect.top;
+            }
+            return left.rect.left < right.rect.left;
+        });
+    for (const auto& item : textItems) {
+        LayoutInfo textLayout = createWrappedLayout(
+            app, item.text, app.textFormat,
+            item.rect.right - item.rect.left,
+            item.rect.bottom - item.rect.top);
+        size_t docStart = app.docText.size();
+        app.docText += item.text;
+        addTextRun(
+            app, std::move(textLayout),
+            D2D1::Point2F(item.rect.left, item.rect.top),
+            item.rect, item.color, docStart, item.text.size(), true);
+        app.docText += L"\n";
+    }
+    app.docText += L"\n";
+
+    app.contentWidth = std::max(
+        app.contentWidth,
+        diagramRight + 40.0f * scale);
+    if (app.focusMermaidOnNextLayout && !nodeRects.empty()) {
+        std::vector<bool> hasIncoming(diagram.nodes.size(), false);
+        for (const auto& edge : diagram.edges) {
+            if (edge.to < hasIncoming.size()) hasIncoming[edge.to] = true;
+        }
+        size_t rootIndex = 0;
+        for (size_t i = 0; i < hasIncoming.size(); i++) {
+            if (!hasIncoming[i]) {
+                rootIndex = i;
+                break;
+            }
+        }
+
+        float rootCenter = (nodeRects[rootIndex].left + nodeRects[rootIndex].right) * 0.5f;
+        float viewportWidth = documentViewportWidth(app);
+        float maxScroll = std::max(0.0f, app.contentWidth - viewportWidth);
+        float focusedScroll = rootCenter - viewportWidth * 0.5f;
+        app.scrollX = std::max(0.0f, std::min(focusedScroll, maxScroll));
+        app.targetScrollX = app.scrollX;
+        app.focusMermaidOnNextLayout = false;
+    }
+    if (renderedBounds) {
+        *renderedBounds =
+            D2D1::RectF(diagramLeft, diagramTop, diagramRight, diagramBottom);
+    }
+    y = diagramBottom + 24.0f * scale;
+    return true;
+}
+
 static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float indent, float maxWidth) {
     std::string code;
     for (const auto& child : elem->children) {
         if (child->type == ElementType::Text) {
             code += child->text;
+        }
+    }
+
+    std::string languageName = elem->language;
+    std::transform(
+        languageName.begin(), languageName.end(), languageName.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (languageName == "mermaid") {
+        D2D1_RECT_F renderedBounds{};
+        if (layoutMermaidDiagram(
+                app, code, elem->sourceOffset, y, indent, maxWidth,
+                &renderedBounds)) {
+            app.codeBlocks.push_back({renderedBounds, toWide(code)});
+            return;
         }
     }
 
@@ -1087,6 +1588,19 @@ static void layoutElement(App& app, const ElementPtr& elem, float& y, float inde
         case ElementType::CodeBlock:
             layoutCodeBlock(app, elem, y, indent, maxWidth);
             break;
+        case ElementType::MermaidDiagram:
+            if (!layoutMermaidDiagram(
+                    app, elem->text, elem->sourceOffset, y, indent, maxWidth)) {
+                app.focusMermaidOnNextLayout = false;
+                auto fallback = std::make_shared<Element>(ElementType::CodeBlock);
+                auto text = std::make_shared<Element>(ElementType::Text);
+                text->text = elem->text;
+                text->parent = fallback.get();
+                fallback->children.push_back(std::move(text));
+                fallback->sourceOffset = elem->sourceOffset;
+                layoutCodeBlock(app, fallback, y, indent, maxWidth);
+            }
+            break;
         case ElementType::BlockQuote:
             layoutBlockquote(app, elem, y, indent, maxWidth);
             break;
@@ -1184,6 +1698,8 @@ bool layoutBegin(App& app) {
     app.layoutTextRuns.reserve(elemCount * 2);
     app.layoutRects.reserve(elemCount);
     app.layoutLines.reserve(elemCount);
+    app.layoutShapes.reserve(elemCount);
+    app.layoutConnectors.reserve(elemCount);
     app.linkRects.reserve(elemCount / 4);
     app.textRects.reserve(elemCount * 2);
     app.lineBuckets.reserve(elemCount);
@@ -1191,11 +1707,7 @@ bool layoutBegin(App& app) {
 
     float scale = app.contentScale * app.zoomFactor;
 
-    // In edit mode, use preview pane width instead of full window
-    float layoutWidth = app.width;
-    if (app.editMode) {
-        layoutWidth = app.width * (1.0f - app.editorSplitRatio) - 6;
-    }
+    float layoutWidth = documentViewportWidth(app);
 
     app.layoutIndent = 40.0f * scale;
     app.layoutMaxWidth = layoutWidth - app.layoutIndent * 2;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -2,6 +2,13 @@
 #include "utils.h"
 #include "render.h"
 
+#include <algorithm>
+#include <limits>
+
+namespace {
+constexpr size_t kNoTextRect = std::numeric_limits<size_t>::max();
+}
+
 void performSearch(App& app) {
     app.searchMatches.clear();
     app.searchCurrentIndex = 0;
@@ -30,7 +37,7 @@ void performSearch(App& app) {
     size_t pos = 0;
     while ((pos = textLower.find(queryLower, pos)) != std::wstring::npos) {
         App::SearchMatch match;
-        match.textRectIndex = 0;
+        match.textRectIndex = kNoTextRect;
         match.startPos = pos;
         match.length = app.searchQuery.length();
         match.highlightRect = D2D1::RectF(0, 0, 0, 0);
@@ -38,22 +45,21 @@ void performSearch(App& app) {
         pos += app.searchQuery.length();
     }
 
-    app.searchMatchYs.assign(app.searchMatches.size(), -1.0f);
     mapSearchMatchesToLayout(app);
 }
 
 void mapSearchMatchesToLayout(App& app) {
-    if (app.searchMatches.empty()) {
-        app.searchMatchYs.clear();
-        return;
+    for (auto& match : app.searchMatches) {
+        match.textRectIndex = kNoTextRect;
+        match.highlightRect = D2D1::RectF(0, 0, 0, 0);
     }
+    if (app.searchMatches.empty()) return;
     if (app.textRects.empty()) return;
-    if (app.searchMatchYs.size() != app.searchMatches.size()) {
-        app.searchMatchYs.assign(app.searchMatches.size(), -1.0f);
-    }
 
     size_t matchIndex = 0;
-    for (const auto& tr : app.textRects) {
+    for (size_t textRectIndex = 0; textRectIndex < app.textRects.size();
+         textRectIndex++) {
+        const auto& tr = app.textRects[textRectIndex];
         size_t rectStart = tr.docStart;
         size_t rectEnd = rectStart + tr.docLength;
         if (rectEnd <= rectStart) continue;
@@ -70,14 +76,38 @@ void mapSearchMatchesToLayout(App& app) {
 
         size_t mi = matchIndex;
         while (mi < app.searchMatches.size()) {
-            const auto& m = app.searchMatches[mi];
+            auto& m = app.searchMatches[mi];
             if (m.startPos >= rectEnd) break;
 
-            if (app.searchMatchYs[mi] < 0.0f) {
-                // Use line top as match Y (document coordinates)
-                app.searchMatchYs[mi] = tr.rect.top;
+            size_t mEnd = m.startPos + m.length;
+            size_t overlapStart = std::max(rectStart, m.startPos);
+            size_t overlapEnd = std::min(rectEnd, mEnd);
+            if (overlapStart < overlapEnd) {
+                float totalWidth = tr.rect.right - tr.rect.left;
+                float charWidth = totalWidth / static_cast<float>(tr.docLength);
+                float startX =
+                    tr.rect.left + static_cast<float>(overlapStart - rectStart) * charWidth;
+                float endX =
+                    startX + static_cast<float>(overlapEnd - overlapStart) * charWidth;
+                D2D1_RECT_F fragment =
+                    D2D1::RectF(startX, tr.rect.top, endX, tr.rect.bottom);
+
+                if (m.textRectIndex == kNoTextRect) {
+                    m.textRectIndex = textRectIndex;
+                    m.highlightRect = fragment;
+                } else {
+                    m.highlightRect.left = std::min(m.highlightRect.left, fragment.left);
+                    m.highlightRect.top = std::min(m.highlightRect.top, fragment.top);
+                    m.highlightRect.right = std::max(m.highlightRect.right, fragment.right);
+                    m.highlightRect.bottom = std::max(m.highlightRect.bottom, fragment.bottom);
+                }
             }
-            mi++;
+
+            if (mEnd <= rectEnd) {
+                mi++;
+            } else {
+                break;
+            }
         }
 
         matchIndex = mi;
@@ -90,16 +120,8 @@ void scrollToCurrentMatch(App& app) {
 
     const auto& match = app.searchMatches[app.searchCurrentIndex];
 
-    float estimatedY = -1.0f;
-
-    // Prefer exact line Y recorded during render
-    if (app.searchCurrentIndex >= 0 &&
-        app.searchCurrentIndex < (int)app.searchMatchYs.size()) {
-        float matchY = app.searchMatchYs[app.searchCurrentIndex];
-        if (matchY >= 0.0f) {
-            estimatedY = matchY;
-        }
-    }
+    bool hasLayoutBounds = match.textRectIndex != kNoTextRect;
+    float estimatedY = hasLayoutBounds ? match.highlightRect.top : -1.0f;
 
     // Fallback: estimate based on character ratio
     if (estimatedY < 0.0f) {
@@ -116,4 +138,24 @@ void scrollToCurrentMatch(App& app) {
     float maxScroll = std::max(0.0f, app.contentHeight - app.height);
     app.targetScrollY = std::max(0.0f, std::min(app.targetScrollY, maxScroll));
     app.scrollY = app.targetScrollY;
+
+    if (hasLayoutBounds) {
+        float viewportWidth = documentViewportWidth(app);
+        float viewportLeft = app.scrollX;
+        float viewportRight = viewportLeft + viewportWidth;
+        if (viewportWidth > 0.0f &&
+            (match.highlightRect.left < viewportLeft ||
+             match.highlightRect.right > viewportRight)) {
+            float matchCenter =
+                (match.highlightRect.left + match.highlightRect.right) * 0.5f;
+            app.targetScrollX = matchCenter - viewportWidth * 0.5f;
+        } else {
+            app.targetScrollX = app.scrollX;
+        }
+
+        float maxScrollX = std::max(0.0f, app.contentWidth - viewportWidth);
+        app.targetScrollX =
+            std::max(0.0f, std::min(app.targetScrollX, maxScrollX));
+        app.scrollX = app.targetScrollX;
+    }
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,4 +1,5 @@
 #include "settings.h"
+#include "document.h"
 
 #include <windows.h>
 #include <shlobj.h>
@@ -79,6 +80,26 @@ Settings loadSettings() {
     return settings;
 }
 
+static bool hasRegisteredFileAssociation(std::wstring_view extension) {
+    HKEY hKey;
+    LONG result = RegOpenKeyExW(
+        HKEY_CURRENT_USER,
+        L"Software\\Tinta\\Capabilities\\FileAssociations",
+        0, KEY_READ, &hKey);
+    if (result != ERROR_SUCCESS) return false;
+
+    wchar_t value[64] = {};
+    DWORD type = 0;
+    DWORD size = sizeof(value);
+    result = RegQueryValueExW(
+        hKey, extension.data(), nullptr, &type,
+        reinterpret_cast<BYTE*>(value), &size);
+    RegCloseKey(hKey);
+    return result == ERROR_SUCCESS &&
+        type == REG_SZ &&
+        wcscmp(value, L"Tinta.MarkdownFile") == 0;
+}
+
 bool registerFileAssociation() {
     // Get the path to the current executable
     wchar_t exePath[MAX_PATH];
@@ -92,7 +113,7 @@ bool registerFileAssociation() {
     result = RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\Classes\\Tinta.MarkdownFile", 0, nullptr,
                               REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr, &hKey, nullptr);
     if (result != ERROR_SUCCESS) return false;
-    const wchar_t* desc = L"Markdown Document";
+    const wchar_t* desc = L"Tinta Document";
     RegSetValueExW(hKey, nullptr, 0, REG_SZ, (BYTE*)desc, (DWORD)((wcslen(desc) + 1) * sizeof(wchar_t)));
     RegCloseKey(hKey);
 
@@ -120,7 +141,7 @@ bool registerFileAssociation() {
                               REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr, &hKey, nullptr);
     if (result != ERROR_SUCCESS) return false;
     const wchar_t* appName = L"Tinta";
-    const wchar_t* appDesc = L"A fast, lightweight markdown reader";
+    const wchar_t* appDesc = L"A fast, lightweight Markdown and Mermaid reader";
     RegSetValueExW(hKey, L"ApplicationName", 0, REG_SZ, (BYTE*)appName, (DWORD)((wcslen(appName) + 1) * sizeof(wchar_t)));
     RegSetValueExW(hKey, L"ApplicationDescription", 0, REG_SZ, (BYTE*)appDesc, (DWORD)((wcslen(appDesc) + 1) * sizeof(wchar_t)));
     RegCloseKey(hKey);
@@ -129,8 +150,15 @@ bool registerFileAssociation() {
     result = RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\Tinta\\Capabilities\\FileAssociations", 0, nullptr,
                               REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr, &hKey, nullptr);
     if (result != ERROR_SUCCESS) return false;
-    RegSetValueExW(hKey, L".md", 0, REG_SZ, (BYTE*)progId, (DWORD)((wcslen(progId) + 1) * sizeof(wchar_t)));
-    RegSetValueExW(hKey, L".markdown", 0, REG_SZ, (BYTE*)progId, (DWORD)((wcslen(progId) + 1) * sizeof(wchar_t)));
+    for (std::wstring_view extension : DOCUMENT_FILE_EXTENSIONS) {
+        result = RegSetValueExW(
+            hKey, extension.data(), 0, REG_SZ, (BYTE*)progId,
+            (DWORD)((wcslen(progId) + 1) * sizeof(wchar_t)));
+        if (result != ERROR_SUCCESS) {
+            RegCloseKey(hKey);
+            return false;
+        }
+    }
     RegCloseKey(hKey);
 
     // Add to RegisteredApplications
@@ -141,19 +169,18 @@ bool registerFileAssociation() {
     RegSetValueExW(hKey, L"Tinta", 0, REG_SZ, (BYTE*)capPath, (DWORD)((wcslen(capPath) + 1) * sizeof(wchar_t)));
     RegCloseKey(hKey);
 
-    // Add OpenWithProgids for .md
-    result = RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\Classes\\.md\\OpenWithProgids", 0, nullptr,
-                              REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr, &hKey, nullptr);
-    if (result != ERROR_SUCCESS) return false;
-    RegSetValueExW(hKey, progId, 0, REG_NONE, nullptr, 0);
-    RegCloseKey(hKey);
-
-    // Add OpenWithProgids for .markdown
-    result = RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\Classes\\.markdown\\OpenWithProgids", 0, nullptr,
-                              REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr, &hKey, nullptr);
-    if (result != ERROR_SUCCESS) return false;
-    RegSetValueExW(hKey, progId, 0, REG_NONE, nullptr, 0);
-    RegCloseKey(hKey);
+    for (std::wstring_view extension : DOCUMENT_FILE_EXTENSIONS) {
+        std::wstring keyPath = L"Software\\Classes\\";
+        keyPath.append(extension);
+        keyPath += L"\\OpenWithProgids";
+        result = RegCreateKeyExW(
+            HKEY_CURRENT_USER, keyPath.c_str(), 0, nullptr,
+            REG_OPTION_NON_VOLATILE, KEY_WRITE, nullptr, &hKey, nullptr);
+        if (result != ERROR_SUCCESS) return false;
+        result = RegSetValueExW(hKey, progId, 0, REG_NONE, nullptr, 0);
+        RegCloseKey(hKey);
+        if (result != ERROR_SUCCESS) return false;
+    }
 
     // Notify shell of the change
     SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, nullptr, nullptr);
@@ -166,11 +193,22 @@ void openDefaultAppsSettings() {
 }
 
 void askAndRegisterFileAssociation(Settings& settings) {
-    if (settings.hasAskedFileAssociation) return;
+    if (settings.hasAskedFileAssociation) {
+        if (hasRegisteredFileAssociation(L".md") &&
+            !hasRegisteredFileAssociation(L".mmd") &&
+            !registerFileAssociation()) {
+            MessageBoxW(
+                nullptr,
+                L"Failed to add the .mmd file association. Run tinta.exe /register to try again.",
+                L"Tinta - File Association",
+                MB_OK | MB_ICONWARNING);
+        }
+        return;
+    }
 
     int result = MessageBoxW(
         nullptr,
-        L"Would you like to set Tinta as the default viewer for .md files?\n\n"
+        L"Would you like to set Tinta as the default viewer for Markdown and Mermaid files?\n\n"
         L"Windows will open Settings where you can select Tinta.",
         L"Tinta - File Association",
         MB_YESNO | MB_ICONQUESTION
@@ -181,7 +219,7 @@ void askAndRegisterFileAssociation(Settings& settings) {
             MessageBoxW(nullptr,
                        L"Tinta has been registered.\n\n"
                        L"In the Settings window that opens:\n"
-                       L"1. Search for '.md'\n"
+                       L"1. Search for '.md' or '.mmd'\n"
                        L"2. Click on the current default app\n"
                        L"3. Select 'Tinta' from the list",
                        L"Almost done!", MB_OK | MB_ICONINFORMATION);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -200,6 +200,10 @@ void extractText(const ElementPtr& elem, std::wstring& out) {
             out += L"\n\n";
             break;
         }
+        case ElementType::MermaidDiagram:
+            out += toWide(elem->text);
+            if (!out.empty() && out.back() != L'\n') out += L"\n";
+            break;
         case ElementType::Ruby:
             // Include base text but skip RubyText (annotation)
             for (const auto& child : elem->children) {

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -1,0 +1,50 @@
+#include "document.h"
+
+#include <iostream>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (condition) return;
+    std::cerr << "FAIL: " << message << '\n';
+    failures++;
+}
+
+} // namespace
+
+int main() {
+    check(isSupportedDocumentPath("notes.md"), ".md is supported");
+    check(isSupportedDocumentPath("notes.MARKDOWN"), ".markdown is case-insensitive");
+    check(isSupportedDocumentPath(L"diagram.MMD"), ".mmd is case-insensitive");
+    check(isMermaidDocumentPath("diagram.mmd"), ".mmd is detected as Mermaid");
+    check(!isMermaidDocumentPath("notes.md"), ".md is not detected as Mermaid");
+    check(!isSupportedDocumentPath("diagram.mmdd"), "similar extensions are rejected");
+    check(!isSupportedDocumentPath("notes.txt"), ".txt is not shown as a document");
+    check(isSupportedDropPath(L"notes.txt"), "existing .txt drag-and-drop remains supported");
+
+    qmd::MarkdownParser parser;
+    auto mermaid = parseDocument(
+        parser, "flowchart LR\nA --> B\n", "diagram.mmd");
+    check(mermaid.success, "Mermaid document is created");
+    check(mermaid.root && mermaid.root->children.size() == 1,
+          "Mermaid document has one diagram element");
+    if (mermaid.root && mermaid.root->children.size() == 1) {
+        check(mermaid.root->children[0]->type == qmd::ElementType::MermaidDiagram,
+              ".mmd content becomes a Mermaid diagram element");
+    }
+
+    auto markdown = parseDocument(parser, "# Heading\n", "notes.md");
+    check(markdown.success, "Markdown document still parses");
+    check(markdown.root && !markdown.root->children.empty() &&
+          markdown.root->children[0]->type == qmd::ElementType::Heading,
+          ".md content keeps Markdown parsing");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All document tests passed\n";
+    return 0;
+}

--- a/tests/mermaid_tests.cpp
+++ b/tests/mermaid_tests.cpp
@@ -1,0 +1,187 @@
+#include "mermaid.h"
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (condition) return;
+    std::cerr << "FAIL: " << message << '\n';
+    failures++;
+}
+
+const mermaid::Node* findNode(const mermaid::Diagram& diagram, const std::string& id) {
+    for (const auto& node : diagram.nodes) {
+        if (node.id == id) return &node;
+    }
+    return nullptr;
+}
+
+void testStyledFlowchart() {
+    const char* source = R"(flowchart TB
+classDef start fill:#fff7ed,stroke:#f97316,color:#7c2d12,stroke-width:2px;
+Start["Begin<br/>enrollment"]:::start --> Choice{"Assigned?"}
+Choice -->|Yes| Done["Complete"]
+Choice -->|No| Retry(["Retry"])
+)";
+
+    auto result = mermaid::parse(source);
+    check(result.success, "styled flowchart parses");
+    if (!result.success) return;
+
+    check(result.diagram.direction == mermaid::Direction::TopToBottom,
+          "TB direction is detected");
+    check(result.diagram.nodes.size() == 4, "all nodes are parsed");
+    check(result.diagram.edges.size() == 3, "all edges are parsed");
+
+    const auto* start = findNode(result.diagram, "Start");
+    const auto* choice = findNode(result.diagram, "Choice");
+    const auto* retry = findNode(result.diagram, "Retry");
+    check(start && start->label == "Begin\nenrollment", "HTML breaks become line breaks");
+    check(start && start->className == "start", "node class is captured");
+    check(choice && choice->shape == mermaid::NodeShape::Diamond,
+          "diamond node shape is captured");
+    check(retry && retry->shape == mermaid::NodeShape::Stadium,
+          "stadium node shape is captured");
+
+    auto style = result.diagram.classStyles.find("start");
+    check(style != result.diagram.classStyles.end(), "class style is captured");
+    if (style != result.diagram.classStyles.end()) {
+        check(style->second.hasFill && style->second.fill.rgb == 0xFFF7ED,
+              "class fill color is parsed");
+        check(style->second.hasStrokeWidth && style->second.strokeWidth == 2.0f,
+              "class stroke width is parsed");
+    }
+    check(result.diagram.edges[1].label == "Yes", "edge label is captured");
+}
+
+void testGraphAliasesAndChaining() {
+    const char* source = R"(graph LR
+A --> B --> C
+class A,B emphasized
+style C fill:#abc,stroke:#123456
+)";
+
+    auto result = mermaid::parse(source);
+    check(result.success, "graph alias parses");
+    if (!result.success) return;
+
+    check(result.diagram.direction == mermaid::Direction::LeftToRight,
+          "LR direction is detected");
+    check(result.diagram.nodes.size() == 3, "chained nodes are parsed once");
+    check(result.diagram.edges.size() == 2, "chained edges are expanded");
+
+    const auto* a = findNode(result.diagram, "A");
+    const auto* b = findNode(result.diagram, "B");
+    const auto* c = findNode(result.diagram, "C");
+    check(a && a->className == "emphasized", "class command styles first node");
+    check(b && b->className == "emphasized", "class command styles second node");
+    check(c && c->style.hasFill && c->style.fill.rgb == 0xAABBCC,
+          "short inline color expands correctly");
+}
+
+void testLayoutDirections() {
+    auto topBottom = mermaid::parse("flowchart TB\nA --> B\nA --> C\n");
+    check(topBottom.success, "layout fixture parses");
+    if (!topBottom.success) return;
+
+    std::vector<mermaid::Size> sizes(topBottom.diagram.nodes.size(), {100.0f, 50.0f});
+    auto vertical = mermaid::layout(topBottom.diagram, sizes, 20.0f, 40.0f);
+    check(vertical.nodes.size() == 3, "vertical layout includes every node");
+    check(vertical.nodes[0].bottom < vertical.nodes[1].top,
+          "TB target is below source");
+    check(vertical.nodes[1].right <= vertical.nodes[2].left,
+          "same-rank nodes do not overlap");
+
+    auto leftRight = mermaid::parse("flowchart LR\nA --> B\n");
+    check(leftRight.success, "LR layout fixture parses");
+    if (!leftRight.success) return;
+    sizes.assign(leftRight.diagram.nodes.size(), {100.0f, 50.0f});
+    auto horizontal = mermaid::layout(leftRight.diagram, sizes, 20.0f, 40.0f);
+    check(horizontal.nodes[0].right < horizontal.nodes[1].left,
+          "LR target is right of source");
+}
+
+void testUnsupportedDiagram() {
+    auto result = mermaid::parse("sequenceDiagram\nAlice->>Bob: Hello\n");
+    check(!result.success, "unsupported Mermaid diagram is rejected");
+    check(result.errorLine == 1, "unsupported diagram reports its line");
+}
+
+void testBomAndSemicolonStatements() {
+    const char* source =
+        "\xEF\xBB\xBF"
+        "flowchart LR; A[\"One; still one label\"] -->|Yes; still yes| B; "
+        "%% comment; not a statement\n"
+        "B --> C;";
+    auto result = mermaid::parse(source);
+    check(result.success, "UTF-8 BOM and semicolon-separated statements parse");
+    if (!result.success) return;
+    check(result.diagram.nodes.size() == 3, "semicolon statements include all nodes");
+    check(result.diagram.edges.size() == 2, "semicolon statements include all edges");
+    const auto* a = findNode(result.diagram, "A");
+    check(a && a->label == "One; still one label",
+          "semicolon inside a node label is preserved");
+    check(result.diagram.edges[0].label == "Yes; still yes",
+          "semicolon inside a pipe-delimited edge label is preserved");
+}
+
+void testCyclicLayout() {
+    auto parsed = mermaid::parse(
+        "flowchart TB\n"
+        "A --> B\n"
+        "B --> A\n"
+        "A --> A\n");
+    check(parsed.success, "cyclic flowchart parses");
+    if (!parsed.success) return;
+
+    std::vector<mermaid::Size> sizes(parsed.diagram.nodes.size(), {100.0f, 50.0f});
+    auto graph = mermaid::layout(parsed.diagram, sizes, 20.0f, 40.0f);
+    check(graph.nodes.size() == 2, "cyclic layout includes every node");
+    check(graph.nodes[0].top == 0.0f, "cyclic layout does not leave an empty first rank");
+    check(graph.nodes[0].bottom < graph.nodes[1].top,
+          "cyclic nodes occupy distinct non-overlapping ranks");
+}
+
+void testFiles(int argc, char** argv) {
+    for (int i = 1; i < argc; i++) {
+        std::ifstream file(argv[i], std::ios::binary);
+        check(static_cast<bool>(file), "supplied Mermaid file opens");
+        if (!file) continue;
+
+        std::string source(
+            (std::istreambuf_iterator<char>(file)),
+            std::istreambuf_iterator<char>());
+        auto result = mermaid::parse(source);
+        if (!result.success) {
+            std::cerr << argv[i] << ':' << result.errorLine << ": "
+                      << result.error << '\n';
+        }
+        check(result.success, "supplied Mermaid file parses");
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    testStyledFlowchart();
+    testGraphAliasesAndChaining();
+    testLayoutDirections();
+    testUnsupportedDiagram();
+    testBomAndSemicolonStatements();
+    testCyclicLayout();
+    testFiles(argc, argv);
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All Mermaid tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary
- open `.mmd` files as native Direct2D-rendered Mermaid flowcharts across startup, browsing, drag-and-drop, reload, and live edit preview
- support common flowchart directions, shapes, styles, connectors, edge labels, cycles, search, scrolling, and source copy with readable fallback for unsupported Mermaid families
- add document/parser tests, Windows file association migration, documentation, changelog entries, and CTest execution in release CI

## Testing
- Release build succeeds
- CTest passes 2/2 tests
- all nine supplied `.mmd` fixtures pass parser validation
- runtime smoke-tested rendered code blocks, multiline labels, copy, search, cyclic routing, and wide diagrams