### PR TITLE
Load remote images on a worker thread (#44)

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -75,6 +75,65 @@ struct D2DTheme {
 };
 
 // Helper to create color from hex
+// TEMP perf instrumentation for issue #44 — remove before release
+#include <cstdio>
+inline void tintaPerfLog(const char* what, double ms) {
+    static FILE* perfFile = nullptr;
+    if (!perfFile) {
+        char path[MAX_PATH];
+        GetTempPathA(MAX_PATH, path);
+        strcat_s(path, "tinta-perf.log");
+        fopen_s(&perfFile, path, "a");
+    }
+    if (perfFile) { fprintf(perfFile, "%s: %.1f ms\n", what, ms); fflush(perfFile); }
+}
+inline double g_perfAnalyzeMs = 0; inline int g_perfAnalyzeN = 0;
+inline double g_perfInlineMs = 0;  inline int g_perfInlineN = 0;
+inline double g_perfCreateMs = 0;  inline int g_perfCreateN = 0;
+inline double g_perfTableMs = 0;   inline int g_perfTableN = 0;
+inline double g_perfSetupMs = 0;   inline int g_perfSetupN = 0;
+inline double g_perfLoopMs = 0;    inline int g_perfLoopN = 0;
+inline double g_perfMermaidMs = 0; inline int g_perfMermaidN = 0;
+struct TintaPerfAccum {
+    double* acc; int* n; LARGE_INTEGER t0;
+    TintaPerfAccum(double* a, int* c) : acc(a), n(c) { QueryPerformanceCounter(&t0); }
+    ~TintaPerfAccum() {
+        LARGE_INTEGER t1, f;
+        QueryPerformanceCounter(&t1); QueryPerformanceFrequency(&f);
+        *acc += (t1.QuadPart - t0.QuadPart) * 1000.0 / f.QuadPart;
+        (*n)++;
+    }
+};
+inline void tintaPerfDump(const char* tag) {
+    char buf[512];
+    snprintf(buf, sizeof(buf),
+        "%s breakdown: analyze %d/%.0fms | inline %d/%.0fms | createLayout %d/%.0fms | table %d/%.0fms | setup %d/%.0fms | loop %d/%.0fms | mermaid %d/%.0fms",
+        tag, g_perfAnalyzeN, g_perfAnalyzeMs, g_perfInlineN, g_perfInlineMs,
+        g_perfCreateN, g_perfCreateMs, g_perfTableN, g_perfTableMs,
+        g_perfSetupN, g_perfSetupMs, g_perfLoopN, g_perfLoopMs,
+        g_perfMermaidN, g_perfMermaidMs);
+    tintaPerfLog(buf, 0.0);
+    g_perfAnalyzeMs = g_perfInlineMs = g_perfCreateMs = g_perfTableMs = 0;
+    g_perfAnalyzeN = g_perfInlineN = g_perfCreateN = g_perfTableN = 0;
+    g_perfSetupMs = g_perfLoopMs = g_perfMermaidMs = 0;
+    g_perfSetupN = g_perfLoopN = g_perfMermaidN = 0;
+}
+struct TintaPerfTimer {
+    const char* name;
+    double threshold;
+    LARGE_INTEGER t0;
+    TintaPerfTimer(const char* n, double thresholdMs = 20.0) : name(n), threshold(thresholdMs) {
+        QueryPerformanceCounter(&t0);
+    }
+    ~TintaPerfTimer() {
+        LARGE_INTEGER t1, f;
+        QueryPerformanceCounter(&t1);
+        QueryPerformanceFrequency(&f);
+        double ms = (t1.QuadPart - t0.QuadPart) * 1000.0 / f.QuadPart;
+        if (ms >= threshold) tintaPerfLog(name, ms);
+    }
+};
+
 inline D2D1_COLOR_F hexColor(uint32_t hex, float alpha = 1.0f) {
     return D2D1::ColorF(
         ((hex >> 16) & 0xFF) / 255.0f,

--- a/include/app.h
+++ b/include/app.h
@@ -79,65 +79,6 @@ struct D2DTheme {
 };
 
 // Helper to create color from hex
-// TEMP perf instrumentation for issue #44 — remove before release
-#include <cstdio>
-inline void tintaPerfLog(const char* what, double ms) {
-    static FILE* perfFile = nullptr;
-    if (!perfFile) {
-        char path[MAX_PATH];
-        GetTempPathA(MAX_PATH, path);
-        strcat_s(path, "tinta-perf.log");
-        fopen_s(&perfFile, path, "a");
-    }
-    if (perfFile) { fprintf(perfFile, "%s: %.1f ms\n", what, ms); fflush(perfFile); }
-}
-inline double g_perfAnalyzeMs = 0; inline int g_perfAnalyzeN = 0;
-inline double g_perfInlineMs = 0;  inline int g_perfInlineN = 0;
-inline double g_perfCreateMs = 0;  inline int g_perfCreateN = 0;
-inline double g_perfTableMs = 0;   inline int g_perfTableN = 0;
-inline double g_perfSetupMs = 0;   inline int g_perfSetupN = 0;
-inline double g_perfLoopMs = 0;    inline int g_perfLoopN = 0;
-inline double g_perfMermaidMs = 0; inline int g_perfMermaidN = 0;
-struct TintaPerfAccum {
-    double* acc; int* n; LARGE_INTEGER t0;
-    TintaPerfAccum(double* a, int* c) : acc(a), n(c) { QueryPerformanceCounter(&t0); }
-    ~TintaPerfAccum() {
-        LARGE_INTEGER t1, f;
-        QueryPerformanceCounter(&t1); QueryPerformanceFrequency(&f);
-        *acc += (t1.QuadPart - t0.QuadPart) * 1000.0 / f.QuadPart;
-        (*n)++;
-    }
-};
-inline void tintaPerfDump(const char* tag) {
-    char buf[512];
-    snprintf(buf, sizeof(buf),
-        "%s breakdown: analyze %d/%.0fms | inline %d/%.0fms | createLayout %d/%.0fms | table %d/%.0fms | setup %d/%.0fms | loop %d/%.0fms | mermaid %d/%.0fms",
-        tag, g_perfAnalyzeN, g_perfAnalyzeMs, g_perfInlineN, g_perfInlineMs,
-        g_perfCreateN, g_perfCreateMs, g_perfTableN, g_perfTableMs,
-        g_perfSetupN, g_perfSetupMs, g_perfLoopN, g_perfLoopMs,
-        g_perfMermaidN, g_perfMermaidMs);
-    tintaPerfLog(buf, 0.0);
-    g_perfAnalyzeMs = g_perfInlineMs = g_perfCreateMs = g_perfTableMs = 0;
-    g_perfAnalyzeN = g_perfInlineN = g_perfCreateN = g_perfTableN = 0;
-    g_perfSetupMs = g_perfLoopMs = g_perfMermaidMs = 0;
-    g_perfSetupN = g_perfLoopN = g_perfMermaidN = 0;
-}
-struct TintaPerfTimer {
-    const char* name;
-    double threshold;
-    LARGE_INTEGER t0;
-    TintaPerfTimer(const char* n, double thresholdMs = 20.0) : name(n), threshold(thresholdMs) {
-        QueryPerformanceCounter(&t0);
-    }
-    ~TintaPerfTimer() {
-        LARGE_INTEGER t1, f;
-        QueryPerformanceCounter(&t1);
-        QueryPerformanceFrequency(&f);
-        double ms = (t1.QuadPart - t0.QuadPart) * 1000.0 / f.QuadPart;
-        if (ms >= threshold) tintaPerfLog(name, ms);
-    }
-};
-
 inline D2D1_COLOR_F hexColor(uint32_t hex, float alpha = 1.0f) {
     return D2D1::ColorF(
         ((hex >> 16) & 0xFF) / 255.0f,

--- a/include/app.h
+++ b/include/app.h
@@ -35,6 +35,10 @@ inline int64_t usElapsed(Clock::time_point start) {
 // Posted to continue an incomplete document layout in time-budgeted chunks
 #define WM_APP_LAYOUT_CHUNK (WM_APP + 1)
 
+// Posted by an image download worker thread when a remote image finished
+// loading (lParam = AsyncImageResult*, ownership transfers to the handler)
+#define WM_APP_IMAGE_READY (WM_APP + 2)
+
 // Startup metrics
 struct StartupMetrics {
     int64_t windowInitUs = 0;
@@ -191,6 +195,7 @@ struct App {
         int width = 0;
         int height = 0;
         bool failed = false;
+        bool pending = false;  // remote image download in flight
     };
     std::unordered_map<std::string, ImageEntry> imageCache;
 

--- a/include/render.h
+++ b/include/render.h
@@ -17,4 +17,8 @@ bool layoutDocumentContinue(App& app, int64_t budgetUs);
 // Synchronously finishes any incomplete/dirty layout (search, TOC, End key)
 void ensureLayoutComplete(App& app);
 
+// UI-thread completion for WM_APP_IMAGE_READY: takes ownership of the
+// AsyncImageResult, updates the image cache, and triggers a reflow
+void completeAsyncImage(App& app, void* asyncResult);
+
 #endif // TINTA_RENDER_H

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -34,7 +34,6 @@ void render(App& app);
 
 void render(App& app) {
     if (!app.renderTarget) return;
-    TintaPerfTimer _perf("render", 20.0);
 
     app.renderTarget->BeginDraw();
     app.drawCalls = 0;
@@ -818,10 +817,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         }
 
         case WM_MOUSEWHEEL:
-            if (app) {
-                TintaPerfTimer _perf("wheel", 20.0);
-                handleMouseWheel(*app, hwnd, wParam, lParam);
-            }
+            if (app) handleMouseWheel(*app, hwnd, wParam, lParam);
             return 0;
 
         case WM_MOUSEHWHEEL:
@@ -906,12 +902,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             // Continue an incomplete document layout in ~10ms slices, yielding
             // to input between slices
             if (app && !app->layoutDirty && !app->layoutComplete) {
-                bool done;
-                {
-                    TintaPerfTimer _perf("layoutChunk", 30.0);
-                    done = layoutDocumentContinue(*app, 10000);
-                }
-                tintaPerfDump("chunk");
+                bool done = layoutDocumentContinue(*app, 10000);
                 InvalidateRect(hwnd, nullptr, FALSE);  // scrollbar grows as layout fills in
                 if (!done) PostMessage(hwnd, WM_APP_LAYOUT_CHUNK, 0, 0);
             }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -896,6 +896,12 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             }
             return 0;
 
+        case WM_APP_IMAGE_READY:
+            // A background image download finished: swap it into the cache
+            // and reflow (handler takes ownership of the result)
+            if (app) completeAsyncImage(*app, (void*)lParam);
+            return 0;
+
         case WM_APP_LAYOUT_CHUNK:
             // Continue an incomplete document layout in ~10ms slices, yielding
             // to input between slices

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -34,6 +34,7 @@ void render(App& app);
 
 void render(App& app) {
     if (!app.renderTarget) return;
+    TintaPerfTimer _perf("render", 20.0);
 
     app.renderTarget->BeginDraw();
     app.drawCalls = 0;
@@ -817,7 +818,10 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         }
 
         case WM_MOUSEWHEEL:
-            if (app) handleMouseWheel(*app, hwnd, wParam, lParam);
+            if (app) {
+                TintaPerfTimer _perf("wheel", 20.0);
+                handleMouseWheel(*app, hwnd, wParam, lParam);
+            }
             return 0;
 
         case WM_MOUSEHWHEEL:
@@ -896,7 +900,12 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             // Continue an incomplete document layout in ~10ms slices, yielding
             // to input between slices
             if (app && !app->layoutDirty && !app->layoutComplete) {
-                bool done = layoutDocumentContinue(*app, 10000);
+                bool done;
+                {
+                    TintaPerfTimer _perf("layoutChunk", 30.0);
+                    done = layoutDocumentContinue(*app, 10000);
+                }
+                tintaPerfDump("chunk");
                 InvalidateRect(hwnd, nullptr, FALSE);  // scrollbar grows as layout fills in
                 if (!done) PostMessage(hwnd, WM_APP_LAYOUT_CHUNK, 0, 0);
             }

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -12,6 +12,7 @@
 #include <string_view>
 #include <filesystem>
 #include <urlmon.h>
+#include <thread>
 #pragma comment(lib, "urlmon.lib")
 
 namespace {
@@ -1558,6 +1559,68 @@ static void layoutList(App& app, const ElementPtr& elem, float& y, float indent,
     y += 8 * scale;
 }
 
+// Result of a background image download+decode, handed to the UI thread
+// via WM_APP_IMAGE_READY. Pixels are premultiplied BGRA.
+struct AsyncImageResult {
+    std::string src;
+    UINT width = 0;
+    UINT height = 0;
+    std::vector<uint8_t> pixels;
+    bool ok = false;
+};
+
+// Runs on a worker thread: blocking download + WIC decode never touch the
+// UI thread, so dead links can't stall layout (#44). The worker owns its own
+// COM apartment and WIC factory; only plain pixel bytes cross the thread
+// boundary.
+static void asyncImageWorker(HWND hwnd, std::string src) {
+    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    auto* result = new AsyncImageResult();
+    result->src = src;
+
+    wchar_t tempPath[MAX_PATH] = {};
+    std::wstring wideSrc = toWide(src);
+    if (SUCCEEDED(URLDownloadToCacheFileW(nullptr, wideSrc.c_str(), tempPath, MAX_PATH, 0, nullptr))) {
+        IWICImagingFactory* wic = nullptr;
+        if (SUCCEEDED(CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+                                       IID_PPV_ARGS(&wic))) && wic) {
+            IWICBitmapDecoder* decoder = nullptr;
+            if (SUCCEEDED(wic->CreateDecoderFromFilename(tempPath, nullptr, GENERIC_READ,
+                                                         WICDecodeMetadataCacheOnDemand, &decoder)) && decoder) {
+                IWICBitmapFrameDecode* frame = nullptr;
+                if (SUCCEEDED(decoder->GetFrame(0, &frame)) && frame) {
+                    IWICFormatConverter* converter = nullptr;
+                    if (SUCCEEDED(wic->CreateFormatConverter(&converter)) && converter) {
+                        if (SUCCEEDED(converter->Initialize(frame, GUID_WICPixelFormat32bppPBGRA,
+                                WICBitmapDitherTypeNone, nullptr, 0.0, WICBitmapPaletteTypeCustom))) {
+                            UINT w = 0, h = 0;
+                            converter->GetSize(&w, &h);
+                            if (w > 0 && h > 0 && w < 16384 && h < 16384) {
+                                result->pixels.resize((size_t)w * h * 4);
+                                if (SUCCEEDED(converter->CopyPixels(nullptr, w * 4,
+                                        (UINT)result->pixels.size(), result->pixels.data()))) {
+                                    result->width = w;
+                                    result->height = h;
+                                    result->ok = true;
+                                }
+                            }
+                        }
+                        converter->Release();
+                    }
+                    frame->Release();
+                }
+                decoder->Release();
+            }
+            wic->Release();
+        }
+    }
+
+    if (!PostMessageW(hwnd, WM_APP_IMAGE_READY, 0, (LPARAM)result)) {
+        delete result;  // window already gone
+    }
+    CoUninitialize();
+}
+
 static App::ImageEntry& getOrLoadImage(App& app, const std::string& src) {
     auto it = app.imageCache.find(src);
     if (it != app.imageCache.end()) return it->second;
@@ -1572,18 +1635,15 @@ static App::ImageEntry& getOrLoadImage(App& app, const std::string& src) {
 
     std::wstring widePath;
 
-    // Check if URL
+    // Remote images load on a worker thread — a synchronous download here
+    // stalled layout for seconds per unreachable URL (#44)
     bool isUrl = (src.rfind("http://", 0) == 0 || src.rfind("https://", 0) == 0);
     if (isUrl) {
-        // Download to temp file
-        wchar_t tempPath[MAX_PATH] = {};
-        std::wstring wideSrc = toWide(src);
-        HRESULT hr = URLDownloadToCacheFileW(nullptr, wideSrc.c_str(), tempPath, MAX_PATH, 0, nullptr);
-        if (FAILED(hr)) {
-            app.imageCache[src] = entry;
-            return app.imageCache[src];
-        }
-        widePath = tempPath;
+        entry.failed = false;
+        entry.pending = true;
+        app.imageCache[src] = entry;
+        std::thread(asyncImageWorker, app.hwnd, src).detach();
+        return app.imageCache[src];
     } else {
         // Resolve relative to current file's directory
         std::wstring wsrc = toWide(src);
@@ -2155,6 +2215,38 @@ bool layoutDocumentContinue(App& app, int64_t budgetUs) {
     if (done) layoutFinish(app);
     app.layoutTimeUs += (size_t)usElapsed(t0);
     return done;
+}
+
+void completeAsyncImage(App& app, void* asyncResult) {
+    auto* result = static_cast<AsyncImageResult*>(asyncResult);
+    if (!result) return;
+
+    App::ImageEntry entry;
+    entry.failed = true;
+    if (result->ok && app.renderTarget) {
+        D2D1_BITMAP_PROPERTIES props = D2D1::BitmapProperties(
+            D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED));
+        ID2D1Bitmap* bitmap = nullptr;
+        if (SUCCEEDED(app.renderTarget->CreateBitmap(
+                D2D1::SizeU(result->width, result->height),
+                result->pixels.data(), result->width * 4, props, &bitmap)) && bitmap) {
+            entry.bitmap = bitmap;
+            entry.width = (int)result->width;
+            entry.height = (int)result->height;
+            entry.failed = false;
+        }
+    }
+
+    auto it = app.imageCache.find(result->src);
+    if (it != app.imageCache.end() && it->second.bitmap) {
+        it->second.bitmap->Release();
+    }
+    app.imageCache[result->src] = entry;
+    delete result;
+
+    // Reflow with the real image dimensions
+    app.layoutDirty = true;
+    if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
 }
 
 void ensureLayoutComplete(App& app) {

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -26,6 +26,7 @@ struct LayoutInfo {
 
 static LayoutInfo createLayout(App& app, std::wstring_view text, IDWriteTextFormat* format,
                                float lineHeight, IDWriteTypography* typography) {
+    TintaPerfAccum _acc(&g_perfCreateMs, &g_perfCreateN);
     LayoutInfo info;
     if (!format || text.empty()) return info;
 
@@ -277,6 +278,7 @@ private:
 // canBreak[i] == true when a line may break before text[i]; canBreak[len]
 // is always true. Falls back to space-only breaking if analysis fails.
 void analyzeBreakOpportunities(App& app, const std::wstring& text, std::vector<bool>& canBreak) {
+    TintaPerfAccum _acc(&g_perfAnalyzeMs, &g_perfAnalyzeN);
     canBreak.assign(text.size() + 1, false);
     if (text.empty()) return;
     canBreak[text.size()] = true;
@@ -323,6 +325,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                                 float startX, float& y, float maxWidth,
                                 IDWriteTextFormat* baseFormat, D2D1_COLOR_F baseColor,
                                 const std::string& baseLinkUrl = {}, float customLineHeight = 0.0f) {
+    TintaPerfAccum _acc(&g_perfInlineMs, &g_perfInlineN);
     float x = startX;
     float lineHeight = customLineHeight > 0 ? customLineHeight : baseFormat->GetFontSize() * 1.7f;
     float maxX = startX + maxWidth;
@@ -577,6 +580,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
 
         // Measure the whole element once: cluster metrics give every break
         // unit's width without creating one IDWriteTextLayout per unit.
+        TintaPerfAccum _accSetup(&g_perfSetupMs, &g_perfSetupN);
         std::vector<float> cumW(text.length() + 1, -1.0f);
         std::vector<bool> isBoundary(text.length() + 1, false);
         cumW[0] = 0.0f;
@@ -660,6 +664,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
 
         size_t pos = 0;
         size_t lastWordEnd = 0;
+        TintaPerfAccum _accLoop(&g_perfLoopMs, &g_perfLoopN);
 
         auto emitWord = [&](size_t wordStart, size_t wordEnd) {
             float wordWidth = widthOf(wordStart, wordEnd);
@@ -892,6 +897,7 @@ static bool layoutMermaidDiagram(App& app, const std::string& source,
                                  size_t sourceOffset, float& y,
                                  float indent, float maxWidth,
                                  D2D1_RECT_F* renderedBounds = nullptr) {
+    TintaPerfAccum _acc(&g_perfMermaidMs, &g_perfMermaidN);
     auto parsed = mermaid::parse(source);
     if (!parsed.success || parsed.diagram.nodes.empty()) return false;
 
@@ -1699,6 +1705,7 @@ static void layoutImage(App& app, const ElementPtr& elem, float& y, float indent
 }
 
 static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent, float maxWidth) {
+    TintaPerfAccum _acc(&g_perfTableMs, &g_perfTableN);
     float scale = app.contentScale * app.zoomFactor;
     float cellPadding = 8.0f * scale;
     float fontSize = app.textFormat->GetFontSize();
@@ -2151,6 +2158,7 @@ bool layoutDocumentContinue(App& app, int64_t budgetUs) {
 }
 
 void ensureLayoutComplete(App& app) {
+    TintaPerfTimer _perf("ensureLayoutComplete", 1.0);
     if (app.layoutDirty) {
         layoutDocument(app);
         return;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -27,7 +27,6 @@ struct LayoutInfo {
 
 static LayoutInfo createLayout(App& app, std::wstring_view text, IDWriteTextFormat* format,
                                float lineHeight, IDWriteTypography* typography) {
-    TintaPerfAccum _acc(&g_perfCreateMs, &g_perfCreateN);
     LayoutInfo info;
     if (!format || text.empty()) return info;
 
@@ -279,7 +278,6 @@ private:
 // canBreak[i] == true when a line may break before text[i]; canBreak[len]
 // is always true. Falls back to space-only breaking if analysis fails.
 void analyzeBreakOpportunities(App& app, const std::wstring& text, std::vector<bool>& canBreak) {
-    TintaPerfAccum _acc(&g_perfAnalyzeMs, &g_perfAnalyzeN);
     canBreak.assign(text.size() + 1, false);
     if (text.empty()) return;
     canBreak[text.size()] = true;
@@ -326,7 +324,6 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                                 float startX, float& y, float maxWidth,
                                 IDWriteTextFormat* baseFormat, D2D1_COLOR_F baseColor,
                                 const std::string& baseLinkUrl = {}, float customLineHeight = 0.0f) {
-    TintaPerfAccum _acc(&g_perfInlineMs, &g_perfInlineN);
     float x = startX;
     float lineHeight = customLineHeight > 0 ? customLineHeight : baseFormat->GetFontSize() * 1.7f;
     float maxX = startX + maxWidth;
@@ -581,7 +578,6 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
 
         // Measure the whole element once: cluster metrics give every break
         // unit's width without creating one IDWriteTextLayout per unit.
-        TintaPerfAccum _accSetup(&g_perfSetupMs, &g_perfSetupN);
         std::vector<float> cumW(text.length() + 1, -1.0f);
         std::vector<bool> isBoundary(text.length() + 1, false);
         cumW[0] = 0.0f;
@@ -665,7 +661,6 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
 
         size_t pos = 0;
         size_t lastWordEnd = 0;
-        TintaPerfAccum _accLoop(&g_perfLoopMs, &g_perfLoopN);
 
         auto emitWord = [&](size_t wordStart, size_t wordEnd) {
             float wordWidth = widthOf(wordStart, wordEnd);
@@ -898,7 +893,6 @@ static bool layoutMermaidDiagram(App& app, const std::string& source,
                                  size_t sourceOffset, float& y,
                                  float indent, float maxWidth,
                                  D2D1_RECT_F* renderedBounds = nullptr) {
-    TintaPerfAccum _acc(&g_perfMermaidMs, &g_perfMermaidN);
     auto parsed = mermaid::parse(source);
     if (!parsed.success || parsed.diagram.nodes.empty()) return false;
 
@@ -1765,7 +1759,6 @@ static void layoutImage(App& app, const ElementPtr& elem, float& y, float indent
 }
 
 static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent, float maxWidth) {
-    TintaPerfAccum _acc(&g_perfTableMs, &g_perfTableN);
     float scale = app.contentScale * app.zoomFactor;
     float cellPadding = 8.0f * scale;
     float fontSize = app.textFormat->GetFontSize();
@@ -2250,7 +2243,6 @@ void completeAsyncImage(App& app, void* asyncResult) {
 }
 
 void ensureLayoutComplete(App& app) {
-    TintaPerfTimer _perf("ensureLayoutComplete", 1.0);
     if (app.layoutDirty) {
         layoutDocument(app);
         return;


### PR DESCRIPTION
Fixes #44 — opening a 12.6 KB file took seconds because `URLDownloadToCacheFileW` ran **synchronously inside layout**: every remote image blocked the UI thread for the full download, or the full connection timeout when the host is dead. The reporter's file embeds four images from the now-defunct `via.placeholder.com` — ~650 ms timeout each locally, ~4 s total on their network. The block hit during the background layout chunks, so the file *appeared* to open fast and then froze with a busy cursor on first scroll.

**Fix:** remote (http/https) images now load on a detached worker thread with its own COM apartment and WIC factory; only raw premultiplied-BGRA pixels cross the thread boundary. Layout renders the alt-text placeholder immediately and never blocks; `WM_APP_IMAGE_READY` creates the D2D bitmap on the UI thread, swaps it into the image cache, and triggers a reflow. Local images keep the synchronous path (fast, no behavior change). In-flight dedupe via a `pending` cache entry.

**Verified empirically** (instrumented timings, added and removed within this branch — squash keeps the diff clean):
- Before: two layout chunks of 687 ms and 624 ms blocking the message loop on the reporter's file; after: zero chunks over 30 ms, no busy cursor on immediate scroll
- A live remote image (tinta.cc logo) downloads async, appears, and reflows the document correctly
- Dead URLs settle as the italic alt-text placeholder
- ctest green