### PR TITLE
Folder browser: editable path header + new file/folder creation (#52)

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -226,6 +226,13 @@ struct App {
     int hoveredFolderIndex = -1;
     float folderBrowserScroll = 0.0f;     // Scroll offset for folder list
 
+    // Path header editing + new file/folder creation (#52)
+    bool folderBrowserEditingPath = false;   // Path header is an edit box
+    int folderBrowserNaming = 0;             // 0 = off, 1 = naming a new file, 2 = a new folder
+    std::wstring folderBrowserInput;         // Single-line buffer shared by both inputs
+    bool folderBrowserInputSelectAll = false; // Whole input selected: next keystroke replaces it
+    bool folderBrowserInputError = false;    // Last commit failed (bad path/name): red border
+
     // Help overlay
     bool showHelp = false;
     float helpAnimation = 0.0f;
@@ -610,7 +617,9 @@ inline float documentViewportWidth(const App& app) {
 // app is fully idle between blinks. Call after editMode/search state changes.
 inline void updateBlinkTimer(App& app) {
     if (!app.hwnd) return;
-    if (app.editMode || (app.showSearch && app.searchActive)) {
+    if (app.editMode || (app.showSearch && app.searchActive) ||
+        (app.showFolderBrowser &&
+         (app.folderBrowserEditingPath || app.folderBrowserNaming != 0))) {
         app.cursorBlinkOn = true;
         SetTimer(app.hwnd, TIMER_CURSOR_BLINK, 500, nullptr);
     } else {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -20,6 +20,166 @@ static HCURSOR cursorArrow = LoadCursor(nullptr, IDC_ARROW);
 static HCURSOR cursorHand  = LoadCursor(nullptr, IDC_HAND);
 static HCURSOR cursorIBeam = LoadCursor(nullptr, IDC_IBEAM);
 
+// Loads a document into the viewer and resets per-document state.
+// Shared by the folder browser's item clicks, path input, and new-file flow.
+static bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
+    std::ifstream file(fullPath);
+    if (!file) return false;
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    auto result = parseDocument(app.parser, buffer.str(), fullPath);
+    if (!result.success) return false;
+
+    app.root = result.root;
+    app.parseTimeUs = result.parseTimeUs;
+    int utf8Len = WideCharToMultiByte(CP_UTF8, 0, fullPath.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    app.currentFile.resize(utf8Len - 1);
+    WideCharToMultiByte(CP_UTF8, 0, fullPath.c_str(), -1, &app.currentFile[0], utf8Len, nullptr, nullptr);
+    app.scrollY = 0;
+    app.scrollX = 0;
+    app.targetScrollY = 0;
+    app.targetScrollX = 0;
+    app.focusMermaidOnNextLayout = isMermaidDocumentPath(fullPath);
+    app.contentHeight = 0;
+    app.docText.clear();
+    app.docTextLower.clear();
+    app.searchMatches.clear();
+    app.layoutDirty = true;
+    updateFileWriteTime(app);
+    updateWindowTitle(app);
+    return true;
+}
+
+// --- Folder browser path/name input (#52) ---
+
+static void closeFolderBrowserInput(App& app) {
+    app.folderBrowserEditingPath = false;
+    app.folderBrowserNaming = 0;
+    app.folderBrowserInput.clear();
+    app.folderBrowserInputSelectAll = false;
+    app.folderBrowserInputError = false;
+    updateBlinkTimer(app);
+}
+
+// Single-line clipboard text: newlines and tabs become spaces
+static std::wstring clipboardLine(HWND hwnd) {
+    if (!OpenClipboard(hwnd)) return {};
+    std::wstring text;
+    if (HANDLE hData = GetClipboardData(CF_UNICODETEXT)) {
+        if (wchar_t* ptr = (wchar_t*)GlobalLock(hData)) {
+            text = ptr;
+            GlobalUnlock(hData);
+        }
+    }
+    CloseClipboard();
+    for (wchar_t& ch : text) {
+        if (ch == L'\r' || ch == L'\n' || ch == L'\t') ch = L' ';
+    }
+    return text;
+}
+
+// Trims whitespace and the quotes Explorer's "Copy as path" adds
+static std::wstring cleanPathInput(std::wstring s) {
+    auto trim = [](std::wstring& t) {
+        size_t a = t.find_first_not_of(L" ");
+        size_t b = t.find_last_not_of(L" ");
+        t = (a == std::wstring::npos) ? L"" : t.substr(a, b - a + 1);
+    };
+    trim(s);
+    if (s.length() >= 2 && s.front() == L'"' && s.back() == L'"') {
+        s = s.substr(1, s.length() - 2);
+        trim(s);
+    }
+    return s;
+}
+
+// Enter in the path box: a directory browses there, a file opens
+static void commitFolderBrowserPath(App& app) {
+    std::wstring path = cleanPathInput(app.folderBrowserInput);
+    if (path.empty()) {
+        closeFolderBrowserInput(app);
+        return;
+    }
+    wchar_t expanded[MAX_PATH];
+    if (ExpandEnvironmentStringsW(path.c_str(), expanded, MAX_PATH) > 0) {
+        path = expanded;
+    }
+
+    DWORD attrs = GetFileAttributesW(path.c_str());
+    if (attrs == INVALID_FILE_ATTRIBUTES) {
+        app.folderBrowserInputError = true;
+        return;
+    }
+    if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
+        // Strip a trailing separator (but keep drive roots like C:\)
+        while (path.length() > 3 && (path.back() == L'\\' || path.back() == L'/')) {
+            path.pop_back();
+        }
+        app.folderBrowserPath = path;
+        populateFolderItems(app);
+        closeFolderBrowserInput(app);
+        return;
+    }
+    if (isSupportedDropPath(path) && openDocumentInViewer(app, path)) {
+        closeFolderBrowserInput(app);
+        app.showFolderBrowser = false;
+        app.folderBrowserAnimation = 0;
+    } else {
+        app.folderBrowserInputError = true;
+    }
+}
+
+// Enter in the naming box: creates the file/folder in the browsed directory.
+// A new folder is entered; a new file opens straight into edit mode.
+static void commitFolderBrowserNaming(App& app) {
+    std::wstring name = cleanPathInput(app.folderBrowserInput);
+    if (name.empty()) {
+        closeFolderBrowserInput(app);
+        return;
+    }
+    if (name.find_first_of(L"\\/:*?\"<>|") != std::wstring::npos ||
+        name == L"." || name == L"..") {
+        app.folderBrowserInputError = true;
+        return;
+    }
+
+    bool isFolder = app.folderBrowserNaming == 2;
+    if (!isFolder && name.find(L'.') == std::wstring::npos) {
+        name += L".md";
+    }
+    std::wstring fullPath = app.folderBrowserPath;
+    if (!fullPath.empty() && fullPath.back() != L'\\' && fullPath.back() != L'/') {
+        fullPath += L'\\';
+    }
+    fullPath += name;
+
+    if (isFolder) {
+        if (!CreateDirectoryW(fullPath.c_str(), nullptr)) {
+            app.folderBrowserInputError = true;
+            return;
+        }
+        app.folderBrowserPath = fullPath;
+        populateFolderItems(app);
+        closeFolderBrowserInput(app);
+        return;
+    }
+
+    // CREATE_NEW fails if the file already exists instead of truncating it
+    HANDLE h = CreateFileW(fullPath.c_str(), GENERIC_WRITE, 0, nullptr,
+                           CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (h == INVALID_HANDLE_VALUE) {
+        app.folderBrowserInputError = true;
+        return;
+    }
+    CloseHandle(h);
+    if (openDocumentInViewer(app, fullPath)) {
+        closeFolderBrowserInput(app);
+        app.showFolderBrowser = false;
+        app.folderBrowserAnimation = 0;
+        enterEditMode(app);
+    }
+}
+
 // Ctrl+wheel zoom. The scroll anchor scales immediately, but text format
 // recreation (~47 COM objects) + full relayout is applied on the leading
 // tick and then coalesced via TIMER_ZOOM_APPLY while the wheel keeps spinning.
@@ -75,7 +235,8 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             float itemHeight = dpi(app, 28.0f);
             float headerHeight = dpi(app, 48.0f);
             float listHeight = app.height - headerHeight - dpi(app, 20.0f);
-            float totalItemsHeight = app.folderItems.size() * itemHeight;
+            float totalItemsHeight = app.folderItems.size() * itemHeight +
+                (app.folderBrowserNaming != 0 ? itemHeight : 0.0f);
             float maxScroll = std::max(0.0f, totalItemsHeight - listHeight);
             app.folderBrowserScroll = std::max(0.0f, std::min(app.folderBrowserScroll, maxScroll));
             InvalidateRect(hwnd, nullptr, FALSE);
@@ -606,6 +767,58 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
         // Check if click is inside panel
         if (clickX >= panelX && clickX <= panelX + panelWidth) {
+            // Header geometry (must match renderFolderBrowser)
+            float padding = dpi(app, 12.0f);
+            float headerY = padding;
+            float headerHeight = dpi(app, 40.0f);
+            float btnSize = dpi(app, 24.0f);
+            float btnGap = dpi(app, 6.0f);
+            float fileBtnX = panelX + panelWidth - padding - btnSize;
+            float folderBtnX = fileBtnX - btnGap - btnSize;
+            float btnY = headerY + (headerHeight - btnSize) / 2 - dpi(app, 6.0f);
+            bool inHeader = clickY >= headerY && clickY <= headerY + headerHeight;
+
+            // An active input keeps focus when clicked, anything else cancels it
+            if (app.folderBrowserEditingPath || app.folderBrowserNaming != 0) {
+                bool onInput = app.folderBrowserEditingPath
+                    ? inHeader
+                    : (clickY >= headerY + headerHeight + dpi(app, 8.0f) &&
+                       clickY <= headerY + headerHeight + dpi(app, 8.0f) + dpi(app, 28.0f));
+                if (onInput) {
+                    app.folderBrowserInputSelectAll = false;
+                } else {
+                    closeFolderBrowserInput(app);
+                }
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+
+            if (inHeader && clickY >= btnY && clickY <= btnY + btnSize &&
+                clickX >= folderBtnX && clickX <= fileBtnX + btnSize) {
+                // + folder / + file buttons: start naming a new item
+                app.folderBrowserNaming = (clickX < folderBtnX + btnSize + btnGap / 2) ? 2 : 1;
+                app.folderBrowserInput.clear();
+                app.folderBrowserInputSelectAll = false;
+                app.folderBrowserInputError = false;
+                app.folderBrowserScroll = 0.0f;
+                updateBlinkTimer(app);
+                resetCursorBlink(app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+            if (inHeader) {
+                // Path header becomes an edit box with everything selected,
+                // so click + paste + Enter jumps straight to a new path (#52)
+                app.folderBrowserEditingPath = true;
+                app.folderBrowserInput = app.folderBrowserPath;
+                app.folderBrowserInputSelectAll = true;
+                app.folderBrowserInputError = false;
+                updateBlinkTimer(app);
+                resetCursorBlink(app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+
             // Hit-test items
             if (app.hoveredFolderIndex >= 0 && app.hoveredFolderIndex < (int)app.folderItems.size()) {
                 const auto& item = app.folderItems[app.hoveredFolderIndex];
@@ -631,41 +844,16 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                     }
                     fullPath += item.name;
 
-                    // Load the file
-                    std::ifstream file(fullPath);
-                    if (file) {
-                        std::stringstream buffer;
-                        buffer << file.rdbuf();
-                        auto result = parseDocument(app.parser, buffer.str(), fullPath);
-                        if (result.success) {
-                            app.root = result.root;
-                            app.parseTimeUs = result.parseTimeUs;
-                            // Convert wide path to UTF-8 for currentFile
-                            int utf8Len = WideCharToMultiByte(CP_UTF8, 0, fullPath.c_str(), -1, nullptr, 0, nullptr, nullptr);
-                            app.currentFile.resize(utf8Len - 1);
-                            WideCharToMultiByte(CP_UTF8, 0, fullPath.c_str(), -1, &app.currentFile[0], utf8Len, nullptr, nullptr);
-                            app.scrollY = 0;
-                            app.scrollX = 0;
-                            app.targetScrollY = 0;
-                            app.targetScrollX = 0;
-                            app.focusMermaidOnNextLayout = isMermaidDocumentPath(fullPath);
-                            app.contentHeight = 0;
-                            app.docText.clear();
-                            app.docTextLower.clear();
-                            app.searchMatches.clear();
-                            app.layoutDirty = true;
-                            updateFileWriteTime(app);
-                            updateWindowTitle(app);
-
-                            // Close folder browser after opening file
-                            app.showFolderBrowser = false;
-                            app.folderBrowserAnimation = 0;
-                        }
+                    if (openDocumentInViewer(app, fullPath)) {
+                        // Close folder browser after opening file
+                        app.showFolderBrowser = false;
+                        app.folderBrowserAnimation = 0;
                     }
                 }
             }
         } else {
             // Click outside panel = close browser
+            closeFolderBrowserInput(app);
             app.showFolderBrowser = false;
             app.folderBrowserAnimation = 0;
         }
@@ -809,6 +997,48 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
         return;
     }
 
+    // Folder browser path/name input captures the keyboard while active
+    // (printable characters arrive separately via WM_CHAR)
+    if (app.showFolderBrowser &&
+        (app.folderBrowserEditingPath || app.folderBrowserNaming != 0)) {
+        if (ctrl && wParam == 'V') {
+            std::wstring pasted = clipboardLine(hwnd);
+            if (!pasted.empty()) {
+                if (app.folderBrowserInputSelectAll) {
+                    app.folderBrowserInput.clear();
+                    app.folderBrowserInputSelectAll = false;
+                }
+                app.folderBrowserInput += pasted;
+                app.folderBrowserInputError = false;
+                resetCursorBlink(app);
+            }
+        } else if (ctrl && wParam == 'A') {
+            if (!app.folderBrowserInput.empty()) app.folderBrowserInputSelectAll = true;
+        } else if (!ctrl) {
+            switch (wParam) {
+                case VK_ESCAPE:
+                    closeFolderBrowserInput(app);
+                    break;
+                case VK_RETURN:
+                    if (app.folderBrowserEditingPath) commitFolderBrowserPath(app);
+                    else commitFolderBrowserNaming(app);
+                    break;
+                case VK_BACK:
+                    if (app.folderBrowserInputSelectAll) {
+                        app.folderBrowserInput.clear();
+                        app.folderBrowserInputSelectAll = false;
+                    } else if (!app.folderBrowserInput.empty()) {
+                        app.folderBrowserInput.pop_back();
+                    }
+                    app.folderBrowserInputError = false;
+                    resetCursorBlink(app);
+                    break;
+            }
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     // Handle search-specific keys when search is active
     if (app.showSearch && app.searchActive) {
         switch (wParam) {
@@ -932,6 +1162,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 // B to toggle folder browser
                 if (!app.showSearch && !app.showThemeChooser && !app.showToc) {
                     app.showFolderBrowser = !app.showFolderBrowser;
+                    closeFolderBrowserInput(app);
                     if (app.showFolderBrowser) {
                         app.folderBrowserAnimation = 0;
                         // Initialize to directory of current file, or working directory
@@ -1048,6 +1279,22 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
             InvalidateRect(app.hwnd, nullptr, FALSE);
             return;
         }
+    }
+
+    if (app.showFolderBrowser &&
+        (app.folderBrowserEditingPath || app.folderBrowserNaming != 0)) {
+        wchar_t ch = (wchar_t)wParam;
+        if (ch >= 32 && ch != 127) {
+            if (app.folderBrowserInputSelectAll) {
+                app.folderBrowserInput.clear();
+                app.folderBrowserInputSelectAll = false;
+            }
+            app.folderBrowserInput += ch;
+            app.folderBrowserInputError = false;
+            resetCursorBlink(app);
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
+        return;
     }
 
     if (app.showSearch && app.searchActive) {

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -170,34 +170,96 @@ void renderFolderBrowser(App& app) {
         float itemHeight = dpi(app, 28.0f);
         float headerHeight = dpi(app, 40.0f);
 
-        // Current path header
+        // Current path header — click converts it to an edit box (#52)
         float headerY = panelY + padding;
-        D2D1_COLOR_F headerColor = app.theme.heading;
-        headerColor.a = anim;
-        app.brush->SetColor(headerColor);
 
-        // Truncate path if too long, keeping the tail (leaf folder) visible:
-        // measure with the actual font instead of estimating character widths,
-        // which breaks down for CJK and other wide scripts
-        std::wstring displayPath = app.folderBrowserPath;
-        float maxPathWidth = panelWidth - padding * 2;
-
-        if (!displayPath.empty() && app.dwriteFactory) {
-            auto textWidth = [&](const std::wstring& s) {
-                float w = 0.0f;
-                IDWriteTextLayout* layout = nullptr;
-                if (SUCCEEDED(app.dwriteFactory->CreateTextLayout(
-                        s.c_str(), (UINT32)s.length(), browserFormat,
-                        1000000.0f, headerHeight, &layout)) && layout) {
-                    DWRITE_TEXT_METRICS metrics;
-                    if (SUCCEEDED(layout->GetMetrics(&metrics))) {
-                        w = metrics.widthIncludingTrailingWhitespace;
-                    }
-                    layout->Release();
+        auto textWidth = [&](const std::wstring& s) {
+            float w = 0.0f;
+            IDWriteTextLayout* layout = nullptr;
+            if (app.dwriteFactory && SUCCEEDED(app.dwriteFactory->CreateTextLayout(
+                    s.c_str(), (UINT32)s.length(), browserFormat,
+                    1000000.0f, headerHeight, &layout)) && layout) {
+                DWRITE_TEXT_METRICS metrics;
+                if (SUCCEEDED(layout->GetMetrics(&metrics))) {
+                    w = metrics.widthIncludingTrailingWhitespace;
                 }
-                return w;
-            };
-            if (textWidth(displayPath) > maxPathWidth) {
+                layout->Release();
+            }
+            return w;
+        };
+
+        D2D1_COLOR_F accentColor = app.theme.accent;
+        accentColor.a = anim;
+        D2D1_COLOR_F errorColor = hexColor(app.theme.isDark ? 0xF85149 : 0xCF222E, anim);
+        float inputPad = dpi(app, 6.0f);
+        float boxHeight = dpi(app, 26.0f);
+
+        // Draws a single-line input box; the text is clipped from the left so
+        // its tail (where typing happens) stays visible, with select-all
+        // highlight and a caret at the end
+        auto drawInputBox = [&](float boxX, float boxRight, float boxY) {
+            D2D1_RECT_F box = D2D1::RectF(boxX, boxY, boxRight, boxY + boxHeight);
+            D2D1_COLOR_F boxBg = app.theme.isDark ? hexColor(0x2A2A30, 0.9f * anim)
+                                                  : hexColor(0xFFFFFF, 0.9f * anim);
+            app.brush->SetColor(boxBg);
+            app.renderTarget->FillRoundedRectangle(D2D1::RoundedRect(box, 4, 4), app.brush);
+            app.brush->SetColor(app.folderBrowserInputError ? errorColor : accentColor);
+            app.renderTarget->DrawRoundedRectangle(D2D1::RoundedRect(box, 4, 4), app.brush, 1.0f);
+
+            std::wstring display = app.folderBrowserInput;
+            float maxTextWidth = (boxRight - boxX) - inputPad * 2 - dpi(app, 2.0f);
+            while (!display.empty() && textWidth(display) > maxTextWidth) {
+                display.erase(0, 1);
+            }
+            float shownWidth = textWidth(display);
+            float textY = boxY + (boxHeight - dpi(app, 18.0f)) / 2;
+
+            if (app.folderBrowserInputSelectAll && !display.empty()) {
+                D2D1_COLOR_F selColor = app.theme.accent;
+                selColor.a = 0.35f * anim;
+                app.brush->SetColor(selColor);
+                app.renderTarget->FillRectangle(
+                    D2D1::RectF(boxX + inputPad - 1, boxY + dpi(app, 3.0f),
+                                boxX + inputPad + shownWidth + 1, boxY + boxHeight - dpi(app, 3.0f)),
+                    app.brush);
+            }
+
+            D2D1_COLOR_F inputTextColor = app.theme.text;
+            inputTextColor.a = anim;
+            app.brush->SetColor(inputTextColor);
+            app.renderTarget->DrawText(display.c_str(), (UINT32)display.length(), browserFormat,
+                D2D1::RectF(boxX + inputPad, textY, boxRight - inputPad, boxY + boxHeight),
+                app.brush);
+
+            if (!app.folderBrowserInputSelectAll && app.cursorBlinkOn) {
+                float caretX = boxX + inputPad + shownWidth + 1;
+                app.brush->SetColor(inputTextColor);
+                app.renderTarget->DrawLine(
+                    D2D1::Point2F(caretX, boxY + dpi(app, 4.0f)),
+                    D2D1::Point2F(caretX, boxY + boxHeight - dpi(app, 4.0f)),
+                    app.brush, 1.0f);
+            }
+        };
+
+        float btnSize = dpi(app, 24.0f);
+        float btnGap = dpi(app, 6.0f);
+        float fileBtnX = panelX + panelWidth - padding - btnSize;
+        float folderBtnX = fileBtnX - btnGap - btnSize;
+        float btnY = headerY + (headerHeight - btnSize) / 2 - dpi(app, 6.0f);
+
+        if (app.folderBrowserEditingPath) {
+            drawInputBox(panelX + padding, panelX + panelWidth - padding, headerY - dpi(app, 2.0f));
+        } else {
+            D2D1_COLOR_F headerColor = app.theme.heading;
+            headerColor.a = anim;
+
+            // Truncate path if too long, keeping the tail (leaf folder) visible:
+            // measure with the actual font instead of estimating character widths,
+            // which breaks down for CJK and other wide scripts
+            std::wstring displayPath = app.folderBrowserPath;
+            float maxPathWidth = panelWidth - padding * 2 - (btnSize * 2 + btnGap * 2);
+
+            if (!displayPath.empty() && textWidth(displayPath) > maxPathWidth) {
                 std::wstring tail = displayPath;
                 while (textWidth(L"..." + tail) > maxPathWidth) {
                     size_t sep = tail.find(L'\\', 1);
@@ -206,11 +268,72 @@ void renderFolderBrowser(App& app) {
                 }
                 displayPath = L"..." + tail;
             }
-        }
 
-        app.renderTarget->DrawText(displayPath.c_str(), (UINT32)displayPath.length(), browserFormat,
-            D2D1::RectF(panelX + padding, headerY, panelX + panelWidth - padding, headerY + headerHeight),
-            app.brush);
+            // Subtle hover backdrop signals the path is clickable
+            bool pathHovered = app.mouseX >= panelX + padding - dpi(app, 4.0f) &&
+                               app.mouseX < folderBtnX - dpi(app, 2.0f) &&
+                               app.mouseY >= headerY && app.mouseY <= headerY + headerHeight * 0.6f;
+            if (pathHovered) {
+                D2D1_COLOR_F hoverColor = app.theme.accent;
+                hoverColor.a = 0.12f * anim;
+                app.brush->SetColor(hoverColor);
+                app.renderTarget->FillRoundedRectangle(
+                    D2D1::RoundedRect(D2D1::RectF(panelX + padding - dpi(app, 4.0f), headerY - dpi(app, 2.0f),
+                                                  folderBtnX - dpi(app, 2.0f), headerY + dpi(app, 22.0f)), 4, 4),
+                    app.brush);
+            }
+
+            app.brush->SetColor(headerColor);
+            app.renderTarget->DrawText(displayPath.c_str(), (UINT32)displayPath.length(), browserFormat,
+                D2D1::RectF(panelX + padding, headerY, folderBtnX - dpi(app, 4.0f), headerY + headerHeight),
+                app.brush);
+
+            // + folder / + file buttons
+            auto drawAddButton = [&](float bx, bool isFolder) {
+                bool hovered = app.mouseX >= bx && app.mouseX <= bx + btnSize &&
+                               app.mouseY >= btnY && app.mouseY <= btnY + btnSize;
+                if (hovered) {
+                    D2D1_COLOR_F hoverColor = app.theme.accent;
+                    hoverColor.a = 0.2f * anim;
+                    app.brush->SetColor(hoverColor);
+                    app.renderTarget->FillRoundedRectangle(
+                        D2D1::RoundedRect(D2D1::RectF(bx, btnY, bx + btnSize, btnY + btnSize), 4, 4),
+                        app.brush);
+                }
+                float gx = bx + dpi(app, 3.0f);
+                float gy = btnY + dpi(app, 6.0f);
+                if (isFolder) {
+                    D2D1_COLOR_F folderColor = app.theme.isDark ? hexColor(0xE8A848) : hexColor(0xD4941A);
+                    folderColor.a = anim;
+                    app.brush->SetColor(folderColor);
+                    app.renderTarget->FillRoundedRectangle(
+                        D2D1::RoundedRect(D2D1::RectF(gx, gy + dpi(app, 4.0f), gx + dpi(app, 13.0f), gy + dpi(app, 13.0f)), 2, 2),
+                        app.brush);
+                    app.renderTarget->FillRectangle(
+                        D2D1::RectF(gx, gy + dpi(app, 2.0f), gx + dpi(app, 6.0f), gy + dpi(app, 5.0f)),
+                        app.brush);
+                } else {
+                    D2D1_COLOR_F fileColor = app.theme.text;
+                    fileColor.a = 0.6f * anim;
+                    app.brush->SetColor(fileColor);
+                    app.renderTarget->DrawRoundedRectangle(
+                        D2D1::RoundedRect(D2D1::RectF(gx + dpi(app, 1.0f), gy, gx + dpi(app, 11.0f), gy + dpi(app, 13.0f)), 1, 1),
+                        app.brush, 1.0f);
+                }
+                // Accent "+" badge in the top-right corner of the button
+                float px = bx + btnSize - dpi(app, 7.0f);
+                float py = btnY + dpi(app, 2.0f);
+                app.brush->SetColor(accentColor);
+                app.renderTarget->DrawLine(
+                    D2D1::Point2F(px, py + dpi(app, 3.0f)), D2D1::Point2F(px + dpi(app, 6.0f), py + dpi(app, 3.0f)),
+                    app.brush, 2.0f);
+                app.renderTarget->DrawLine(
+                    D2D1::Point2F(px + dpi(app, 3.0f), py), D2D1::Point2F(px + dpi(app, 3.0f), py + dpi(app, 6.0f)),
+                    app.brush, 2.0f);
+            };
+            drawAddButton(folderBtnX, true);
+            drawAddButton(fileBtnX, false);
+        }
 
         // Divider line
         float dividerY = headerY + headerHeight;
@@ -220,10 +343,12 @@ void renderFolderBrowser(App& app) {
             D2D1::Point2F(panelX + panelWidth - padding, dividerY),
             app.brush, 1.0f);
 
-        // Items list (with scrolling)
+        // Items list (with scrolling); an active naming row occupies the
+        // first slot and the real items shift down beneath it
         float listStartY = dividerY + dpi(app, 8.0f);
         float listHeight = panelHeight - listStartY - padding;
-        float totalItemsHeight = app.folderItems.size() * itemHeight;
+        float namingOffset = app.folderBrowserNaming != 0 ? itemHeight : 0.0f;
+        float totalItemsHeight = app.folderItems.size() * itemHeight + namingOffset;
 
         // Clamp scroll
         float maxScroll = std::max(0.0f, totalItemsHeight - listHeight);
@@ -232,7 +357,7 @@ void renderFolderBrowser(App& app) {
         app.hoveredFolderIndex = -1;
 
         for (size_t i = 0; i < app.folderItems.size(); i++) {
-            float itemY = listStartY + i * itemHeight - app.folderBrowserScroll;
+            float itemY = listStartY + namingOffset + i * itemHeight - app.folderBrowserScroll;
 
             // Skip items outside visible area
             if (itemY + itemHeight < listStartY || itemY > panelHeight - padding) continue;
@@ -294,6 +419,42 @@ void renderFolderBrowser(App& app) {
             app.renderTarget->DrawText(item.name.c_str(), (UINT32)item.name.length(), browserFormat,
                 D2D1::RectF(textX, itemY + dpi(app, 4.0f), panelX + panelWidth - padding, itemY + itemHeight),
                 app.brush);
+        }
+
+        // Naming row for a new file/folder: pinned to the top of the list,
+        // drawn after the items so they scroll underneath it
+        if (app.folderBrowserNaming != 0) {
+            bool isFolder = app.folderBrowserNaming == 2;
+            float rowY = listStartY;
+            float iconX = panelX + padding + dpi(app, 4.0f);
+            float textX = panelX + padding + dpi(app, 26.0f);
+
+            app.brush->SetColor(panelBg);
+            app.renderTarget->FillRectangle(
+                D2D1::RectF(panelX + padding - dpi(app, 4.0f), rowY,
+                            panelX + panelWidth - padding + dpi(app, 4.0f), rowY + itemHeight),
+                app.brush);
+
+            if (isFolder) {
+                D2D1_COLOR_F folderColor = app.theme.isDark ? hexColor(0xE8A848) : hexColor(0xD4941A);
+                folderColor.a = anim;
+                app.brush->SetColor(folderColor);
+                app.renderTarget->FillRoundedRectangle(
+                    D2D1::RoundedRect(D2D1::RectF(iconX, rowY + dpi(app, 10.0f), iconX + dpi(app, 16.0f), rowY + dpi(app, 22.0f)), 2, 2),
+                    app.brush);
+                app.renderTarget->FillRectangle(
+                    D2D1::RectF(iconX, rowY + dpi(app, 8.0f), iconX + dpi(app, 8.0f), rowY + dpi(app, 11.0f)),
+                    app.brush);
+            } else {
+                D2D1_COLOR_F fileColor = app.theme.text;
+                fileColor.a = 0.6f * anim;
+                app.brush->SetColor(fileColor);
+                app.renderTarget->DrawRoundedRectangle(
+                    D2D1::RoundedRect(D2D1::RectF(iconX + dpi(app, 2.0f), rowY + dpi(app, 6.0f), iconX + dpi(app, 14.0f), rowY + dpi(app, 22.0f)), 1, 1),
+                    app.brush, 1.0f);
+            }
+
+            drawInputBox(textX, panelX + panelWidth - padding, rowY + dpi(app, 1.0f));
         }
 
         // Scrollbar if needed


### PR DESCRIPTION
Implements both requests from #52.

**Editable path header**: clicking the current path at the top of the folder browser converts it into an edit box with the whole path selected — one click + paste + Enter navigates anywhere. A pasted/typed directory browses there; a file path opens the file directly. Handles Explorer's quoted `Copy as path` output, environment variables (`%USERPROFILE%`), and trailing separators. Nonexistent paths show a red border and stay editable; Esc cancels back to the plain header.

**+ folder / + file buttons** to the right of the path: clicking one pins an inline naming row (icon + input box) at the top of the list. Enter creates the item in the browsed directory — a new folder is navigated into, a new file (`.md` appended when no extension is given, `CREATE_NEW` so an existing file is never truncated) opens straight into edit mode for immediate note-taking. Invalid filename characters show the error border.

Implementation: a minimal shared single-line input (type-to-replace selection, backspace, Ctrl+V paste flattened to one line, Ctrl+A reselect, blinking caret, left-clipped display so the tail stays visible) rendered by one `drawInputBox` helper used by both the header and the naming row; keyboard is captured ahead of the global shortcuts while an input is active so B/Q/T/F don't fire. The browser's inline document loader was extracted into `openDocumentInViewer` and shared by item clicks, path commits, and new-file creation.

Verified end-to-end by driving the UI with injected messages: open→click path→type→Enter navigates; +file→name→Enter creates and lands in edit mode; +folder creates and enters; bad path shows the error border; Esc cancels the input first and closes the browser second; wheel scrolling accounts for the naming row. ctest green.

Closes #52