### PR TITLE
CI: fix stale binary-size claim in release notes template

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
             - 10 beautiful themes (5 light, 5 dark)
             - Hardware-accelerated rendering via Direct2D
             - Native Mermaid flowchart rendering
-            - ~270KB single executable, no dependencies
+            - Single portable executable under 1 MB, no dependencies
           files: build/Release/tinta.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The generated release notes claimed ~270KB; the binary is ~570KB since v2.1.0. Use a claim that stays true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)