### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [v2.2.0] - 2026-07-15
 
 ### Added
 - Obsidian/Typora inline extensions: `==highlight==`, `^superscript^`, `~subscript~` (#24)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(tinta VERSION 2.1.5 LANGUAGES C CXX)
+project(tinta VERSION 2.2.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
CJK-first-class layout release: Unicode line breaking (#29), browser-style table columns (#30), Obsidian/Typora inline extensions + real strikethrough (#28). Closes the layout portion of #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)