### PR TITLE
Link the CRT statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ if(MSVC)
     add_compile_options(/W4)
     add_compile_options($<$<CONFIG:Release>:/O2>)
     add_compile_definitions(NOMINMAX _CRT_SECURE_NO_WARNINGS)
+    # Static CRT: the exe must run on clean Windows installs without the
+    # VC++ redistributable (costs ~250 KB, keeps the single-file promise)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
 # MD4C markdown parser


### PR DESCRIPTION
winget moderation ([microsoft/winget-pkgs#399137](https://github.com/microsoft/winget-pkgs/pull/399137)) caught that `tinta.exe` imports `VCRUNTIME140.dll`/`MSVCP140.dll` — missing on clean Windows installs, so first-run fails with a missing-DLL dialog unless the VC++ redistributable happens to be present.

This switches to the static CRT (`CMAKE_MSVC_RUNTIME_LIBRARY = MultiThreaded`):

- zero CRT imports — verified no `VCRUNTIME*`/`MSVCP*`/`api-ms-win-crt-*`/`ucrtbase` in the import table
- size: 573 KB → 821 KB (+248 KB), still under 1 MB
- ctest green, launch-verified against the demo document
- lets us drop the `Microsoft.VCRedist.2015+.x64` winget dependency for releases from this commit on, and unblocks the PortableApps requirement