### PR TITLE
Inline extensions: ==highlight==, ^sup^, ~sub~, real ~~strikethrough~~

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Obsidian/Typora inline extensions: `==highlight==`, `^superscript^`, `~subscript~` (#24)
+- `~~strikethrough~~` now actually renders with a line through the text — previously the markers were consumed but no styling was applied
+
 ## [v2.1.5] - 2026-07-14
 
 ### Fixed

--- a/include/app.h
+++ b/include/app.h
@@ -482,6 +482,7 @@ struct App {
     std::vector<EditAction> redoStack;
 
     // Editor text format (monospace)
+    IDWriteTextFormat* supSubFormat = nullptr;   // small size for ^sup^/~sub~
     IDWriteTextFormat* editorTextFormat = nullptr;
     float editorCharWidth = 0.0f; // Measured monospace char width
 
@@ -519,6 +520,7 @@ struct App {
         if (folderBrowserFormat) { folderBrowserFormat->Release(); folderBrowserFormat = nullptr; }
         if (tocFormat) { tocFormat->Release(); tocFormat = nullptr; }
         if (tocFormatBold) { tocFormatBold->Release(); tocFormatBold = nullptr; }
+        if (supSubFormat) { supSubFormat->Release(); supSubFormat = nullptr; }
         if (editorTextFormat) { editorTextFormat->Release(); editorTextFormat = nullptr; }
         for (auto& fmt : themePreviewFormats) {
             if (fmt.name) { fmt.name->Release(); fmt.name = nullptr; }

--- a/include/markdown.h
+++ b/include/markdown.h
@@ -36,6 +36,11 @@ enum class ElementType {
     HardBreak,
     Ruby,
     RubyText,
+    // Obsidian/Typora inline extensions (parsed in a post-pass)
+    Highlight,     // ==text==
+    Superscript,   // ^text^
+    Subscript,     // ~text~
+    Strikethrough, // ~~text~~ (handled in the post-pass, not md4c)
 };
 
 // Forward declaration

--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -64,6 +64,7 @@ void updateTextFormats(App& app) {
     if (app.codeFormat) { app.codeFormat->Release(); app.codeFormat = nullptr; }
     if (app.boldFormat) { app.boldFormat->Release(); app.boldFormat = nullptr; }
     if (app.italicFormat) { app.italicFormat->Release(); app.italicFormat = nullptr; }
+    if (app.supSubFormat) { app.supSubFormat->Release(); app.supSubFormat = nullptr; }
     for (auto& fmt : app.headingFormats) {
         if (fmt) { fmt->Release(); fmt = nullptr; }
     }
@@ -96,6 +97,11 @@ void updateTextFormats(App& app) {
         DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_ITALIC, DWRITE_FONT_STRETCH_NORMAL,
         fontSize, L"en-us", &app.italicFormat);
 
+    // Small format for ^superscript^ / ~subscript~ spans
+    app.dwriteFactory->CreateTextFormat(fontFamily, nullptr,
+        DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+        fontSize * 0.68f, L"en-us", &app.supSubFormat);
+
     // Heading formats by level (use Segoe UI to match previous behavior)
     const wchar_t* headingFont = L"Segoe UI";
     float headingSizes[] = {32, 26, 22, 18, 16, 14};
@@ -111,6 +117,7 @@ void updateTextFormats(App& app) {
     if (app.codeFormat) app.codeFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR);
     if (app.boldFormat) app.boldFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR);
     if (app.italicFormat) app.italicFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR);
+    if (app.supSubFormat) app.supSubFormat->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR);
     for (auto* fmt : app.headingFormats) {
         if (fmt) fmt->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_NEAR);
     }

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -315,6 +315,114 @@ static int textCallback(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, voi
 }
 
 // MarkdownParser implementation
+// --- Inline extension post-pass (==highlight==, ^sup^, ~sub~) ---
+//
+// md4c has no extension hooks for these Obsidian/Typora spans, so a pass
+// over the finished tree splits Text nodes that contain them. Code spans,
+// code blocks, and Mermaid sources are never touched.
+
+namespace {
+
+struct ExtensionMatch {
+    size_t start;       // index of the opening delimiter
+    size_t contentLen;  // bytes between the delimiters
+    size_t delimLen;    // 2 for ==, 1 for ^ and ~
+    ElementType type;
+};
+
+// Find the first extension span at or after `from`. Delimiters are ASCII,
+// so byte scanning is UTF-8 safe.
+static bool findExtensionSpan(const std::string& text, size_t from, ExtensionMatch& match) {
+    for (size_t i = from; i < text.size(); i++) {
+        char c = text[i];
+        if (c == '=' && i + 1 < text.size() && text[i + 1] == '=') {
+            size_t close = text.find("==", i + 2);
+            if (close != std::string::npos && close > i + 2) {
+                match = {i, close - (i + 2), 2, ElementType::Highlight};
+                return true;
+            }
+        } else if (c == '~' && i + 1 < text.size() && text[i + 1] == '~') {
+            size_t close = text.find("~~", i + 2);
+            if (close != std::string::npos && close > i + 2) {
+                match = {i, close - (i + 2), 2, ElementType::Strikethrough};
+                return true;
+            }
+            // No closing ~~: fall through to try a single-tilde subscript
+            size_t single = text.find('~', i + 2);
+            if (single == std::string::npos) continue;
+            i++;  // retry from the second tilde as a potential single opener
+            continue;
+        } else if (c == '^' || c == '~') {
+            size_t close = text.find(c, i + 1);
+            if (close == std::string::npos || close == i + 1) continue;
+            // Typora rule: no whitespace inside sup/sub spans
+            bool hasSpace = false;
+            for (size_t j = i + 1; j < close; j++) {
+                unsigned char uc = static_cast<unsigned char>(text[j]);
+                if (uc == ' ' || uc == '\t' || uc == '\n') { hasSpace = true; break; }
+            }
+            if (hasSpace) continue;
+            match = {i, close - (i + 1), 1,
+                     c == '^' ? ElementType::Superscript : ElementType::Subscript};
+            return true;
+        }
+    }
+    return false;
+}
+
+static ElementPtr makeTextElement(std::string text, Element* parent) {
+    auto node = std::make_shared<Element>(ElementType::Text);
+    node->text = std::move(text);
+    node->parent = parent;
+    return node;
+}
+
+static void splitInlineExtensions(const ElementPtr& parent) {
+    if (parent->type == ElementType::Code ||
+        parent->type == ElementType::CodeBlock ||
+        parent->type == ElementType::MermaidDiagram) {
+        return;
+    }
+
+    std::vector<ElementPtr> rebuilt;
+    bool changed = false;
+    for (auto& child : parent->children) {
+        if (child->type != ElementType::Text) {
+            splitInlineExtensions(child);
+            rebuilt.push_back(child);
+            continue;
+        }
+
+        const std::string& text = child->text;
+        size_t cursor = 0;
+        ExtensionMatch m;
+        bool any = false;
+        while (findExtensionSpan(text, cursor, m)) {
+            any = true;
+            if (m.start > cursor) {
+                rebuilt.push_back(makeTextElement(text.substr(cursor, m.start - cursor), parent.get()));
+            }
+            auto span = std::make_shared<Element>(m.type);
+            span->parent = parent.get();
+            span->children.push_back(makeTextElement(
+                text.substr(m.start + m.delimLen, m.contentLen), span.get()));
+            rebuilt.push_back(std::move(span));
+            cursor = m.start + m.delimLen + m.contentLen + m.delimLen;
+        }
+        if (!any) {
+            rebuilt.push_back(child);
+            continue;
+        }
+        changed = true;
+        if (cursor < text.size()) {
+            rebuilt.push_back(makeTextElement(text.substr(cursor), parent.get()));
+        }
+    }
+    if (changed) parent->children = std::move(rebuilt);
+}
+
+} // namespace
+
 MarkdownParser::MarkdownParser() = default;
 MarkdownParser::~MarkdownParser() = default;
 
@@ -330,7 +438,9 @@ ParseResult MarkdownParser::parse(const std::string& markdown) {
         0, // abi_version
         static_cast<unsigned>(
             MD_FLAG_TABLES |
-            MD_FLAG_STRIKETHROUGH |
+            // Strikethrough is handled in the extension post-pass: md4c's
+            // implementation also consumes single ~tilde~ pairs, which we
+            // need for ~subscript~
             MD_FLAG_PERMISSIVEAUTOLINKS |
             MD_FLAG_PERMISSIVEURLAUTOLINKS |
             MD_FLAG_TASKLISTS |
@@ -361,6 +471,7 @@ ParseResult MarkdownParser::parse(const std::string& markdown) {
     }
 
     ctx.flushText();
+    splitInlineExtensions(ctx.root);
     result.root = ctx.root;
     result.success = true;
     return result;
@@ -390,6 +501,10 @@ std::string elementTypeToString(ElementType type) {
         case ElementType::Heading: return "Heading";
         case ElementType::CodeBlock: return "CodeBlock";
         case ElementType::MermaidDiagram: return "MermaidDiagram";
+        case ElementType::Highlight: return "Highlight";
+        case ElementType::Strikethrough: return "Strikethrough";
+        case ElementType::Superscript: return "Superscript";
+        case ElementType::Subscript: return "Subscript";
         case ElementType::BlockQuote: return "BlockQuote";
         case ElementType::List: return "List";
         case ElementType::ListItem: return "ListItem";

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -215,6 +215,10 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
         D2D1_COLOR_F color = baseColor;
         std::string linkUrl = baseLinkUrl;
         bool isLink = !baseLinkUrl.empty();
+        bool hasBg = false;
+        bool hasStrike = false;
+        D2D1_COLOR_F bgColor{};
+        float drawYOffset = 0.0f;
 
         std::wstring text;
 
@@ -234,6 +238,48 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
 
             case ElementType::Emphasis:
                 format = app.italicFormat;
+                for (const auto& child : elem->children) {
+                    if (child->type == ElementType::Text) {
+                        text += toWide(child->text);
+                    }
+                }
+                break;
+
+            case ElementType::Strikethrough:
+                hasStrike = true;
+                for (const auto& child : elem->children) {
+                    if (child->type == ElementType::Text) {
+                        text += toWide(child->text);
+                    }
+                }
+                break;
+
+            case ElementType::Highlight:
+                // ==text== renders on a marker-pen background
+                hasBg = true;
+                bgColor = app.theme.isDark
+                    ? D2D1::ColorF(0.98f, 0.80f, 0.25f, 0.28f)
+                    : D2D1::ColorF(1.00f, 0.88f, 0.20f, 0.45f);
+                for (const auto& child : elem->children) {
+                    if (child->type == ElementType::Text) {
+                        text += toWide(child->text);
+                    }
+                }
+                break;
+
+            case ElementType::Superscript:
+                // Small text; NEAR alignment already sits it at the top of the line
+                format = app.supSubFormat ? app.supSubFormat : baseFormat;
+                for (const auto& child : elem->children) {
+                    if (child->type == ElementType::Text) {
+                        text += toWide(child->text);
+                    }
+                }
+                break;
+
+            case ElementType::Subscript:
+                format = app.supSubFormat ? app.supSubFormat : baseFormat;
+                drawYOffset = lineHeight * 0.38f;
                 for (const auto& child : elem->children) {
                     if (child->type == ElementType::Text) {
                         text += toWide(child->text);
@@ -446,7 +492,18 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
             std::wstring_view segText(text.data() + segStart, segEnd - segStart);
             LayoutInfo info = createLayout(app, segText, format, lineHeight, app.bodyTypography);
             float segWidth = widthOf(segStart, segEnd);
-            D2D1_POINT_2F segPos = D2D1::Point2F(segX, y);
+            if (hasBg) {
+                app.layoutRects.push_back({
+                    D2D1::RectF(segX - 2, y + 1, segX + segWidth + 2, y + lineHeight - 1),
+                    bgColor});
+            }
+            if (hasStrike) {
+                float strikeY = y + lineHeight * 0.55f;
+                app.layoutLines.push_back({D2D1::Point2F(segX, strikeY),
+                                           D2D1::Point2F(segX + segWidth, strikeY),
+                                           color, 1.0f});
+            }
+            D2D1_POINT_2F segPos = D2D1::Point2F(segX, y + drawYOffset);
             D2D1_RECT_F segBounds = D2D1::RectF(segX, y, segX + segWidth, y + lineHeight);
             addTextRun(app, std::move(info), segPos, segBounds, color,
                        textDocStart + segStart, segEnd - segStart, false);

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -35,6 +35,45 @@ int main() {
               ".mmd content becomes a Mermaid diagram element");
     }
 
+    // Obsidian/Typora inline extensions
+    auto ext = parseDocument(parser,
+        "before ==mark 中文== mid x^2^ and H~2~O ~~gone~~ `==not this==`\n", "notes.md");
+    check(ext.success, "extension test parses");
+    if (ext.success && !ext.root->children.empty()) {
+        const auto& para = ext.root->children[0];
+        int highlights = 0, sups = 0, subs = 0, codeIntact = 0, strikes = 0;
+        for (const auto& child : para->children) {
+            if (child->type == qmd::ElementType::Highlight) {
+                highlights++;
+                check(!child->children.empty() &&
+                      child->children[0]->text == "mark \xe4\xb8\xad\xe6\x96\x87",
+                      "highlight content preserved incl. CJK");
+            }
+            if (child->type == qmd::ElementType::Superscript) {
+                sups++;
+                check(!child->children.empty() && child->children[0]->text == "2",
+                      "superscript content preserved");
+            }
+            if (child->type == qmd::ElementType::Subscript) subs++;
+            if (child->type == qmd::ElementType::Strikethrough) {
+                strikes++;
+                check(!child->children.empty() && child->children[0]->text == "gone",
+                      "strikethrough content preserved");
+            }
+            if (child->type == qmd::ElementType::Code) {
+                codeIntact++;
+                check(!child->children.empty() &&
+                      child->children[0]->text == "==not this==",
+                      "code spans are not transformed");
+            }
+        }
+        check(highlights == 1, "one ==highlight== parsed");
+        check(sups == 1, "one ^sup^ parsed");
+        check(subs == 1, "one ~sub~ parsed");
+        check(strikes == 1, "one ~~strike~~ parsed");
+        check(codeIntact == 1, "inline code untouched");
+    }
+
     auto markdown = parseDocument(parser, "# Heading\n", "notes.md");
     check(markdown.success, "Markdown document still parses");
     check(markdown.root && !markdown.root->children.empty() &&


### PR DESCRIPTION
First part of the #24 follow-up work.

- Post-parse pass splits Text nodes containing `==highlight==`, `^superscript^`, `~subscript~` (Obsidian/Typora syntax) into dedicated elements. Code spans, code blocks, and Mermaid sources are never transformed.
- Tilde handling moves out of md4c entirely: its STRIKETHROUGH flag also consumes single `~x~` pairs (needed for subscript), and Tinta was ignoring `MD_SPAN_DEL` anyway — strikethrough text rendered plain with the markers silently eaten. `~~text~~` now renders an actual strike line.
- Highlight draws a theme-aware marker background per wrapped segment; sup/sub use a 0.68× format (sub baseline-shifted down).
- Parser tests cover all four plus code-span immunity and CJK content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)