### PR TITLE
Images no longer vanish on render-target recreation

### DIFF
--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -367,10 +367,16 @@ bool createRenderTarget(App& app) {
         app.brush = nullptr;
     }
 
-    // D2D bitmaps are tied to the render target, so invalidate cached images
-    for (auto& [key, entry] : app.imageCache) {
-        if (entry.bitmap) { entry.bitmap->Release(); entry.bitmap = nullptr; }
-        entry.failed = false;  // retry on next layout
+    // D2D bitmaps are tied to the render target, so cached images must go.
+    // Entries are ERASED, not just nulled: getOrLoadImage returns any
+    // existing entry as-is, so a kept-but-empty entry would render as the
+    // alt-text placeholder forever instead of reloading. In-flight
+    // downloads keep their entry — the arriving result creates its bitmap
+    // on whatever target exists then.
+    for (auto it = app.imageCache.begin(); it != app.imageCache.end();) {
+        if (it->second.bitmap) { it->second.bitmap->Release(); it->second.bitmap = nullptr; }
+        if (it->second.pending) { ++it; }
+        else { it = app.imageCache.erase(it); }
     }
 
     RECT rc;

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -34,8 +34,10 @@ static App* g_app = nullptr;
 // Initializes the GPU driver on a worker thread after the first (software)
 // frame is on screen. D3D device creation costs ~200 ms dominated by
 // process-global driver initialization — done here once, the hardware
-// render target created on WM_APP_GPU_READY takes ~40 ms. The device is
-// kept alive so the driver state it initialized stays warm.
+// render target created on WM_APP_GPU_READY takes ~40 ms. The warm-up
+// device is held only until that target exists (its own device keeps the
+// driver initialized), then released — it pins tens of MB otherwise.
+static ID3D11Device* g_warmupDevice = nullptr;
 static void startGpuWarmup() {
     std::thread([] {
         ID3D11Device* device = nullptr;
@@ -46,9 +48,11 @@ static void startGpuWarmup() {
                           D3D11_SDK_VERSION, &device, &fl, &ctx);
         if (ctx) ctx->Release();
         if (device && g_app && g_app->hwnd) {
+            g_warmupDevice = device;
             PostMessageW(g_app->hwnd, WM_APP_GPU_READY, 0, 0);
+        } else if (device) {
+            device->Release();
         }
-        // device intentionally not released
     }).detach();
 }
 
@@ -806,7 +810,13 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (app && app->d2dFactory) {
                 app->width = LOWORD(lParam);
                 app->height = HIWORD(lParam);
-                createRenderTarget(*app);
+                // Resize the target in place: device resources (image and
+                // diagram bitmaps) stay valid, unlike a full recreation
+                if (!app->renderTarget ||
+                    FAILED(app->renderTarget->Resize(
+                        D2D1::SizeU(app->width, app->height)))) {
+                    createRenderTarget(*app);
+                }
                 app->layoutDirty = true;
                 InvalidateRect(hwnd, nullptr, FALSE);
             }
@@ -924,13 +934,17 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case WM_APP_GPU_READY:
             // Driver is warm: swap the startup software render target for a
-            // hardware one. Same resource-recreation path a resize takes,
-            // and the frame it redraws is pixel-identical.
+            // hardware one. The recreated target's own device keeps the
+            // driver initialized, so the warm-up device can go.
             if (app && !app->useHardwareRT) {
                 app->useHardwareRT = true;
                 createRenderTarget(*app);
                 app->layoutDirty = true;
                 InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            if (g_warmupDevice) {
+                g_warmupDevice->Release();
+                g_warmupDevice = nullptr;
             }
             return 0;
 


### PR DESCRIPTION
Fixes an image regression found while auditing the startup hybrid (#56) — with a twist: **the bug predates #56 and ships in v2.4.5**.

`createRenderTarget` nulls cached image bitmaps but keeps the entries, and `getOrLoadImage` returns any cached entry unconditionally — so after any render-target recreation, every image in the document renders as its alt-text placeholder forever. Verified live on the v2.4.5 release build: resize the window of a document with images and they all turn into placeholders. The #56 software→hardware swap promoted this from "on resize" to "on every launch ~0.3 s in".

Three changes:
- **`WM_SIZE` uses `ID2D1HwndRenderTarget::Resize`** (in place, device resources stay valid) instead of full recreation — recreation remains the fallback and still covers DPI changes, device loss, and the startup GPU swap. This also removes per-resize bitmap churn entirely.
- **`createRenderTarget` erases image cache entries** instead of keeping empty ones, so the post-swap relayout genuinely reloads images. In-flight downloads keep their entry; the arriving result creates its bitmap on whatever target exists then.
- **The GPU warm-up device is released once the hardware target exists** — the target's own device keeps the driver initialized; holding the warm-up device pinned tens of MB of working set for nothing.

Verified: local + remote images survive the startup GPU swap and window resizes (screenshots in both states), tests green.