### PR TITLE
Mermaid: label chip collision avoidance + \n line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Mermaid: edges that skip over intermediate ranks now route around the diagram through an exterior lane instead of cutting straight through nodes — their labels no longer land on unrelated edges
 - Mermaid: edge labels render as bordered chips on the edge instead of erasing the line beneath them
 - Mermaid: unsupported v11 `@{ }` attribute syntax now falls back to a readable code block instead of rendering raw attributes as a diamond
+- Mermaid: edge label chips slide along their edge to avoid stacking on top of each other when several labeled edges share the same corridor
+- Mermaid: a literal `\n` in node and edge labels renders as a line break, matching mermaid.js
 - Long code block lines now extend the block background and participate in horizontal scrolling instead of being clipped with no way to reach them
 
 ## [v2.0.1] - 2026-07-08

--- a/src/mermaid.cpp
+++ b/src/mermaid.cpp
@@ -112,6 +112,12 @@ std::string decodeLabel(std::string_view encoded) {
                 i += 2;
                 continue;
             }
+            if (next == 'n') {
+                // Mermaid renders a literal \n in labels as a line break
+                decoded.push_back('\n');
+                i += 2;
+                continue;
+            }
         }
 
         if (encoded[i] == '<') {

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -770,6 +770,8 @@ static bool layoutMermaidDiagram(App& app, const std::string& source,
     app.layoutConnectors.reserve(
         app.layoutConnectors.size() + diagram.edges.size());
     size_t exteriorLane = 0;
+    std::vector<D2D1_RECT_F> placedLabelRects;
+    placedLabelRects.reserve(diagram.edges.size());
     for (size_t edgeIndex = 0; edgeIndex < diagram.edges.size(); edgeIndex++) {
         const auto& edge = diagram.edges[edgeIndex];
         if (edge.from >= nodeRects.size() || edge.to >= nodeRects.size()) continue;
@@ -917,11 +919,38 @@ static bool layoutMermaidDiagram(App& app, const std::string& source,
             const auto& middleEnd = points[middle];
             float centerX = (middleStart.x + middleEnd.x) * 0.5f;
             float centerY = (middleStart.y + middleEnd.y) * 0.5f;
-            D2D1_RECT_F labelRect = D2D1::RectF(
-                centerX - edgeLabel.width * 0.5f,
-                centerY - edgeLabel.height * 0.5f,
-                centerX + edgeLabel.width * 0.5f,
-                centerY + edgeLabel.height * 0.5f);
+            auto chipAt = [&](float cx, float cy) {
+                return D2D1::RectF(
+                    cx - edgeLabel.width * 0.5f,
+                    cy - edgeLabel.height * 0.5f,
+                    cx + edgeLabel.width * 0.5f,
+                    cy + edgeLabel.height * 0.5f);
+            };
+            D2D1_RECT_F labelRect = chipAt(centerX, centerY);
+
+            // Parallel exterior lanes sit only a few pixels apart, so their
+            // midpoint chips stack on top of each other — slide an
+            // overlapping chip along its own segment until it finds space
+            bool segVertical = std::abs(middleEnd.x - middleStart.x) <
+                               std::abs(middleEnd.y - middleStart.y);
+            float stepX = segVertical ? 0.0f : edgeLabel.width + 8.0f * scale;
+            float stepY = segVertical ? edgeLabel.height + 8.0f * scale : 0.0f;
+            auto overlapsPlaced = [&](const D2D1_RECT_F& rect) {
+                for (const auto& placed : placedLabelRects) {
+                    if (rect.left < placed.right && rect.right > placed.left &&
+                        rect.top < placed.bottom && rect.bottom > placed.top) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            for (int attempt = 1; attempt <= 8 && overlapsPlaced(labelRect); attempt++) {
+                float direction = (attempt % 2 == 1) ? 1.0f : -1.0f;
+                float magnitude = (float)((attempt + 1) / 2);
+                labelRect = chipAt(centerX + stepX * direction * magnitude,
+                                   centerY + stepY * direction * magnitude);
+            }
+            placedLabelRects.push_back(labelRect);
             // Draw the label as a visible chip on the edge — an invisible
             // background-colored pill erases the line under it, which makes
             // edges look disconnected and labels look like floating text

--- a/tests/mermaid_tests.cpp
+++ b/tests/mermaid_tests.cpp
@@ -167,6 +167,18 @@ void testFiles(int argc, char** argv) {
     }
 }
 
+void testBackslashNLineBreak() {
+    const char* source = R"(graph TD
+    BG[background thread\nengine.stop / PlotLan / DNS] --> TK[main]
+)";
+    auto result = mermaid::parse(source);
+    check(result.success, "label with \\n parses");
+    if (!result.success) return;
+    const auto* bg = findNode(result.diagram, "BG");
+    check(bg && bg->label == "background thread\nengine.stop / PlotLan / DNS",
+          "literal \\n in a label becomes a line break");
+}
+
 void testAttributeSyntaxRejected() {
     const char* source = R"(flowchart TD
 A@{ shape: rounded, label: "Fancy" } --> B[Plain]
@@ -206,6 +218,7 @@ int main(int argc, char** argv) {
     testUnsupportedDiagram();
     testBomAndSemicolonStatements();
     testCyclicLayout();
+    testBackslashNLineBreak();
     testAttributeSyntaxRejected();
     testLayoutExposesRanks();
     testFiles(argc, argv);


### PR DESCRIPTION
Found testing 08-pcapxray-dev.md (PcapXray threading model):

- Several labeled edges routed through adjacent exterior lanes dropped their chips at nearly the same midpoint, rendering as garbled overlapping text. Chips now slide along their own segment (alternating above/below or left/right) until they stop intersecting previously placed chips.
- `BG[background thread\nengine.stop / ...]` rendered the `\n` literally — mermaid.js treats it as a line break; `decodeLabel` now does too.

Adds a parser test for the `\n` decode; 2/2 suites pass. Verified visually on the diagram that exposed both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)