### PR TITLE
Fix off-screen window restore (#25), lenient indentation parsing (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- Window no longer restores onto a disconnected monitor — the saved position is validated against the monitors present at startup and clamped into the nearest one (#25)
+- Deeply indented list continuations (common in AI-chat markdown exports) render as regular text instead of code blocks with literal `**` markers; fenced ``` blocks are unaffected (#24)
+
 ### Changed
 - The executable now embeds proper version metadata (company, product, description, version) — files without it disproportionately trip antivirus ML heuristics
 - md4c dependency pinned by commit hash instead of tag

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1086,12 +1086,39 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     wc.lpszClassName = L"Tinta";
     RegisterClassExW(&wc);
 
+    // Validate the saved window position against the monitors that exist
+    // NOW — a position saved on a since-disconnected screen (docked laptop,
+    // unplugged external monitor) would otherwise restore off-screen (#25)
+    int windowX = savedSettings.windowX;
+    int windowY = savedSettings.windowY;
+    if (windowX != CW_USEDEFAULT && windowY != CW_USEDEFAULT) {
+        RECT saved = { windowX, windowY,
+                       windowX + savedSettings.windowWidth,
+                       windowY + savedSettings.windowHeight };
+        HMONITOR monitor = MonitorFromRect(&saved, MONITOR_DEFAULTTONULL);
+        if (!monitor) {
+            // Fully off every live monitor: clamp into the nearest one
+            monitor = MonitorFromRect(&saved, MONITOR_DEFAULTTONEAREST);
+            MONITORINFO mi = { sizeof(mi) };
+            if (monitor && GetMonitorInfoW(monitor, &mi)) {
+                const RECT& wa = mi.rcWork;
+                int width = std::min<int>(savedSettings.windowWidth, wa.right - wa.left);
+                int height = std::min<int>(savedSettings.windowHeight, wa.bottom - wa.top);
+                windowX = std::max<int>(wa.left, std::min<int>(windowX, wa.right - width));
+                windowY = std::max<int>(wa.top, std::min<int>(windowY, wa.bottom - height));
+            } else {
+                windowX = CW_USEDEFAULT;
+                windowY = CW_USEDEFAULT;
+            }
+        }
+    }
+
     app.hwnd = CreateWindowExW(
         WS_EX_ACCEPTFILES,
         L"Tinta",
         L"Tinta",
         WS_OVERLAPPEDWINDOW,
-        savedSettings.windowX, savedSettings.windowY,
+        windowX, windowY,
         savedSettings.windowWidth, savedSettings.windowHeight,
         nullptr, nullptr, hInstance, nullptr
     );

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -333,7 +333,12 @@ ParseResult MarkdownParser::parse(const std::string& markdown) {
             MD_FLAG_STRIKETHROUGH |
             MD_FLAG_PERMISSIVEAUTOLINKS |
             MD_FLAG_PERMISSIVEURLAUTOLINKS |
-            MD_FLAG_TASKLISTS
+            MD_FLAG_TASKLISTS |
+            // Real-world notes (especially AI-chat exports) indent list
+            // continuations far enough that CommonMark turns them into code
+            // blocks — literal ** markers, no wrapping (#24). Fenced ```
+            // blocks are unaffected and remain the way to write code.
+            MD_FLAG_NOINDENTEDCODEBLOCKS
         ),
         enterBlockCallback,
         leaveBlockCallback,


### PR DESCRIPTION
Two user reports:

**#25 — window restores onto a disconnected monitor.** The saved position is now validated with `MonitorFromRect(MONITOR_DEFAULTTONULL)` at startup; if no live monitor contains it, the window clamps into the nearest monitor's work area. Verified by writing (15000, -9000) into settings.ini — the window opened clamped to the desktop edge at (3720, 0).

**#24 (partial) — literal `**` markers and unwrappable long lines.** The reported document (an AI-chat export) indents list continuations deep enough that CommonMark parses them as indented code blocks — technically spec-correct, but wrong for a notes viewer. Enables md4c's `MD_FLAG_NOINDENTEDCODEBLOCKS`: deeply indented text now renders as regular wrapped paragraphs with working inline formatting. Trade-off: 4-space-indented code no longer renders as code; fenced ``` blocks (unchanged) are the supported way.

Remaining #24 items (table cell overlap/wrapping for CJK, bold-CJK font weight) tracked separately — they need the reporter's sample file to reproduce exactly.

Verified against a repro of the reporter's structure: bold renders bold, paragraphs wrap, inline code and fenced blocks unaffected; tests 2/2 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)