### PR TITLE
Embed PE version metadata, pin md4c by commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- The executable now embeds proper version metadata (company, product, description, version) — files without it disproportionately trip antivirus ML heuristics
+- md4c dependency pinned by commit hash instead of tag
+
 ## [v2.1.0] - 2026-07-10
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include(FetchContent)
 FetchContent_Declare(
     md4c
     GIT_REPOSITORY https://github.com/mity/md4c.git
-    GIT_TAG release-0.5.2
+    GIT_TAG 729e6b8b320caa96328968ab27d7db2235e4fb47  # release-0.5.2, pinned by commit
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(md4c)
@@ -90,7 +90,10 @@ target_link_libraries(tinta PRIVATE
     imm32
 )
 
-target_compile_definitions(tinta PRIVATE UNICODE _UNICODE)
+target_compile_definitions(tinta PRIVATE UNICODE _UNICODE
+    TINTA_VERSION_MAJOR=${PROJECT_VERSION_MAJOR}
+    TINTA_VERSION_MINOR=${PROJECT_VERSION_MINOR}
+    TINTA_VERSION_PATCH=${PROJECT_VERSION_PATCH})
 
 if(BUILD_TESTING)
     add_executable(mermaid_tests

--- a/resources/tinta.rc
+++ b/resources/tinta.rc
@@ -2,3 +2,53 @@
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
 IDI_ICON1 ICON "tinta.ico"
+
+// Version metadata. The numbers come from CMake (project VERSION) via
+// TINTA_VERSION_* compile definitions so the exe always self-describes
+// correctly — executables without version metadata disproportionately
+// trip antivirus ML heuristics.
+#ifndef TINTA_VERSION_MAJOR
+#define TINTA_VERSION_MAJOR 0
+#endif
+#ifndef TINTA_VERSION_MINOR
+#define TINTA_VERSION_MINOR 0
+#endif
+#ifndef TINTA_VERSION_PATCH
+#define TINTA_VERSION_PATCH 0
+#endif
+
+#define TINTA_STR_HELPER(x) #x
+#define TINTA_STR(x) TINTA_STR_HELPER(x)
+#define TINTA_VERSION_STRING \
+    TINTA_STR(TINTA_VERSION_MAJOR) "." \
+    TINTA_STR(TINTA_VERSION_MINOR) "." \
+    TINTA_STR(TINTA_VERSION_PATCH)
+
+1 VERSIONINFO
+FILEVERSION     TINTA_VERSION_MAJOR,TINTA_VERSION_MINOR,TINTA_VERSION_PATCH,0
+PRODUCTVERSION  TINTA_VERSION_MAJOR,TINTA_VERSION_MINOR,TINTA_VERSION_PATCH,0
+FILEFLAGSMASK   0x3fL
+FILEFLAGS       0x0L
+FILEOS          0x40004L
+FILETYPE        0x1L
+FILESUBTYPE     0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName",      "oipoistar"
+            VALUE "FileDescription",  "Tinta - fast, lightweight Markdown and Mermaid viewer"
+            VALUE "FileVersion",      TINTA_VERSION_STRING
+            VALUE "InternalName",     "tinta"
+            VALUE "LegalCopyright",   "Copyright (c) oipoistar. MIT License."
+            VALUE "OriginalFilename", "tinta.exe"
+            VALUE "ProductName",      "Tinta"
+            VALUE "ProductVersion",   TINTA_VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
Follow-up to the Defender `Trojan:Win32/Sabsik.TE.A!ml` false positive on the v2.1.0 release asset (Microsoft FP report submitted, pending analysis).

- **VERSIONINFO resource**: the exe previously shipped with zero version metadata — no company, product, description, or version. Anonymous PEs disproportionately trip AV machine-learning heuristics, and metadata is table stakes for the AV vendor allowlisting processes anyway. Values auto-sync from CMake's `project(VERSION)` via resource-compiler defines, so releases can't drift.
- **md4c pinned by commit hash** (`729e6b8b` = release-0.5.2) instead of a movable tag — supply-chain hygiene for CI builds.

Verified locally: `(Get-Item tinta.exe).VersionInfo` shows all fields, FileVersion 2.1.0 synced from CMake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)