### PR TITLE
Mermaid polish: skip-edge routing, label chips, horizontal scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Added
 - Native Mermaid `flowchart`/`graph` rendering for `.mmd` files and fenced `mermaid` blocks
 - `.mmd` support in the folder browser, drag-and-drop, live edit preview, file watching, and Windows file association registration
+- Shift+mouse wheel scrolls horizontally (same as tilt wheels)
+
+### Fixed
+- Mermaid: edges that skip over intermediate ranks now route around the diagram through an exterior lane instead of cutting straight through nodes — their labels no longer land on unrelated edges
+- Mermaid: edge labels render as bordered chips on the edge instead of erasing the line beneath them
+- Mermaid: unsupported v11 `@{ }` attribute syntax now falls back to a readable code block instead of rendering raw attributes as a diamond
+- Long code block lines now extend the block background and participate in horizontal scrolling instead of being clipped with no way to reach them
 
 ## [v2.0.1] - 2026-07-08
 

--- a/include/mermaid.h
+++ b/include/mermaid.h
@@ -88,6 +88,7 @@ struct Rect {
 
 struct Layout {
     std::vector<Rect> nodes;
+    std::vector<size_t> ranks;  // layer index per node, for edge routing
     float width = 0.0f;
     float height = 0.0f;
 };

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -101,6 +101,13 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     if (ctrl) {
         // Zoom in/out — scale scroll position to keep content anchored
         applyZoomDelta(app, delta);
+    } else if ((GetKeyState(VK_SHIFT) & 0x8000) != 0) {
+        // Shift+wheel: horizontal scroll (wheel up = left), same as tilt wheels
+        app.targetScrollX -= delta * dpi(app, 60.0f);
+        float maxScrollX = std::max(
+            0.0f, app.contentWidth - documentViewportWidth(app));
+        app.targetScrollX = std::max(0.0f, std::min(app.targetScrollX, maxScrollX));
+        app.scrollX = app.targetScrollX;
     } else {
         // Normal scroll
         app.targetScrollY -= delta * dpi(app, 60.0f);

--- a/src/mermaid.cpp
+++ b/src/mermaid.cpp
@@ -347,6 +347,15 @@ bool parseNodeSpec(std::string_view line, size_t& position, size_t sourceOffset,
     spec.sourceOffset = sourceOffset + idStart;
     skipSpaces(line, position);
 
+    // Mermaid v11 attribute syntax (A@{ shape: ..., label: ... }) is not
+    // supported — fail so the block falls back to a readable code block
+    // instead of rendering the raw attributes as a diamond label
+    if (!spec.id.empty() && spec.id.back() == '@' &&
+        position < line.size() && line[position] == '{') {
+        error = "Mermaid '@{ }' attribute syntax is not supported";
+        return false;
+    }
+
     const Delimiter* delimiter = nullptr;
     for (const auto& candidate : kDelimiters) {
         if (startsWithAt(line, position, candidate.open)) {
@@ -773,6 +782,7 @@ Layout layout(const Diagram& diagram, const std::vector<Size>& nodeSizes,
 
     std::vector<std::vector<size_t>> ranks(maxRank + 1);
     for (size_t i = 0; i < nodeCount; i++) ranks[rank[i]].push_back(i);
+    result.ranks = rank;
 
     std::vector<float> order(nodeCount, 0.0f);
     for (size_t level = 0; level < ranks.size(); level++) {

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -789,10 +789,23 @@ static bool layoutMermaidDiagram(App& app, const std::string& source,
         float toCenterY = (to.top + to.bottom) * 0.5f;
         bool selfLoop = edge.from == edge.to;
 
+        // Edges that skip over intermediate ranks would cut straight through
+        // the nodes between them (and drop their label onto whatever edge
+        // happens to sit at the midpoint) — route those through an exterior
+        // lane like back-edges instead
+        bool skipsRanks = false;
+        if (edge.from < graphLayout.ranks.size() &&
+            edge.to < graphLayout.ranks.size()) {
+            size_t fromRank = graphLayout.ranks[edge.from];
+            size_t toRank = graphLayout.ranks[edge.to];
+            skipsRanks = (fromRank < toRank ? toRank - fromRank
+                                            : fromRank - toRank) > 1;
+        }
+
         if (vertical) {
             bool topToBottom =
                 diagram.direction == mermaid::Direction::TopToBottom;
-            bool forward = !selfLoop &&
+            bool forward = !selfLoop && !skipsRanks &&
                 (topToBottom ? toCenterY > fromCenterY : toCenterY < fromCenterY);
             if (selfLoop) {
                 float lane = (36.0f + exteriorLane++ * 14.0f) * scale;
@@ -834,7 +847,7 @@ static bool layoutMermaidDiagram(App& app, const std::string& source,
         } else {
             bool leftToRight =
                 diagram.direction == mermaid::Direction::LeftToRight;
-            bool forward = !selfLoop &&
+            bool forward = !selfLoop && !skipsRanks &&
                 (leftToRight ? toCenterX > fromCenterX : toCenterX < fromCenterX);
             if (selfLoop) {
                 float lane = (36.0f + exteriorLane++ * 14.0f) * scale;
@@ -909,14 +922,17 @@ static bool layoutMermaidDiagram(App& app, const std::string& source,
                 centerY - edgeLabel.height * 0.5f,
                 centerX + edgeLabel.width * 0.5f,
                 centerY + edgeLabel.height * 0.5f);
-            D2D1_COLOR_F transparent = app.theme.background;
-            transparent.a = 0.0f;
+            // Draw the label as a visible chip on the edge — an invisible
+            // background-colored pill erases the line under it, which makes
+            // edges look disconnected and labels look like floating text
+            D2D1_COLOR_F chipStroke = connectorColor;
+            chipStroke.a *= 0.6f;
             app.layoutShapes.push_back({
                 App::LayoutShapeType::RoundedRectangle,
                 labelRect,
-                app.theme.background,
-                transparent,
-                0.0f,
+                app.theme.codeBackground,
+                chipStroke,
+                1.2f * scale,
                 4.0f * scale,
             });
             diagramLeft = std::min(diagramLeft, labelRect.left);
@@ -1062,6 +1078,7 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
     app.docText += L"\n";
 
     float blockHeight = lineCount * lineHeight + padding * 2;
+    size_t bgRectIndex = app.layoutRects.size();
     app.layoutRects.push_back({D2D1::RectF(indent, y, indent + maxWidth, y + blockHeight),
                                app.theme.codeBackground});
 
@@ -1076,6 +1093,7 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
     bool inBlockComment = false;
     size_t codeDocStart = app.docText.size();
     size_t lineStart = 0;
+    float maxLineWidth = 0.0f;
 
     while (lineStart <= wcode.length()) {
         size_t lineEnd = wcode.find(L'\n', lineStart);
@@ -1143,9 +1161,19 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
             addTextRect(app, lineBounds, lineDocStart, wline.length());
         }
 
+        maxLineWidth = std::max(maxLineWidth, lineWidth);
         textY += lineHeight;
         if (lineEnd == wcode.length()) break;
         lineStart = lineEnd + 1;
+    }
+
+    // Long code lines used to be clipped at the block edge with no way to
+    // reach them — extend the block background and the document width so
+    // wide code participates in horizontal scrolling like diagrams do
+    float widestExtent = maxLineWidth + padding * 2;
+    if (widestExtent > maxWidth) {
+        app.layoutRects[bgRectIndex].rect.right = indent + widestExtent;
+        app.contentWidth = std::max(app.contentWidth, indent + widestExtent);
     }
 
     app.docText += wcode;

--- a/tests/mermaid_tests.cpp
+++ b/tests/mermaid_tests.cpp
@@ -167,6 +167,36 @@ void testFiles(int argc, char** argv) {
     }
 }
 
+void testAttributeSyntaxRejected() {
+    const char* source = R"(flowchart TD
+A@{ shape: rounded, label: "Fancy" } --> B[Plain]
+)";
+    auto result = mermaid::parse(source);
+    check(!result.success, "v11 '@{ }' attribute syntax fails instead of mis-rendering");
+}
+
+void testLayoutExposesRanks() {
+    const char* source = R"(graph LR
+A --> B
+B --> C
+C --> D
+A --> D
+)";
+    auto result = mermaid::parse(source);
+    check(result.success, "rank test diagram parses");
+    if (!result.success) return;
+
+    std::vector<mermaid::Size> sizes(result.diagram.nodes.size(), {100.0f, 40.0f});
+    auto layout = mermaid::layout(result.diagram, sizes, 20.0f, 60.0f);
+    check(layout.ranks.size() == result.diagram.nodes.size(),
+          "layout exposes one rank per node");
+    if (layout.ranks.size() == 4) {
+        check(layout.ranks[0] == 0 && layout.ranks[1] == 1 &&
+              layout.ranks[2] == 2 && layout.ranks[3] == 3,
+              "ranks follow the longest path (A=0, B=1, C=2, D=3)");
+    }
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -176,6 +206,8 @@ int main(int argc, char** argv) {
     testUnsupportedDiagram();
     testBomAndSemicolonStatements();
     testCyclicLayout();
+    testAttributeSyntaxRejected();
+    testLayoutExposesRanks();
     testFiles(argc, argv);
 
     if (failures != 0) {


### PR DESCRIPTION
Follow-ups to #16 found while reviewing/testing with real-world documents:

- **Skip-edge routing**: edges spanning more than one rank (e.g. `B -->|yes| C` where a longer path `B --> D --> E --> C` also exists) drew straight through the intermediate nodes, and their midpoint label visually attached to the wrong edge. They now route through an exterior lane using the same mechanism #16 built for back-edges. `mermaid::Layout` now exposes per-node ranks to support this.
- **Edge label chips**: labels used a background-colored pill that erased the edge line beneath them, making edges look disconnected. They now render as bordered chips on the line.
- **Shift+mouse wheel scrolls horizontally** — previously only tilt-wheel/touchpad `WM_MOUSEHWHEEL` could scroll wide diagrams.
- **Wide code block lines** now extend the block background and feed `contentWidth`, so they participate in horizontal scrolling instead of being clipped unreachably (visible in real-world docs with wide preformatted content).
- **Mermaid v11 `@{ }` attribute syntax** now fails parsing → readable code-block fallback, instead of rendering raw attributes inside a diamond.

Tests: two new parser/layout tests (attribute-syntax rejection, rank exposure); 2/2 suites pass. Verified visually against the corpus files that exposed each issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)