### PR TITLE
Table columns: auto-layout distribution with CJK-aware minimums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Fixed
 - Chinese/Japanese/Korean text now wraps correctly everywhere — line breaking uses the Unicode line breaking algorithm (via DirectWrite) instead of only breaking at spaces, so CJK paragraphs fill the line and break between ideographs with proper punctuation rules, long URLs break at slashes, and table cells wrap their content within the column instead of overflowing into neighbors (#24)
 - A single unbreakable run wider than the whole line now splits at glyph-cluster boundaries instead of being clipped at the window or cell edge (#24)
+- Table columns distribute like a browser's auto layout: narrow columns keep their natural width and only wide columns shrink — a three-character CJK header no longer collapses into a vertical strip while one huge cell hogs the row (#24)
+- Tables whose minimum column widths exceed the window width now participate in horizontal scrolling
 
 ## [v2.1.5] - 2026-07-14
 

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -1725,17 +1725,54 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
         }
     }
 
-    // Distribute widths: if total exceeds maxWidth, scale proportionally
+    // Distribute widths like a browser's auto table layout: columns whose
+    // natural width is under their fair share keep it untouched; only the
+    // wide columns shrink, splitting the remaining space proportionally.
+    // Pure proportional scaling starved narrow columns (a 3-character CJK
+    // header ended up one character wide) while a single huge cell hogged
+    // the row (#24).
     float totalWidth = 0;
     for (int c = 0; c < colCount; c++) totalWidth += colWidths[c];
 
     if (totalWidth > maxWidth) {
-        float ratio = maxWidth / totalWidth;
-        for (int c = 0; c < colCount; c++) {
-            colWidths[c] = std::max(minColWidth, colWidths[c] * ratio);
+        // Floor: at least ~2.5 CJK glyphs per line so no column degenerates
+        // into a vertical strip
+        float minCol = std::max(minColWidth, fontSize * 2.5f + cellPadding * 2);
+        std::vector<bool> fixed(colCount, false);
+        float available = maxWidth;
+        int unfixedCount = colCount;
+        bool changed = true;
+        while (changed && unfixedCount > 0) {
+            changed = false;
+            float fair = available / unfixedCount;
+            for (int c = 0; c < colCount; c++) {
+                if (!fixed[c] && colWidths[c] <= fair) {
+                    fixed[c] = true;
+                    available -= colWidths[c];
+                    unfixedCount--;
+                    changed = true;
+                }
+            }
+        }
+        if (unfixedCount > 0) {
+            float naturalSum = 0;
+            for (int c = 0; c < colCount; c++) {
+                if (!fixed[c]) naturalSum += colWidths[c];
+            }
+            for (int c = 0; c < colCount; c++) {
+                if (!fixed[c]) {
+                    float w = (naturalSum > 0.0f)
+                        ? available * (colWidths[c] / naturalSum)
+                        : available / unfixedCount;
+                    colWidths[c] = std::max(minCol, w);
+                }
+            }
         }
         totalWidth = 0;
         for (int c = 0; c < colCount; c++) totalWidth += colWidths[c];
+        // Minimum widths can push past maxWidth; the table then joins
+        // horizontal scrolling instead of squeezing columns unreadably
+        app.contentWidth = std::max(app.contentWidth, indent + totalWidth);
     }
 
     // Pass 1b: Measure row heights via layoutInlineContent with snapshot-rollback


### PR DESCRIPTION
Final piece of the #24 layout work. Proportional column scaling starved narrow columns (a 3-character CJK header rendered one character per line) while huge cells hogged the row.

- Columns whose natural width is under their fair share keep it; only wide columns shrink, splitting remaining space proportionally (iterative fair-share, same idea as browser auto table layout)
- Minimum column width fits ~2.5 CJK glyphs so no column becomes a vertical strip
- If minimums exceed the window width, the table feeds `contentWidth` and horizontal-scrolls instead of squeezing unreadably

Verified on the reporter's cn-test.md squeeze table: short columns single-line at natural width, long content wraps within borders, ordinary tables unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)