### PR TITLE
Editor: preview pane toggle (Ctrl+P) + opt-in soft word wrap (Ctrl+W)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Native Mermaid `flowchart`/`graph` rendering for `.mmd` files and fenced `mermaid` blocks
 - `.mmd` support in the folder browser, drag-and-drop, live edit preview, file watching, and Windows file association registration
 - Shift+mouse wheel scrolls horizontally (same as tilt wheels)
+- Edit mode: Ctrl+P shows/hides the preview pane; the editor takes the full window while it's hidden (#17)
+- Edit mode: Ctrl+W toggles soft word wrap in the editor (off by default); caret, clicks, selection, and search highlights follow wrapped rows (#17)
+- Both editor view options persist across sessions
 
 ### Fixed
 - Mermaid: edges that skip over intermediate ranks now route around the diagram through an exterior lane instead of cutting straight through nodes — their labels no longer land on unrelated edges

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 | `:` | Enter edit mode |
 | `ESC` `ESC` | Exit edit mode |
 | `Ctrl+S` | Save (in edit mode) |
+| `Ctrl+P` | Show/hide preview pane (in edit mode) |
+| `Ctrl+W` | Toggle word wrap (in edit mode) |
 | `Q` | Quit |
 
 ## Building

--- a/include/app.h
+++ b/include/app.h
@@ -105,6 +105,8 @@ struct Settings {
     int windowHeight = 768;
     bool windowMaximized = false;
     bool hasAskedFileAssociation = false;
+    bool editorShowPreview = true;
+    bool editorWordWrap = false;
 };
 
 // Application state
@@ -436,9 +438,21 @@ struct App {
     bool editorDirty = false;
     std::vector<size_t> editorLineStarts;
 
+    // Editor view options (persisted)
+    bool editorShowPreview = true;
+    bool editorWordWrap = false;
+
+    // Soft-wrap metrics: cumulative visual rows before each logical line
+    // (editorRowStarts.size() == lines + 1). Only maintained while
+    // editorWordWrap is on; rebuilt when text or wrap width changes.
+    std::vector<size_t> editorRowStarts;
+    size_t editorTotalRows = 0;
+    float editorRowMetricsWidth = -1.0f;  // wrap width the metrics were built for
+
     // Editor cursor & selection
     size_t editorCursorPos = 0;
     int editorDesiredCol = -1;
+    float editorDesiredX = -1.0f;  // desired caret x for Up/Down in wrap mode
     bool editorSelecting = false;
     size_t editorSelStart = 0;
     size_t editorSelEnd = 0;
@@ -549,8 +563,19 @@ inline float dpi(const App& app, float value) {
     return value * app.contentScale;
 }
 
+// Width of the editor pane in edit mode (full window when preview is hidden)
+inline float editorPaneWidth(const App& app) {
+    return app.editorShowPreview
+        ? app.width * app.editorSplitRatio - 3.0f
+        : static_cast<float>(app.width);
+}
+
 inline float documentViewportX(const App& app) {
-    return app.editMode ? app.width * app.editorSplitRatio + 3.0f : 0.0f;
+    if (!app.editMode) return 0.0f;
+    // Preview hidden: zero-width viewport at the right edge — document
+    // rendering flows through unchanged and clips to nothing
+    if (!app.editorShowPreview) return static_cast<float>(app.width);
+    return app.width * app.editorSplitRatio + 3.0f;
 }
 
 inline float documentViewportWidth(const App& app) {

--- a/include/editor.h
+++ b/include/editor.h
@@ -34,6 +34,7 @@ void scrollEditorToMatch(App& app);
 
 // Utility
 void rebuildLineStarts(App& app);
+size_t editorTopVisibleLine(App& app);
 std::string toUtf8(const std::wstring& wstr);
 
 #endif // TINTA_EDITOR_H

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -39,13 +39,42 @@ static std::wstring fromUtf8(const std::string& str) {
 // math must go through DirectWrite hit testing instead of multiplying a
 // column index by a fixed character width.
 
+// Width available for line text in the editor pane (after gutter + padding)
+static float editorTextMaxWidth(const App& app) {
+    float gutterWidth = dpi(app, 48.0f);
+    float padding = dpi(app, 8.0f);
+    return std::max(10.0f, editorPaneWidth(app) - gutterWidth - padding * 2.0f);
+}
+
 static IDWriteTextLayout* createEditorLineLayout(const App& app, size_t lineStart, size_t lineLen) {
     if (!app.dwriteFactory || !app.editorTextFormat || lineLen == 0) return nullptr;
+    float maxWidth = app.editorWordWrap ? editorTextMaxWidth(app) : 1e7f;
     IDWriteTextLayout* layout = nullptr;
     app.dwriteFactory->CreateTextLayout(
         app.editorText.data() + lineStart, (UINT32)lineLen,
-        app.editorTextFormat, 1e7f, 1e7f, &layout);
+        app.editorTextFormat, maxWidth, 1e7f, &layout);
+    // The shared editor format is NO_WRAP; the wrap toggle overrides per layout
+    if (layout && app.editorWordWrap) {
+        layout->SetWordWrapping(DWRITE_WORD_WRAPPING_WRAP);
+    }
     return layout;
+}
+
+// Caret x,y within a (possibly wrapped) line layout for the caret placed
+// before column `col`
+static void editorCaretXY(IDWriteTextLayout* layout, size_t col, float& x, float& y) {
+    x = 0.0f;
+    y = 0.0f;
+    if (!layout) return;
+    FLOAT hx = 0, hy = 0;
+    DWRITE_HIT_TEST_METRICS m{};
+    HRESULT hr = (col == 0)
+        ? layout->HitTestTextPosition(0, FALSE, &hx, &hy, &m)
+        : layout->HitTestTextPosition((UINT32)(col - 1), TRUE, &hx, &hy, &m);
+    if (SUCCEEDED(hr)) {
+        x = hx;
+        y = hy;
+    }
 }
 
 // X offset of the caret placed before column `col`, relative to the text origin.
@@ -86,6 +115,8 @@ static size_t editorNextCharEnd(const App& app, size_t pos) {
 
 // --- Line starts ---
 
+static void rebuildEditorRowMetrics(App& app);
+
 void rebuildLineStarts(App& app) {
     app.editorLineStarts.clear();
     app.editorLineStarts.push_back(0);
@@ -94,6 +125,7 @@ void rebuildLineStarts(App& app) {
             app.editorLineStarts.push_back(i + 1);
         }
     }
+    rebuildEditorRowMetrics(app);
 }
 
 static size_t getLineFromPos(const App& app, size_t pos) {
@@ -120,6 +152,141 @@ static size_t getLineEnd(const App& app, size_t line) {
 
 static size_t getLineLength(const App& app, size_t line) {
     return getLineEnd(app, line) - app.editorLineStarts[line];
+}
+
+// --- Soft-wrap row metrics ---
+//
+// In wrap mode each logical line occupies one or more visual rows.
+// editorRowStarts holds the cumulative row count before each line so
+// scroll, click, and caret math can map between rows and lines.
+
+static void rebuildEditorRowMetrics(App& app) {
+    app.editorRowStarts.clear();
+    app.editorTotalRows = 0;
+    app.editorRowMetricsWidth = -1.0f;
+    if (!app.editorWordWrap || !app.editMode) return;
+
+    float maxTextWidth = editorTextMaxWidth(app);
+    app.editorRowMetricsWidth = maxTextWidth;
+    float charWidth = app.editorCharWidth > 0 ? app.editorCharWidth
+        : (app.editorTextFormat ? app.editorTextFormat->GetFontSize() * 0.6f : 10.0f);
+
+    size_t lineCount = app.editorLineStarts.size();
+    app.editorRowStarts.reserve(lineCount + 1);
+    app.editorRowStarts.push_back(0);
+    for (size_t i = 0; i < lineCount; i++) {
+        size_t lineLen = getLineLength(app, i);
+        size_t rows = 1;
+        // A line can't wrap unless it could exceed the pane width even at
+        // full-width glyph advances (2x the ASCII cell) — skip the layout
+        // for the common short line
+        if (lineLen > 0 && (float)lineLen * charWidth * 2.0f > maxTextWidth) {
+            IDWriteTextLayout* layout =
+                createEditorLineLayout(app, app.editorLineStarts[i], lineLen);
+            if (layout) {
+                DWRITE_TEXT_METRICS tm{};
+                if (SUCCEEDED(layout->GetMetrics(&tm)) && tm.lineCount > 0) {
+                    rows = tm.lineCount;
+                }
+                layout->Release();
+            }
+        }
+        app.editorRowStarts.push_back(app.editorRowStarts.back() + rows);
+    }
+    app.editorTotalRows = app.editorRowStarts.back();
+}
+
+// Rebuild row metrics if the wrap width changed (resize, zoom, splitter,
+// preview toggle) or the line count is out of sync
+static void ensureEditorRowMetrics(App& app) {
+    if (!app.editorWordWrap) return;
+    if (app.editorRowStarts.size() != app.editorLineStarts.size() + 1 ||
+        std::abs(editorTextMaxWidth(app) - app.editorRowMetricsWidth) > 0.5f) {
+        rebuildEditorRowMetrics(app);
+    }
+}
+
+// Logical line containing a global visual row
+static size_t editorLineFromRow(const App& app, size_t row) {
+    if (app.editorRowStarts.size() < 2) return 0;
+    size_t lo = 0, hi = app.editorRowStarts.size() - 1;
+    while (lo + 1 < hi) {
+        size_t mid = (lo + hi) / 2;
+        if (app.editorRowStarts[mid] <= row) lo = mid;
+        else hi = mid;
+    }
+    return lo;
+}
+
+// Top visible logical line for the current editor scroll position
+size_t editorTopVisibleLine(App& app) {
+    float lineHeight = app.editorTextFormat ? app.editorTextFormat->GetFontSize() * 1.5f : 20.0f;
+    size_t row = (size_t)std::max(0.0f, app.editorScrollY / lineHeight);
+    if (app.editorWordWrap) {
+        ensureEditorRowMetrics(app);
+        return editorLineFromRow(app, row);
+    }
+    return row;
+}
+
+// Up/Down in wrap mode moves by VISUAL row, staying near the same x —
+// within a wrapped line first, then into the adjacent logical line
+static void editorMoveCursorVertical(App& app, bool down) {
+    ensureEditorRowMetrics(app);
+    float lineHeight = app.editorTextFormat ? app.editorTextFormat->GetFontSize() * 1.5f : 20.0f;
+    size_t line = getLineFromPos(app, app.editorCursorPos);
+    size_t col = app.editorCursorPos - app.editorLineStarts[line];
+
+    IDWriteTextLayout* layout = createEditorLineLayout(
+        app, app.editorLineStarts[line], getLineLength(app, line));
+    float cx = 0, cy = 0;
+    editorCaretXY(layout, col, cx, cy);
+    if (app.editorDesiredCol < 0) {
+        app.editorDesiredX = cx;
+        app.editorDesiredCol = 0;  // wrap mode uses the flag only; x is authoritative
+    }
+
+    auto hitCol = [&](IDWriteTextLayout* lay, float x, float y, size_t lineLen) {
+        if (!lay) return (size_t)0;
+        BOOL trailing = FALSE, inside = FALSE;
+        DWRITE_HIT_TEST_METRICS m{};
+        lay->HitTestPoint(x, y, &trailing, &inside, &m);
+        size_t c = (size_t)m.textPosition + (trailing ? (size_t)m.length : 0);
+        return std::min(c, lineLen);
+    };
+
+    bool moved = false;
+    if (layout) {
+        DWRITE_TEXT_METRICS tm{};
+        float layoutHeight = SUCCEEDED(layout->GetMetrics(&tm)) ? tm.height : lineHeight;
+        float targetY = cy + (down ? lineHeight : -lineHeight) + lineHeight * 0.5f;
+        if (targetY >= 0.0f && targetY < layoutHeight) {
+            app.editorCursorPos = app.editorLineStarts[line] +
+                hitCol(layout, app.editorDesiredX, targetY, getLineLength(app, line));
+            moved = true;
+        }
+        layout->Release();
+    }
+
+    if (!moved) {
+        bool hasAdjacent = down ? (line + 1 < app.editorLineStarts.size()) : (line > 0);
+        if (!hasAdjacent) return;
+        size_t adjacent = down ? line + 1 : line - 1;
+        size_t adjacentLen = getLineLength(app, adjacent);
+        IDWriteTextLayout* adjacentLayout = createEditorLineLayout(
+            app, app.editorLineStarts[adjacent], adjacentLen);
+        float targetY = lineHeight * 0.5f;
+        if (!down && adjacentLayout) {
+            // entering from below: land on the LAST visual row
+            DWRITE_TEXT_METRICS tm{};
+            if (SUCCEEDED(adjacentLayout->GetMetrics(&tm))) {
+                targetY = tm.height - lineHeight * 0.5f;
+            }
+        }
+        app.editorCursorPos = app.editorLineStarts[adjacent] +
+            hitCol(adjacentLayout, app.editorDesiredX, targetY, adjacentLen);
+        if (adjacentLayout) adjacentLayout->Release();
+    }
 }
 
 // --- Undo/Redo ---
@@ -305,7 +472,19 @@ static void editorEnsureCursorVisible(App& app) {
     size_t line = getLineFromPos(app, app.editorCursorPos);
     float lineHeight = app.editorTextFormat ? app.editorTextFormat->GetFontSize() * 1.5f : 20.0f;
     float padding = dpi(app, 8.0f);
-    float cursorY = padding + line * lineHeight;
+    float cursorY;
+    if (app.editorWordWrap) {
+        ensureEditorRowMetrics(app);
+        IDWriteTextLayout* layout = createEditorLineLayout(
+            app, app.editorLineStarts[line], getLineLength(app, line));
+        float cx = 0, cy = 0;
+        editorCaretXY(layout, app.editorCursorPos - app.editorLineStarts[line], cx, cy);
+        if (layout) layout->Release();
+        size_t rowStart = (line < app.editorRowStarts.size()) ? app.editorRowStarts[line] : line;
+        cursorY = padding + rowStart * lineHeight + cy;
+    } else {
+        cursorY = padding + line * lineHeight;
+    }
 
     if (cursorY < app.editorScrollY + lineHeight) {
         app.editorScrollY = std::max(0.0f, cursorY - lineHeight);
@@ -383,6 +562,8 @@ static void scheduleReparse(App& app) {
         std::wstring title = L"Tinta - * " + fname;
         SetWindowTextW(app.hwnd, title.c_str());
     }
+    // No preview pane — nothing to keep in sync until it's shown again
+    if (!app.editorShowPreview) return;
     // Debounce: coalesce rapid typing into one reparse per pause. WM_TIMER
     // calls editorReparse, which kills the timer. 300ms so brief pauses
     // mid-typing (common with IME input) don't trigger a full preview
@@ -392,7 +573,7 @@ static void scheduleReparse(App& app) {
 
 void editorReparse(App& app) {
     KillTimer(app.hwnd, TIMER_EDITOR_REPARSE);
-    if (!app.editMode) return;
+    if (!app.editMode || !app.editorShowPreview) return;
     std::string utf8 = toUtf8(app.editorText);
 
     // Build line-to-byte-offset mapping for scroll sync
@@ -777,6 +958,41 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 return;
             }
+            case 'P': {
+                app.editorShowPreview = !app.editorShowPreview;
+                if (app.editorShowPreview) {
+                    // Re-parse so the preview catches up with edits made
+                    // while it was hidden
+                    editorReparse(app);
+                }
+                app.editorRowMetricsWidth = -1.0f;  // pane width changed
+                app.editorNotificationMsg = app.editorShowPreview
+                    ? L"Preview shown (Ctrl+P to hide)"
+                    : L"Preview hidden (Ctrl+P to show)";
+                app.showEditModeNotification = true;
+                app.editModeNotificationAlpha = 1.0f;
+                app.editModeNotificationStart = std::chrono::steady_clock::now();
+                startNotificationTimer(app);
+                app.layoutDirty = app.editorShowPreview;
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+            case 'W': {
+                app.editorWordWrap = !app.editorWordWrap;
+                app.editorDesiredCol = -1;
+                app.editorDesiredX = -1.0f;
+                rebuildEditorRowMetrics(app);
+                editorEnsureCursorVisible(app);
+                app.editorNotificationMsg = app.editorWordWrap
+                    ? L"Word wrap on (Ctrl+W to turn off)"
+                    : L"Word wrap off (Ctrl+W to turn on)";
+                app.showEditModeNotification = true;
+                app.editModeNotificationAlpha = 1.0f;
+                app.editModeNotificationStart = std::chrono::steady_clock::now();
+                startNotificationTimer(app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
             case VK_HOME:
                 editorStartOrExtendSelection(app, shift);
                 app.editorCursorPos = 0;
@@ -847,26 +1063,19 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             InvalidateRect(hwnd, nullptr, FALSE);
             return;
 
-        case VK_UP: {
+        case VK_UP:
+        case VK_DOWN: {
+            bool down = (wParam == VK_DOWN);
             editorStartOrExtendSelection(app, shift);
             size_t line = getLineFromPos(app, app.editorCursorPos);
-            if (line > 0) {
+            if (app.editorWordWrap) {
+                editorMoveCursorVertical(app, down);
+            } else if (!down && line > 0) {
                 size_t col = (app.editorDesiredCol >= 0) ? (size_t)app.editorDesiredCol : getColFromPos(app, app.editorCursorPos);
                 if (app.editorDesiredCol < 0) app.editorDesiredCol = (int)col;
                 size_t prevLineLen = getLineLength(app, line - 1);
                 app.editorCursorPos = app.editorLineStarts[line - 1] + std::min(col, prevLineLen);
-            }
-            if (shift) editorUpdateSelEnd(app);
-            else app.editorHasSelection = false;
-            editorEnsureCursorVisible(app);
-            InvalidateRect(hwnd, nullptr, FALSE);
-            return;
-        }
-
-        case VK_DOWN: {
-            editorStartOrExtendSelection(app, shift);
-            size_t line = getLineFromPos(app, app.editorCursorPos);
-            if (line + 1 < app.editorLineStarts.size()) {
+            } else if (down && line + 1 < app.editorLineStarts.size()) {
                 size_t col = (app.editorDesiredCol >= 0) ? (size_t)app.editorDesiredCol : getColFromPos(app, app.editorCursorPos);
                 if (app.editorDesiredCol < 0) app.editorDesiredCol = (int)col;
                 size_t nextLineLen = getLineLength(app, line + 1);
@@ -1054,31 +1263,53 @@ void editorPositionImeWindow(App& app, HWND hwnd) {
     size_t col = std::min(app.editorCursorPos - lineStart, lineLen);
 
     IDWriteTextLayout* layout = createEditorLineLayout(app, lineStart, lineLen);
-    float xOff = editorColToX(app, layout, col);
+    float xOff = 0, yOff = 0;
+    editorCaretXY(layout, col, xOff, yOff);
     if (layout) layout->Release();
 
     float lineHeight = app.editorTextFormat ? app.editorTextFormat->GetFontSize() * 1.5f : 20.0f;
     float padding = dpi(app, 8.0f);
     float gutterWidth = dpi(app, 48.0f);
 
+    float lineTop;
+    if (app.editorWordWrap) {
+        ensureEditorRowMetrics(app);
+        size_t rowStart = (line < app.editorRowStarts.size()) ? app.editorRowStarts[line] : line;
+        lineTop = padding + rowStart * lineHeight;
+    } else {
+        lineTop = padding + line * lineHeight;
+    }
+
     COMPOSITIONFORM cf{};
     cf.dwStyle = CFS_POINT;
     cf.ptCurrentPos.x = (LONG)(gutterWidth + padding + xOff);
-    cf.ptCurrentPos.y = (LONG)(padding + line * lineHeight - app.editorScrollY + lineHeight);
+    cf.ptCurrentPos.y = (LONG)(lineTop + yOff - app.editorScrollY + lineHeight);
     ImmSetCompositionWindow(himc, &cf);
     ImmReleaseContext(hwnd, himc);
 }
 
 // --- Mouse handling ---
 
-static size_t editorPosFromClick(const App& app, int x, int y) {
+static size_t editorPosFromClick(App& app, int x, int y) {
     if (!app.editorTextFormat || app.editorLineStarts.empty()) return 0;
 
     float lineHeight = app.editorTextFormat->GetFontSize() * 1.5f;
     float padding = dpi(app, 8.0f);
 
     float adjustedY = y + app.editorScrollY - padding;
-    size_t line = (size_t)std::max(0, (int)(adjustedY / lineHeight));
+    size_t line;
+    float localY = lineHeight * 0.5f;
+    if (app.editorWordWrap) {
+        ensureEditorRowMetrics(app);
+        size_t row = (size_t)std::max(0, (int)(adjustedY / lineHeight));
+        line = editorLineFromRow(app, row);
+        if (line < app.editorRowStarts.size()) {
+            localY = adjustedY - app.editorRowStarts[line] * lineHeight;
+            localY = std::max(0.0f, localY);
+        }
+    } else {
+        line = (size_t)std::max(0, (int)(adjustedY / lineHeight));
+    }
     if (line >= app.editorLineStarts.size()) line = app.editorLineStarts.size() - 1;
 
     size_t lineStart = app.editorLineStarts[line];
@@ -1086,14 +1317,16 @@ static size_t editorPosFromClick(const App& app, int x, int y) {
 
     float gutterWidth = dpi(app, 48.0f);
     float adjustedX = (float)x - gutterWidth - padding;
-    if (adjustedX <= 0.0f || lineLen == 0) return lineStart;
+    if (lineLen == 0) return lineStart;
+    if (adjustedX <= 0.0f && !app.editorWordWrap) return lineStart;
+    adjustedX = std::max(0.0f, adjustedX);
 
     size_t col;
     IDWriteTextLayout* layout = createEditorLineLayout(app, lineStart, lineLen);
     if (layout) {
         BOOL trailing = FALSE, inside = FALSE;
         DWRITE_HIT_TEST_METRICS m{};
-        layout->HitTestPoint(adjustedX, lineHeight * 0.5f, &trailing, &inside, &m);
+        layout->HitTestPoint(adjustedX, localY, &trailing, &inside, &m);
         layout->Release();
         // trailing hit means the click was past the glyph's midpoint: the
         // caret goes after the full character (m.length covers surrogate pairs)
@@ -1108,16 +1341,18 @@ static size_t editorPosFromClick(const App& app, int x, int y) {
 }
 
 void handleEditorMouseDown(App& app, HWND hwnd, int x, int y) {
-    float editorWidth = app.width * app.editorSplitRatio - 3;
+    float editorWidth = editorPaneWidth(app);
 
-    // Check for separator
-    float sepX = app.width * app.editorSplitRatio;
-    if (std::abs((float)x - sepX) < dpi(app, 6.0f)) {
-        app.draggingSeparator = true;
-        app.separatorDragStartX = (float)x;
-        app.separatorDragStartRatio = app.editorSplitRatio;
-        SetCapture(hwnd);
-        return;
+    // Check for separator (only exists while the preview is visible)
+    if (app.editorShowPreview) {
+        float sepX = app.width * app.editorSplitRatio;
+        if (std::abs((float)x - sepX) < dpi(app, 6.0f)) {
+            app.draggingSeparator = true;
+            app.separatorDragStartX = (float)x;
+            app.separatorDragStartRatio = app.editorSplitRatio;
+            SetCapture(hwnd);
+            return;
+        }
     }
 
     // Only handle clicks in the editor pane (left side)
@@ -1210,7 +1445,7 @@ void handleEditorMouseUp(App& app, HWND hwnd, int x, int y) {
 }
 
 void handleEditorMouseMove(App& app, HWND hwnd, int x, int y) {
-    float editorWidth = app.width * app.editorSplitRatio - 3;
+    float editorWidth = editorPaneWidth(app);
 
     if (app.draggingSeparator) {
         float dx = (float)x - app.separatorDragStartX;
@@ -1236,7 +1471,7 @@ void handleEditorMouseMove(App& app, HWND hwnd, int x, int y) {
     static HCURSOR cursorIBeam = LoadCursor(nullptr, IDC_IBEAM);
     static HCURSOR cursorArrow = LoadCursor(nullptr, IDC_ARROW);
 
-    if (std::abs((float)x - sepX) < dpi(app, 6.0f)) {
+    if (app.editorShowPreview && std::abs((float)x - sepX) < dpi(app, 6.0f)) {
         SetCursor(cursorSizeWE);
     } else if (x < editorWidth) {
         SetCursor(cursorIBeam);
@@ -1254,8 +1489,176 @@ void handleEditorMouseWheel(App& app, HWND hwnd, float delta) {
 
 // --- Rendering ---
 
+// Fill highlight rectangles for a text range within a wrapped line layout.
+// HitTestTextRange returns one rect per visual row the range touches.
+static void editorFillRangeRects(App& app, IDWriteTextLayout* layout,
+                                 float originX, float originY,
+                                 size_t rangeStart, size_t rangeLen,
+                                 const D2D1_COLOR_F& color) {
+    if (!layout || rangeLen == 0) return;
+    UINT32 count = 0;
+    layout->HitTestTextRange((UINT32)rangeStart, (UINT32)rangeLen, 0, 0,
+                             nullptr, 0, &count);
+    if (count == 0) return;
+    std::vector<DWRITE_HIT_TEST_METRICS> metrics(count);
+    if (FAILED(layout->HitTestTextRange((UINT32)rangeStart, (UINT32)rangeLen,
+                                        0, 0, metrics.data(), count, &count))) {
+        return;
+    }
+    app.brush->SetColor(color);
+    for (UINT32 i = 0; i < count; i++) {
+        app.renderTarget->FillRectangle(
+            D2D1::RectF(originX + metrics[i].left, originY + metrics[i].top,
+                        originX + metrics[i].left + metrics[i].width,
+                        originY + metrics[i].top + metrics[i].height),
+            app.brush);
+    }
+}
+
+// Soft-wrap rendering: each logical line spans editorRowStarts-many visual
+// rows; highlights and the caret come from DirectWrite hit testing on the
+// wrapped per-line layouts
+static void renderEditorWrapped(App& app, float editorWidth) {
+    ensureEditorRowMetrics(app);
+    if (app.editorRowStarts.size() != app.editorLineStarts.size() + 1) return;
+
+    float lineHeight = app.editorTextFormat->GetFontSize() * 1.5f;
+    float padding = dpi(app, 8.0f);
+    float gutterWidth = dpi(app, 48.0f);
+    float textX = gutterWidth + padding;
+
+    app.brush->SetColor(app.theme.background);
+    app.renderTarget->FillRectangle(
+        D2D1::RectF(0, 0, editorWidth, (float)app.height), app.brush);
+
+    app.renderTarget->PushAxisAlignedClip(
+        D2D1::RectF(0, 0, editorWidth, (float)app.height),
+        D2D1_ANTIALIAS_MODE_ALIASED);
+
+    size_t selMin = 0, selMax = 0;
+    if (app.editorHasSelection) {
+        selMin = editorSelMin(app);
+        selMax = editorSelMax(app);
+    }
+    bool hasSearchMatches = app.showSearch && !app.searchQuery.empty() &&
+                            !app.editorSearchMatches.empty();
+    size_t searchScanIdx = 0;
+
+    size_t curLine = getLineFromPos(app, app.editorCursorPos);
+    float charWidth = app.editorCharWidth > 0 ? app.editorCharWidth
+        : app.editorTextFormat->GetFontSize() * 0.6f;
+
+    size_t firstRow = (size_t)std::max(0.0f, (app.editorScrollY - padding) / lineHeight);
+    size_t firstLine = editorLineFromRow(app, firstRow);
+
+    for (size_t i = firstLine; i < app.editorLineStarts.size(); i++) {
+        float lineY = padding + app.editorRowStarts[i] * lineHeight - app.editorScrollY;
+        if (lineY > app.height) break;
+
+        size_t lineStart = app.editorLineStarts[i];
+        size_t lineLen = getLineLength(app, i);
+        IDWriteTextLayout* lineLayout = createEditorLineLayout(app, lineStart, lineLen);
+
+        // Line number on the first visual row of the line
+        wchar_t lineNum[16];
+        swprintf(lineNum, 16, L"%d", (int)i + 1);
+        D2D1_COLOR_F gutterColor = app.theme.text;
+        gutterColor.a = 0.3f;
+        app.brush->SetColor(gutterColor);
+        app.renderTarget->DrawText(lineNum, (UINT32)wcslen(lineNum), app.editorTextFormat,
+            D2D1::RectF(dpi(app, 4.0f), lineY, gutterWidth - dpi(app, 4.0f), lineY + lineHeight),
+            app.brush);
+
+        // Selection highlight
+        if (app.editorHasSelection && selMax > lineStart && selMin < lineStart + lineLen + 1) {
+            size_t hlStart = (selMin > lineStart) ? selMin - lineStart : 0;
+            size_t hlEnd = std::min(selMax - lineStart, lineLen);
+            D2D1_COLOR_F selColor = D2D1::ColorF(0.2f, 0.4f, 0.9f, 0.35f);
+            editorFillRangeRects(app, lineLayout, textX, lineY, hlStart, hlEnd - hlStart, selColor);
+            if (selMax > lineStart + lineLen && selMin <= lineStart + lineLen) {
+                // Newline included: mark one cell past the end of the last row
+                float ex = 0, ey = 0;
+                editorCaretXY(lineLayout, lineLen, ex, ey);
+                app.brush->SetColor(selColor);
+                app.renderTarget->FillRectangle(
+                    D2D1::RectF(textX + ex, lineY + ey,
+                                textX + ex + charWidth, lineY + ey + lineHeight),
+                    app.brush);
+            }
+        }
+
+        // Search match highlights
+        if (hasSearchMatches) {
+            size_t lineEnd = lineStart + lineLen;
+            while (searchScanIdx < app.editorSearchMatches.size() &&
+                   app.editorSearchMatches[searchScanIdx].startPos +
+                       app.editorSearchMatches[searchScanIdx].length <= lineStart) {
+                searchScanIdx++;
+            }
+            for (size_t si = searchScanIdx; si < app.editorSearchMatches.size(); si++) {
+                const auto& m = app.editorSearchMatches[si];
+                if (m.startPos >= lineEnd) break;
+                size_t overlapStart = std::max(lineStart, m.startPos);
+                size_t overlapEnd = std::min(lineEnd, m.startPos + m.length);
+                if (overlapStart >= overlapEnd) continue;
+                bool isCurrent = ((int)si == app.editorSearchCurrentIndex);
+                D2D1_COLOR_F hlColor = isCurrent
+                    ? D2D1::ColorF(1.0f, 0.6f, 0.0f, 0.5f)
+                    : D2D1::ColorF(1.0f, 0.9f, 0.0f, 0.3f);
+                editorFillRangeRects(app, lineLayout, textX, lineY,
+                                     overlapStart - lineStart,
+                                     overlapEnd - overlapStart, hlColor);
+            }
+        }
+
+        // Line text
+        if (lineLayout) {
+            app.brush->SetColor(app.theme.text);
+            app.renderTarget->DrawTextLayout(
+                D2D1::Point2F(textX, lineY), lineLayout, app.brush);
+        }
+
+        // Caret
+        if (app.cursorBlinkOn && i == curLine) {
+            float cx = 0, cy = 0;
+            editorCaretXY(lineLayout, app.editorCursorPos - lineStart, cx, cy);
+            app.brush->SetColor(app.theme.text);
+            app.renderTarget->FillRectangle(
+                D2D1::RectF(textX + cx, lineY + cy,
+                            textX + cx + dpi(app, 2.0f), lineY + cy + lineHeight),
+                app.brush);
+        }
+
+        if (lineLayout) lineLayout->Release();
+    }
+
+    app.editorContentHeight = padding * 2 + app.editorTotalRows * lineHeight;
+
+    // Editor scrollbar (same as unwrapped)
+    if (app.editorContentHeight > app.height) {
+        float maxScroll = app.editorContentHeight - app.height;
+        float sbHeight = (float)app.height / app.editorContentHeight * app.height;
+        sbHeight = std::max(sbHeight, dpi(app, 30.0f));
+        float sbY = (maxScroll > 0) ? (app.editorScrollY / maxScroll * (app.height - sbHeight)) : 0;
+
+        float sbColorValue = app.theme.isDark ? 1.0f : 0.0f;
+        app.brush->SetColor(D2D1::ColorF(sbColorValue, sbColorValue, sbColorValue, 0.3f));
+        app.renderTarget->FillRoundedRectangle(
+            D2D1::RoundedRect(D2D1::RectF(editorWidth - dpi(app, 10.0f), sbY,
+                                           editorWidth - dpi(app, 4.0f), sbY + sbHeight), 3, 3),
+            app.brush);
+    }
+
+    app.renderTarget->PopAxisAlignedClip();
+}
+
 void renderEditor(App& app, float editorWidth) {
     if (!app.editorTextFormat || app.editorLineStarts.empty()) return;
+
+    if (app.editorWordWrap) {
+        renderEditorWrapped(app, editorWidth);
+        return;
+    }
 
     float lineHeight = app.editorTextFormat->GetFontSize() * 1.5f;
     float padding = dpi(app, 8.0f);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -50,7 +50,9 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
     // Edit mode: route scroll to editor or preview based on mouse X
     if (app.editMode) {
-        float sepX = app.width * app.editorSplitRatio;
+        float sepX = app.editorShowPreview
+            ? app.width * app.editorSplitRatio
+            : static_cast<float>(app.width);
         if (app.mouseX < sepX) {
             if (ctrl) {
                 applyZoomDelta(app, delta);
@@ -157,7 +159,9 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     if (app.editMode) {
         handleEditorMouseMove(app, hwnd, app.mouseX, app.mouseY);
         // If mouse is in the preview pane and not dragging separator, fall through for link hover etc.
-        float sepX = app.width * app.editorSplitRatio;
+        float sepX = app.editorShowPreview
+            ? app.width * app.editorSplitRatio
+            : static_cast<float>(app.width);
         if (app.mouseX < sepX || app.draggingSeparator || app.editorSelecting) return;
         // For preview pane, adjust mouseX to be relative to preview offset
         // but we leave the existing code to work with document coordinates
@@ -357,7 +361,9 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     if (app.editMode) {
         int x = GET_X_LPARAM(lParam);
         int y = GET_Y_LPARAM(lParam);
-        float sepX = app.width * app.editorSplitRatio;
+        float sepX = app.editorShowPreview
+            ? app.width * app.editorSplitRatio
+            : static_cast<float>(app.width);
         if (x < sepX + 6) {
             handleEditorMouseDown(app, hwnd, x, y);
             return;

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -39,7 +39,11 @@ void render(App& app) {
     app.drawCalls = 0;
 
     if (app.layoutDirty) {
-        if (app.editMode) {
+        if (app.editMode && !app.editorShowPreview) {
+            // Preview hidden: defer document layout until it's shown again
+            // (the viewport is zero-width, so laying out now would be wasted
+            // work against a nonsense max width)
+        } else if (app.editMode) {
             // Edit mode needs complete scroll anchors for preview sync
             layoutDocument(app);
         } else {
@@ -53,10 +57,10 @@ void render(App& app) {
     }
 
     // Sync preview scroll to editor scroll position using source-offset anchors
-    if (app.editMode && !app.scrollAnchors.empty() && !app.editorLineByteOffsets.empty()) {
-        // Find the editor's top visible line
-        float lineHeight = app.editorTextFormat ? app.editorTextFormat->GetFontSize() * 1.5f : 20.0f;
-        int topLine = (int)(app.editorScrollY / lineHeight);
+    if (app.editMode && app.editorShowPreview &&
+        !app.scrollAnchors.empty() && !app.editorLineByteOffsets.empty()) {
+        // Find the editor's top visible line (row-aware in wrap mode)
+        int topLine = (int)editorTopVisibleLine(app);
         topLine = std::max(0, std::min(topLine, (int)app.editorLineByteOffsets.size() - 1));
         size_t topByteOffset = app.editorLineByteOffsets[topLine];
 
@@ -100,15 +104,15 @@ void render(App& app) {
     if (app.editMode) {
         app.renderTarget->Clear(app.theme.background);
 
-        float editorWidth = app.width * app.editorSplitRatio - 3;
+        float editorWidth = editorPaneWidth(app);
         float previewX = documentViewportX(app);
         float previewWidth = documentViewportWidth(app);
 
-        // Render editor (left pane)
+        // Render editor (left pane; full width when the preview is hidden)
         renderEditor(app, editorWidth);
 
         // Render separator
-        renderSeparator(app);
+        if (app.editorShowPreview) renderSeparator(app);
 
         // Render preview (right pane) using clip + transform
         app.renderTarget->PushAxisAlignedClip(
@@ -909,6 +913,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 Settings settings = loadSettings();
                 settings.themeIndex = app->currentThemeIndex;
                 settings.zoomFactor = app->zoomFactor;
+                settings.editorShowPreview = app->editorShowPreview;
+                settings.editorWordWrap = app->editorWordWrap;
 
                 // Get window placement for position/size/maximized state
                 WINDOWPLACEMENT wp = {};
@@ -1012,6 +1018,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.theme = THEMES[savedSettings.themeIndex];
     app.darkMode = app.theme.isDark;
     app.zoomFactor = savedSettings.zoomFactor;
+    app.editorShowPreview = savedSettings.editorShowPreview;
+    app.editorWordWrap = savedSettings.editorWordWrap;
 
     // Parse command line
     std::string inputFile;

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -707,6 +707,8 @@ void renderHelpOverlay(App& app) {
     const HelpEntry editEntries[] = {
         {L":",             L"Enter edit mode"},
         {L"Ctrl+S",       L"Save (in edit mode)"},
+        {L"Ctrl+P",       L"Show / hide preview pane"},
+        {L"Ctrl+W",       L"Toggle word wrap"},
         {L"ESC ESC",      L"Exit edit mode"},
     };
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -35,6 +35,8 @@ void saveSettings(const Settings& settings) {
     file << "windowHeight=" << settings.windowHeight << "\n";
     file << "windowMaximized=" << (settings.windowMaximized ? 1 : 0) << "\n";
     file << "hasAskedFileAssociation=" << (settings.hasAskedFileAssociation ? 1 : 0) << "\n";
+    file << "editorShowPreview=" << (settings.editorShowPreview ? 1 : 0) << "\n";
+    file << "editorWordWrap=" << (settings.editorWordWrap ? 1 : 0) << "\n";
 }
 
 Settings loadSettings() {
@@ -75,6 +77,10 @@ Settings loadSettings() {
             settings.windowMaximized = (value == "1");
         } else if (key == "hasAskedFileAssociation") {
             settings.hasAskedFileAssociation = (value == "1");
+        } else if (key == "editorShowPreview") {
+            settings.editorShowPreview = (value == "1");
+        } else if (key == "editorWordWrap") {
+            settings.editorWordWrap = (value == "1");
         }
     }
     return settings;


### PR DESCRIPTION
Implements both requests from #17.

## Preview toggle (Ctrl+P)
- Editor takes the full window while the preview is hidden; separator and preview skipped
- Reparse/relayout fully suspended while hidden (snappier editing on large docs); one reparse on re-show catches the preview up
- Zero-width viewport approach: document render path is untouched, it just clips to nothing

## Soft word wrap (Ctrl+W, off by default)
- Per-line DirectWrite layouts get a real wrap width; `editorRowStarts` maps logical lines ↔ visual rows (rebuilt on edit, self-heals on resize/zoom/splitter/preview-toggle via width check)
- Short lines skip layout creation during metric rebuilds (can't-wrap fast path, full-width-glyph conservative)
- Caret, clicks, selection and search highlights (`HitTestTextRange`, one rect per row), Up/Down by visual row with sticky X, IME window position, and editor↔preview scroll sync are all row-aware
- The unwrapped code path is byte-for-byte the previous behavior — wrap off means zero risk to the #12 CJK fixes

Both options persist in settings. Help overlay + README updated.

## Verification (driven against the real binary)
- Long CJK paragraphs wrap correctly; line numbers on first visual rows
- Click into the middle of a wrapped row inserts exactly at the click point (CJK text)
- Ctrl+P hides/shows; wrap metrics re-flow to the new pane width automatically; preview reparses on show
- Tests 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)