### PR TITLE
Instant first paint: software render target first, GPU warmed in background

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ target_link_libraries(tinta PRIVATE
     urlmon
     ole32
     imm32
+    d3d11
 )
 
 target_compile_definitions(tinta PRIVATE UNICODE _UNICODE

--- a/include/app.h
+++ b/include/app.h
@@ -39,6 +39,11 @@ inline int64_t usElapsed(Clock::time_point start) {
 // loading (lParam = AsyncImageResult*, ownership transfers to the handler)
 #define WM_APP_IMAGE_READY (WM_APP + 2)
 
+// Posted by the GPU warm-up thread once the D3D driver is initialized: the
+// software render target used for the instant first paint is then swapped
+// for a hardware one (cheap now that the driver is warm)
+#define WM_APP_GPU_READY (WM_APP + 3)
+
 // Startup metrics
 struct StartupMetrics {
     int64_t windowInitUs = 0;
@@ -124,6 +129,11 @@ struct App {
     // Direct2D
     ID2D1Factory* d2dFactory = nullptr;
     ID2D1HwndRenderTarget* renderTarget = nullptr;
+    // The first render target is software: it creates in ~20 ms while a
+    // hardware one pays ~200 ms of D3D device + GPU driver initialization.
+    // The warm-up thread flips this and the target is recreated on
+    // WM_APP_GPU_READY, after the first frame is already on screen.
+    bool useHardwareRT = false;
     ID2D1SolidColorBrush* brush = nullptr;
     ID2D1DeviceContext* deviceContext = nullptr;  // For color emoji rendering
 

--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -379,7 +379,8 @@ bool createRenderTarget(App& app) {
     D2D1_SIZE_U size = D2D1::SizeU(rc.right - rc.left, rc.bottom - rc.top);
 
     D2D1_RENDER_TARGET_PROPERTIES rtProps = D2D1::RenderTargetProperties();
-    rtProps.type = D2D1_RENDER_TARGET_TYPE_DEFAULT;
+    rtProps.type = app.useHardwareRT ? D2D1_RENDER_TARGET_TYPE_DEFAULT
+                                     : D2D1_RENDER_TARGET_TYPE_SOFTWARE;
     rtProps.dpiX = 96.0f;
     rtProps.dpiY = 96.0f;
     rtProps.usage = D2D1_RENDER_TARGET_USAGE_NONE;

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -8,12 +8,15 @@
 #include <commdlg.h>
 #include <shlobj.h>
 
+#include <d3d11.h>
+
 #include <fstream>
 #include <sstream>
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <functional>
+#include <thread>
 #include "settings.h"
 #include "document.h"
 #include "d2d_init.h"
@@ -27,6 +30,27 @@
 #include "editor.h"
 
 static App* g_app = nullptr;
+
+// Initializes the GPU driver on a worker thread after the first (software)
+// frame is on screen. D3D device creation costs ~200 ms dominated by
+// process-global driver initialization — done here once, the hardware
+// render target created on WM_APP_GPU_READY takes ~40 ms. The device is
+// kept alive so the driver state it initialized stays warm.
+static void startGpuWarmup() {
+    std::thread([] {
+        ID3D11Device* device = nullptr;
+        ID3D11DeviceContext* ctx = nullptr;
+        D3D_FEATURE_LEVEL fl;
+        D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, nullptr,
+                          D3D11_CREATE_DEVICE_BGRA_SUPPORT, nullptr, 0,
+                          D3D11_SDK_VERSION, &device, &fl, &ctx);
+        if (ctx) ctx->Release();
+        if (device && g_app && g_app->hwnd) {
+            PostMessageW(g_app->hwnd, WM_APP_GPU_READY, 0, 0);
+        }
+        // device intentionally not released
+    }).detach();
+}
 
 // Forward declarations
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -898,6 +922,18 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (app) completeAsyncImage(*app, (void*)lParam);
             return 0;
 
+        case WM_APP_GPU_READY:
+            // Driver is warm: swap the startup software render target for a
+            // hardware one. Same resource-recreation path a resize takes,
+            // and the frame it redraws is pixel-identical.
+            if (app && !app->useHardwareRT) {
+                app->useHardwareRT = true;
+                createRenderTarget(*app);
+                app->layoutDirty = true;
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            return 0;
+
         case WM_APP_LAYOUT_CHUNK:
             // Continue an incomplete document layout in ~10ms slices, yielding
             // to input between slices
@@ -1216,6 +1252,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.metrics.showWindowUs = usElapsed(t0);
 
     app.metrics.totalStartupUs = usElapsed(startupStart);
+
+    // First frame is on screen — now pay for the GPU in the background
+    startGpuWarmup();
 
     // Message loop
     MSG msg;


### PR DESCRIPTION
Profiling the startup sequence showed the time does **not** go where the D2D-vs-OpenGL folklore says. On a warm start (~290 ms total):

| Phase | Time |
|---|---|
| D2D + DWrite + WIC factories | ~4.5 ms |
| All 19 text formats + font fallback chain | ~1.3 ms |
| File load + parse | ~0.7 ms |
| **CreateHwndRenderTarget (hardware)** | **~196–208 ms** |
| ShowWindow + first paint | ~50 ms |

68% of launch is one call: the D3D11 device + GPU driver initialization inside `CreateHwndRenderTarget`.

**Change:** the first render target is created as `D2D1_RENDER_TARGET_TYPE_SOFTWARE` (~20 ms). DirectWrite rasterizes glyphs on the CPU either way, so the first frame is pixel-identical to a hardware one (verified by pixel diff). After the first frame is on screen, a worker thread initializes the GPU driver and posts `WM_APP_GPU_READY`; the render target is then recreated as hardware — ~40 ms with a warm driver — through the same resource-recreation path a window resize already exercises.

**Measured on the built-in stats overlay (`-s`): startup 348.8 ms → 133.4 ms (2.6×).**

Notes from the investigation:
- A warm-up thread racing the hardware creation at process entry does NOT work — both serialize on driver-global init locks, zero overlap gain (measured slightly worse from contention). The warm-up must start after the software target exists.
- The ~0.3 s window of software rendering is imperceptible: full-frame software paints of a dense CJK document measure ~50 ms, and the swap is invisible (same frame, scroll-tested across it).
- Delay-loading urlmon.dll was also profiled and measured as noise; left out.

Tests green; verified old-vs-new side by side on the reporter corpus.