### PR TITLE
Folder browser: fix long-name overflow with ellipsis trimming (#39)

### DIFF
--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -209,6 +209,18 @@ void updateOverlayFormats(App& app) {
     app.dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr,
         DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
         13.0f * scale, L"en-us", &app.folderBrowserFormat);
+    if (app.folderBrowserFormat) {
+        // Entries render on fixed-height rows: wrapping would overlap the next
+        // row, so keep everything single-line and trim with an ellipsis
+        app.folderBrowserFormat->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);
+        DWRITE_TRIMMING trimming = { DWRITE_TRIMMING_GRANULARITY_CHARACTER, 0, 0 };
+        IDWriteInlineObject* ellipsis = nullptr;
+        app.dwriteFactory->CreateEllipsisTrimmingSign(app.folderBrowserFormat, &ellipsis);
+        if (ellipsis) {
+            app.folderBrowserFormat->SetTrimming(&trimming, ellipsis);
+            ellipsis->Release();
+        }
+    }
 
     // TOC formats
     app.dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr,

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -176,23 +176,35 @@ void renderFolderBrowser(App& app) {
         headerColor.a = anim;
         app.brush->SetColor(headerColor);
 
-        // Truncate path if too long
+        // Truncate path if too long, keeping the tail (leaf folder) visible:
+        // measure with the actual font instead of estimating character widths,
+        // which breaks down for CJK and other wide scripts
         std::wstring displayPath = app.folderBrowserPath;
         float maxPathWidth = panelWidth - padding * 2;
 
-        // Truncation: estimate max chars from average char width, then measure once
-        if (!displayPath.empty()) {
-            float avgCharWidth = browserFormat->GetFontSize() * 0.55f;
-            size_t maxChars = (size_t)(maxPathWidth / avgCharWidth);
-            if (displayPath.length() > maxChars && maxChars > 6) {
-                // Find a separator near the truncation point for clean breaks
-                size_t keepLen = maxChars - 3;  // room for "..."
-                size_t sepPos = displayPath.rfind(L'\\', displayPath.length() - keepLen);
-                if (sepPos != std::wstring::npos && sepPos > 3) {
-                    displayPath = L"..." + displayPath.substr(sepPos);
-                } else {
-                    displayPath = L"..." + displayPath.substr(displayPath.length() - keepLen);
+        if (!displayPath.empty() && app.dwriteFactory) {
+            auto textWidth = [&](const std::wstring& s) {
+                float w = 0.0f;
+                IDWriteTextLayout* layout = nullptr;
+                if (SUCCEEDED(app.dwriteFactory->CreateTextLayout(
+                        s.c_str(), (UINT32)s.length(), browserFormat,
+                        1000000.0f, headerHeight, &layout)) && layout) {
+                    DWRITE_TEXT_METRICS metrics;
+                    if (SUCCEEDED(layout->GetMetrics(&metrics))) {
+                        w = metrics.widthIncludingTrailingWhitespace;
+                    }
+                    layout->Release();
                 }
+                return w;
+            };
+            if (textWidth(displayPath) > maxPathWidth) {
+                std::wstring tail = displayPath;
+                while (textWidth(L"..." + tail) > maxPathWidth) {
+                    size_t sep = tail.find(L'\\', 1);
+                    if (sep == std::wstring::npos) break;  // one long component: ellipsis trimming cuts it
+                    tail = tail.substr(sep);
+                }
+                displayPath = L"..." + tail;
             }
         }
 


### PR DESCRIPTION
Fixes the first half of #39.

- Long entry names word-wrapped inside their fixed 28px rows and painted over the following entries. `folderBrowserFormat` now sets `DWRITE_WORD_WRAPPING_NO_WRAP` plus an ellipsis trimming sign, so every entry stays on one line and trims with `…`.
- The path header estimated width as `fontSize × 0.55` per char — wrong for CJK/wide scripts. It now measures with an actual `IDWriteTextLayout` and drops leading path components until the tail fits, so the leaf folder stays visible.

Verified against a folder with 100+ char ASCII and CJK names: entries render single-line with ellipses, header shows `...\tail`, no overlap. ctest green.

The menu-bar half of #39 is deliberately not addressed here — under evaluation.