### PR TITLE
Release v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.4.2] - 2026-07-30
+
+### Fixed
+- Remote images no longer freeze the app while they download: documents render immediately with a placeholder, images pop in when ready, and unreachable URLs settle as their alt text instead of blocking layout for the full connection timeout (#44)
+- Inline `<br>` tags render as line breaks instead of literal text — `<br>`, `<br/>`, and `<br />` are all recognized, case-insensitively (#45)
+
 ## [v2.4.0] - 2026-07-29
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(tinta VERSION 2.4.0 LANGUAGES C CXX)
+project(tinta VERSION 2.4.2 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Version bump + changelog for v2.4.2: async remote image loading (#44) and inline `<br>` support (#45).