### PR TITLE
CI: auto-publish releases to the Microsoft Store

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,3 +54,60 @@ jobs:
           files: build/Release/tinta.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Publishes the release to the Microsoft Store (app 9MZ5MZ3L9RKF).
+  # Skips itself until the MSSTORE_* secrets are configured — see packaging/msix/README notes.
+  store:
+    runs-on: windows-latest
+    needs: build
+    env:
+      MSSTORE_TENANT_ID: ${{ secrets.MSSTORE_TENANT_ID }}
+      MSSTORE_SELLER_ID: ${{ secrets.MSSTORE_SELLER_ID }}
+      MSSTORE_CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
+      MSSTORE_CLIENT_SECRET: ${{ secrets.MSSTORE_CLIENT_SECRET }}
+
+    steps:
+      - name: Check Store credentials
+        id: gate
+        shell: bash
+        run: |
+          if [ -n "$MSSTORE_CLIENT_SECRET" ]; then
+            echo "on=true" >> $GITHUB_OUTPUT
+          else
+            echo "on=false" >> $GITHUB_OUTPUT
+            echo "MSSTORE_* secrets not set - skipping Store publish."
+          fi
+
+      - name: Checkout code
+        if: steps.gate.outputs.on == 'true'
+        uses: actions/checkout@v4
+
+      - name: Download release asset
+        if: steps.gate.outputs.on == 'true'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force build\Release | Out-Null
+          gh release download $env:GITHUB_REF_NAME --pattern tinta.exe --output build\Release\tinta.exe --repo $env:GITHUB_REPOSITORY
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pack MSIX
+        if: steps.gate.outputs.on == 'true'
+        shell: pwsh
+        run: pwsh -File packaging/msix/pack.ps1 -ExePath build/Release/tinta.exe
+
+      - name: Setup Microsoft Store CLI
+        if: steps.gate.outputs.on == 'true'
+        uses: microsoft/setup-msstore-cli@v1
+
+      - name: Configure Store CLI
+        if: steps.gate.outputs.on == 'true'
+        shell: pwsh
+        run: msstore reconfigure --tenantId $env:MSSTORE_TENANT_ID --sellerId $env:MSSTORE_SELLER_ID --clientId $env:MSSTORE_CLIENT_ID --clientSecret $env:MSSTORE_CLIENT_SECRET
+
+      - name: Publish to Microsoft Store
+        if: steps.gate.outputs.on == 'true'
+        shell: pwsh
+        run: |
+          $msix = Get-ChildItem packaging/msix/out/tinta-*.msix | Select-Object -First 1
+          msstore publish $msix.FullName --appId 9MZ5MZ3L9RKF

--- a/packaging/msix/README.md
+++ b/packaging/msix/README.md
@@ -1,0 +1,58 @@
+# MSIX packaging & Microsoft Store publishing
+
+Tinta ships on the Microsoft Store as **Tinta Markdown Viewer**
+([`9MZ5MZ3L9RKF`](https://apps.microsoft.com/detail/9MZ5MZ3L9RKF)).
+
+## Build the package locally
+
+```pwsh
+pwsh packaging/msix/pack.ps1 -ExePath build/Release/tinta.exe
+```
+
+Stamps the version from `CMakeLists.txt` (`x.y.z` → `x.y.z.0`), builds
+`resources.pri`, and packs an **unsigned** MSIX — the Store signs submitted
+packages, so no certificate is needed.
+
+## Automatic Store publishing (CI)
+
+The `store` job in `.github/workflows/build.yml` runs on every `v*` tag after
+the GitHub release is created. It repacks the exact released `tinta.exe` into
+an MSIX and submits it with [msstore-cli](https://github.com/microsoft/msstore-cli).
+The Store then certifies and publishes automatically; Store installs
+auto-update on users' machines.
+
+The job **skips itself** unless these repository secrets are set:
+
+| Secret | Value |
+|---|---|
+| `MSSTORE_TENANT_ID` | Entra (Azure AD) tenant ID associated with the Partner Center account |
+| `MSSTORE_SELLER_ID` | Partner Center seller ID (Account settings → Organization profile) |
+| `MSSTORE_CLIENT_ID` | App registration (client) ID |
+| `MSSTORE_CLIENT_SECRET` | Client secret for that app registration |
+
+One-time setup: associate an Entra tenant with Partner Center
+(Account settings → Tenants), create an Azure AD application under
+Account settings → User management → Azure AD applications with the
+**Manager (Windows)** role, create a client secret for it, then:
+
+```pwsh
+gh secret set MSSTORE_TENANT_ID
+gh secret set MSSTORE_SELLER_ID
+gh secret set MSSTORE_CLIENT_ID
+gh secret set MSSTORE_CLIENT_SECRET
+```
+
+Running `msstore reconfigure` locally walks through the same setup
+interactively and can create the Entra application for you.
+
+Note: the Store requires each submission's package version to be greater than
+the last published one, so the job only succeeds for new version tags.
+
+## Files
+
+- `AppxManifest.xml` — package identity, full-trust entry point, declared
+  `.md`/`.markdown`/`.mmd` file-type associations. `TINTA_MSIX_VERSION` is
+  replaced by `pack.ps1`.
+- `Assets/` — Store logos generated from `resources/tinta.ico`.
+- Store listing art (marketing screenshots, poster/box art) is managed in
+  Partner Center; sources live outside this repo.


### PR DESCRIPTION
Adds a `store` job to the release workflow: after the GitHub release is created it downloads the exact released `tinta.exe`, packs it into an MSIX with `packaging/msix/pack.ps1`, and submits it to the Store (app `9MZ5MZ3L9RKF`) with [msstore-cli](https://github.com/microsoft/msstore-cli).

- Gated on the `MSSTORE_*` repository secrets — until they exist the job logs a notice and skips, so releases are unaffected
- Uses the release asset rather than rebuilding, so the Store package is byte-identical to the GitHub download
- Setup (Entra app + secrets) documented in `packaging/msix/README.md`

With secrets configured, `git tag vX.Y.Z && git push --tags` updates GitHub, scoop (Excavator), and the Microsoft Store in one motion.