### PR TITLE
Render GitHub alerts (> [!NOTE] etc.) as styled callouts (#41)

### DIFF
--- a/include/markdown.h
+++ b/include/markdown.h
@@ -59,6 +59,8 @@ struct Element {
     std::string language;     // for code blocks
     int align = 0;            // for table cells (0=default, 1=left, 2=center, 3=right)
     int col_count = 0;        // for tables (number of columns)
+    int alertKind = 0;        // for blockquotes: GitHub alert (0=none, 1=note, 2=tip,
+                              // 3=important, 4=warning, 5=caution)
 
     size_t sourceOffset = SIZE_MAX; // byte offset in original markdown source
 

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -377,6 +377,48 @@ static ElementPtr makeTextElement(std::string text, Element* parent) {
     return node;
 }
 
+// GitHub alerts: a blockquote whose first line is exactly [!NOTE], [!TIP],
+// [!IMPORTANT], [!WARNING] or [!CAUTION] renders as a styled callout.
+// The marker must be alone on its line, matching github.com behavior.
+static void detectGitHubAlerts(const ElementPtr& parent) {
+    static const char* MARKERS[] = {"[!note]", "[!tip]", "[!important]", "[!warning]", "[!caution]"};
+
+    for (auto& child : parent->children) {
+        detectGitHubAlerts(child);
+    }
+
+    if (parent->type != ElementType::BlockQuote || parent->children.empty()) return;
+    const ElementPtr& para = parent->children.front();
+    if (para->type != ElementType::Paragraph || para->children.empty()) return;
+    const ElementPtr& first = para->children.front();
+    if (first->type != ElementType::Text) return;
+
+    std::string marker = first->text;
+    while (!marker.empty() && (marker.back() == ' ' || marker.back() == '\t')) marker.pop_back();
+    for (auto& c : marker) c = (char)tolower((unsigned char)c);
+
+    int kind = 0;
+    for (int i = 0; i < 5; i++) {
+        if (marker == MARKERS[i]) { kind = i + 1; break; }
+    }
+    if (kind == 0) return;
+
+    // Marker must be the whole first line: alone in the paragraph, or
+    // followed by a line break
+    if (para->children.size() > 1 &&
+        para->children[1]->type != ElementType::SoftBreak &&
+        para->children[1]->type != ElementType::HardBreak) {
+        return;
+    }
+
+    parent->alertKind = kind;
+    size_t remove = std::min<size_t>(2, para->children.size());  // marker text + line break
+    para->children.erase(para->children.begin(), para->children.begin() + remove);
+    if (para->children.empty()) {
+        parent->children.erase(parent->children.begin());
+    }
+}
+
 static void splitInlineExtensions(const ElementPtr& parent) {
     if (parent->type == ElementType::Code ||
         parent->type == ElementType::CodeBlock ||
@@ -472,6 +514,7 @@ ParseResult MarkdownParser::parse(const std::string& markdown) {
 
     ctx.flushText();
     splitInlineExtensions(ctx.root);
+    detectGitHubAlerts(ctx.root);
     result.root = ctx.root;
     result.success = true;
     return result;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -1450,12 +1450,43 @@ static void layoutBlockquote(App& app, const ElementPtr& elem, float& y, float i
     float quoteIndent = 20.0f * scale;
     float startY = y;
 
+    // GitHub alert callouts: accent-colored bar plus a bold title line.
+    // Colors are github.com's light/dark alert accents, picked by theme.
+    static const struct {
+        const wchar_t* title;
+        uint32_t light;
+        uint32_t dark;
+    } ALERT_STYLES[] = {
+        {L"\u24D8  Note",            0x0969DA, 0x4493F8},  // circled info
+        {L"\U0001F4A1\uFE0E  Tip",   0x1A7F37, 0x3FB950},  // bulb, text presentation
+        {L"\u2757\uFE0E  Important", 0x8250DF, 0xAB7DF8},  // exclamation
+        {L"\u26A0\uFE0E  Warning",   0x9A6700, 0xD29922},  // warning triangle
+        {L"\u26D4\uFE0E  Caution",   0xCF222E, 0xF85149},  // no-entry
+    };
+
+    D2D1_COLOR_F barColor = app.theme.blockquoteBorder;
+    if (elem->alertKind >= 1 && elem->alertKind <= 5) {
+        const auto& style = ALERT_STYLES[elem->alertKind - 1];
+        barColor = hexColor(app.theme.isDark ? style.dark : style.light);
+
+        std::wstring title = style.title;
+        LayoutInfo info = createLayout(app, title, app.textFormat, 24.0f, app.bodyTypography);
+        if (info.layout) {
+            DWRITE_TEXT_RANGE range = {0, (UINT32)title.length()};
+            info.layout->SetFontWeight(DWRITE_FONT_WEIGHT_SEMI_BOLD, range);
+        }
+        D2D1_POINT_2F pos = D2D1::Point2F(indent + quoteIndent, y);
+        D2D1_RECT_F bounds = D2D1::RectF(indent + quoteIndent, y,
+                                         indent + maxWidth, y + 24 * scale);
+        addTextRun(app, std::move(info), pos, bounds, barColor, 0, 0, false);
+        y += 30 * scale;
+    }
+
     for (const auto& child : elem->children) {
         layoutElement(app, child, y, indent + quoteIndent, maxWidth - quoteIndent);
     }
 
-    app.layoutRects.push_back({D2D1::RectF(indent, startY, indent + 4, y),
-                               app.theme.blockquoteBorder});
+    app.layoutRects.push_back({D2D1::RectF(indent, startY, indent + 4, y), barColor});
 }
 
 static void layoutList(App& app, const ElementPtr& elem, float& y, float indent, float maxWidth) {

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -74,6 +74,27 @@ int main() {
         check(codeIntact == 1, "inline code untouched");
     }
 
+    // GitHub alerts
+    auto alert = parseDocument(parser, "> [!NOTE]\n> Body text here.\n", "notes.md");
+    check(alert.success, "alert blockquote parses");
+    if (alert.success && !alert.root->children.empty()) {
+        const auto& quote = alert.root->children[0];
+        check(quote->type == qmd::ElementType::BlockQuote, "alert stays a blockquote");
+        check(quote->alertKind == 1, "[!NOTE] detected as alert kind 1");
+        check(!quote->children.empty() &&
+              !quote->children[0]->children.empty() &&
+              quote->children[0]->children[0]->text == "Body text here.",
+              "alert marker stripped, body preserved");
+    }
+    auto caution = parseDocument(parser, "> [!caution]\n> Careful.\n", "notes.md");
+    check(caution.success && !caution.root->children.empty() &&
+          caution.root->children[0]->alertKind == 5,
+          "alert markers match case-insensitively");
+    auto notAlert = parseDocument(parser, "> [!NOTE] trailing words\n", "notes.md");
+    check(notAlert.success && !notAlert.root->children.empty() &&
+          notAlert.root->children[0]->alertKind == 0,
+          "marker with trailing text on the same line stays a plain quote");
+
     auto markdown = parseDocument(parser, "# Heading\n", "notes.md");
     check(markdown.success, "Markdown document still parses");
     check(markdown.root && !markdown.root->children.empty() &&


### PR DESCRIPTION
Implements GitHub's [alerts syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) reported missing in #41.

- **Parser** (markdown.cpp): post-parse pass tags a `BlockQuote` whose first line is exactly one of the five markers (case-insensitive, alone on its line — same strictness as github.com) and strips the marker from the tree.
- **Renderer** (render.cpp): tagged quotes draw an accent-colored bar and a semibold icon + title line. Colors are github.com's own alert accents with light/dark variants selected by `theme.isDark`, so all 10 themes get sensible contrast.
- Marker + trailing text on the same line intentionally stays a plain blockquote (matches GitHub).
- Tests: detection, marker stripping, case-insensitivity, false-positive guard. ctest green.

Verified empirically against all five alert kinds in Midnight (dark) and Paper (light) themes.