### PR TITLE
Inline <br> renders as a hard line break (#45)

### DIFF
--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -252,6 +252,16 @@ static int leaveSpanCallback(MD_SPANTYPE type, void* /*detail*/, void* userdata)
     return 0;
 }
 
+// Matches <br>, <br/>, <br /> etc., case-insensitively
+static bool isBrTag(const MD_CHAR* text, MD_SIZE size) {
+    if (size < 4 || text[0] != '<' || text[size - 1] != '>') return false;
+    std::string norm;
+    for (MD_SIZE i = 0; i < size; i++) {
+        if (!isspace((unsigned char)text[i])) norm += (char)tolower((unsigned char)text[i]);
+    }
+    return norm == "<br>" || norm == "<br/>";
+}
+
 static int textCallback(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata) {
     auto* ctx = static_cast<ParserContext*>(userdata);
 
@@ -261,9 +271,21 @@ static int textCallback(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, voi
     }
 
     switch (type) {
+        case MD_TEXT_HTML:  // Capture HTML content
+            // Inline <br> becomes a hard line break (#45); raw HTML inside an
+            // HtmlBlock keeps accumulating so parseHtmlIntoElements sees it all
+            if (ctx->current() && ctx->current()->type != ElementType::HtmlBlock &&
+                isBrTag(text, size)) {
+                ctx->flushText();
+                auto elem = std::make_shared<Element>(ElementType::HardBreak);
+                elem->parent = ctx->current();
+                ctx->current()->children.push_back(elem);
+                break;
+            }
+            ctx->addText(text, size);
+            break;
         case MD_TEXT_NORMAL:
         case MD_TEXT_CODE:
-        case MD_TEXT_HTML:  // Capture HTML content
             ctx->addText(text, size);
             break;
 

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -95,6 +95,21 @@ int main() {
           notAlert.root->children[0]->alertKind == 0,
           "marker with trailing text on the same line stays a plain quote");
 
+    // Inline <br> becomes a hard break (#45)
+    auto br = parseDocument(parser, "line one<br>line two<BR/>line three<br />end\n", "notes.md");
+    check(br.success, "inline br document parses");
+    if (br.success && !br.root->children.empty()) {
+        int hardBreaks = 0;
+        int literalBr = 0;
+        for (const auto& child : br.root->children[0]->children) {
+            if (child->type == qmd::ElementType::HardBreak) hardBreaks++;
+            if (child->type == qmd::ElementType::Text &&
+                child->text.find("<br") != std::string::npos) literalBr++;
+        }
+        check(hardBreaks == 3, "all three <br> variants become hard breaks");
+        check(literalBr == 0, "no literal <br> text remains");
+    }
+
     auto markdown = parseDocument(parser, "# Heading\n", "notes.md");
     check(markdown.success, "Markdown document still parses");
     check(markdown.root && !markdown.root->children.empty() &&


### PR DESCRIPTION
Fixes #45. Inline HTML (`MD_TEXT_HTML`) was captured as literal text, so `<br>` in a paragraph or table cell printed verbatim. The text callback now recognizes `<br>`/`<br/>`/`<br />` (case-insensitive) and emits the same `HardBreak` element as a two-space markdown line break. HTML-block content is deliberately untouched — `parseHtmlIntoElements` already handled `br` there.

Verified in-app: paragraph breaks for all three variants, `<br>` inside a table cell wraps within the cell, code spans keep the literal text. Parser tests added; ctest green.