### PR TITLE
Performance sweep: fewer DirectWrite layouts, cached paint resources

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -31,6 +31,7 @@ inline int64_t usElapsed(Clock::time_point start) {
 #define TIMER_CURSOR_BLINK 3
 #define TIMER_NOTIFICATION 4
 #define TIMER_ZOOM_APPLY 5
+#define TIMER_IMAGE_REFLOW 6
 
 // Posted to continue an incomplete document layout in time-budgeted chunks
 #define WM_APP_LAYOUT_CHUNK (WM_APP + 1)
@@ -134,6 +135,25 @@ struct App {
     // The warm-up thread flips this and the target is recreated on
     // WM_APP_GPU_READY, after the first frame is already on screen.
     bool useHardwareRT = false;
+
+    // Cached dashed stroke for mermaid edges (factory object: created once,
+    // survives render-target recreation)
+    ID2D1StrokeStyle* dashedStrokeStyle = nullptr;
+
+    // Editor paint-path line layouts, keyed by line start offset. Cleared on
+    // any text/format/width/wrap change; between changes the 500 ms cursor
+    // blink and idle repaints stop reshaping every visible line.
+    struct EditorCachedLayout {
+        IDWriteTextLayout* layout = nullptr;
+        size_t len = 0;
+    };
+    std::unordered_map<size_t, EditorCachedLayout> editorLineLayoutCache;
+    void clearEditorLineLayoutCache() {
+        for (auto& [start, entry] : editorLineLayoutCache) {
+            if (entry.layout) entry.layout->Release();
+        }
+        editorLineLayoutCache.clear();
+    }
     ID2D1SolidColorBrush* brush = nullptr;
     ID2D1DeviceContext* deviceContext = nullptr;  // For color emoji rendering
 
@@ -389,6 +409,10 @@ struct App {
         D2D1_COLOR_F stroke{};
         float strokeWidth = 1.0f;
         float radius = 0.0f;
+        // Cached polygon outline in LOCAL space (origin = rect top-left),
+        // built lazily on first draw. Local space keeps it valid across the
+        // exterior-lane x-shift that moves rects after layout.
+        ID2D1PathGeometry* geometry = nullptr;
     };
     struct LayoutConnector {
         std::vector<D2D1_POINT_2F> points;
@@ -528,6 +552,11 @@ struct App {
                 run.layout->Release();
             }
         }
+        for (auto& shape : layoutShapes) {
+            if (shape.geometry) {
+                shape.geometry->Release();
+            }
+        }
         layoutTextRuns.clear();
         layoutRects.clear();
         layoutLines.clear();
@@ -574,6 +603,7 @@ struct App {
         releaseImageCache();
         if (wicFactory) { wicFactory->Release(); wicFactory = nullptr; }
         if (brush) { brush->Release(); brush = nullptr; }
+        if (dashedStrokeStyle) { dashedStrokeStyle->Release(); dashedStrokeStyle = nullptr; }
         if (deviceContext) { deviceContext->Release(); deviceContext = nullptr; }
         if (renderTarget) { renderTarget->Release(); renderTarget = nullptr; }
         if (fontFallback) { fontFallback->Release(); fontFallback = nullptr; }

--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -61,6 +61,8 @@ void applyTheme(App& app, int themeIndex) {
 }
 
 void updateTextFormats(App& app) {
+    // Editor line layouts hold the old format/size
+    app.clearEditorLineLayoutCache();
     // Release existing formats
     if (app.textFormat) { app.textFormat->Release(); app.textFormat = nullptr; }
     if (app.headingFormat) { app.headingFormat->Release(); app.headingFormat = nullptr; }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -60,6 +60,20 @@ static IDWriteTextLayout* createEditorLineLayout(const App& app, size_t lineStar
     return layout;
 }
 
+// Paint-path variant: returns a cached layout owned by the cache — callers
+// must NOT release it. The cache is cleared on any text/format/width change.
+static IDWriteTextLayout* cachedEditorLineLayout(App& app, size_t lineStart, size_t lineLen) {
+    auto it = app.editorLineLayoutCache.find(lineStart);
+    if (it != app.editorLineLayoutCache.end()) {
+        if (it->second.len == lineLen) return it->second.layout;
+        if (it->second.layout) it->second.layout->Release();
+        app.editorLineLayoutCache.erase(it);
+    }
+    IDWriteTextLayout* layout = createEditorLineLayout(app, lineStart, lineLen);
+    app.editorLineLayoutCache[lineStart] = {layout, lineLen};
+    return layout;
+}
+
 // Caret x,y within a (possibly wrapped) line layout for the caret placed
 // before column `col`
 static void editorCaretXY(IDWriteTextLayout* layout, size_t col, float& x, float& y) {
@@ -118,6 +132,7 @@ static size_t editorNextCharEnd(const App& app, size_t pos) {
 static void rebuildEditorRowMetrics(App& app);
 
 void rebuildLineStarts(App& app) {
+    app.clearEditorLineLayoutCache();
     app.editorLineStarts.clear();
     app.editorLineStarts.push_back(0);
     for (size_t i = 0; i < app.editorText.size(); i++) {
@@ -676,6 +691,7 @@ void exitEditMode(App& app) {
     }
 
     app.editMode = false;
+    app.clearEditorLineLayoutCache();
     app.editorText.clear();
     app.editorLineStarts.clear();
     app.undoStack.clear();
@@ -960,6 +976,7 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             }
             case 'P': {
                 app.editorShowPreview = !app.editorShowPreview;
+                app.clearEditorLineLayoutCache();
                 if (app.editorShowPreview) {
                     // Re-parse so the preview catches up with edits made
                     // while it was hidden
@@ -979,6 +996,7 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             }
             case 'W': {
                 app.editorWordWrap = !app.editorWordWrap;
+                app.clearEditorLineLayoutCache();
                 app.editorDesiredCol = -1;
                 app.editorDesiredX = -1.0f;
                 rebuildEditorRowMetrics(app);
@@ -1451,6 +1469,7 @@ void handleEditorMouseMove(App& app, HWND hwnd, int x, int y) {
         float dx = (float)x - app.separatorDragStartX;
         float newRatio = app.separatorDragStartRatio + dx / app.width;
         app.editorSplitRatio = std::max(0.2f, std::min(0.8f, newRatio));
+        app.clearEditorLineLayoutCache();
         app.layoutDirty = true;
         InvalidateRect(hwnd, nullptr, FALSE);
         return;
@@ -1557,7 +1576,7 @@ static void renderEditorWrapped(App& app, float editorWidth) {
 
         size_t lineStart = app.editorLineStarts[i];
         size_t lineLen = getLineLength(app, i);
-        IDWriteTextLayout* lineLayout = createEditorLineLayout(app, lineStart, lineLen);
+        IDWriteTextLayout* lineLayout = cachedEditorLineLayout(app, lineStart, lineLen);
 
         // Line number on the first visual row of the line
         wchar_t lineNum[16];
@@ -1629,7 +1648,6 @@ static void renderEditorWrapped(App& app, float editorWidth) {
                 app.brush);
         }
 
-        if (lineLayout) lineLayout->Release();
     }
 
     app.editorContentHeight = padding * 2 + app.editorTotalRows * lineHeight;
@@ -1710,7 +1728,7 @@ void renderEditor(App& app, float editorWidth) {
         // One DirectWrite layout per visible line: reused for highlight
         // metrics and drawing so overlays always match the actual glyphs
         // (CJK and other full-width characters are wider than charWidth)
-        IDWriteTextLayout* lineLayout = createEditorLineLayout(app, lineStart, lineLen);
+        IDWriteTextLayout* lineLayout = cachedEditorLineLayout(app, lineStart, lineLen);
 
         // Line number
         wchar_t lineNum[16];
@@ -1780,7 +1798,6 @@ void renderEditor(App& app, float editorWidth) {
                 D2D1::Point2F(gutterWidth + padding, lineY), lineLayout, app.brush);
         }
 
-        if (lineLayout) lineLayout->Release();
     }
 
     // Cursor (blink state driven by TIMER_CURSOR_BLINK)
@@ -1789,9 +1806,8 @@ void renderEditor(App& app, float editorWidth) {
         size_t curCol = getColFromPos(app, app.editorCursorPos);
         size_t curLineStart = app.editorLineStarts[curLine];
         size_t curLineLen = getLineLength(app, curLine);
-        IDWriteTextLayout* curLayout = createEditorLineLayout(app, curLineStart, curLineLen);
+        IDWriteTextLayout* curLayout = cachedEditorLineLayout(app, curLineStart, curLineLen);
         float curX = gutterWidth + padding + editorColToX(app, curLayout, std::min(curCol, curLineLen));
-        if (curLayout) curLayout->Release();
         float curY = padding + curLine * lineHeight - app.editorScrollY;
 
         app.brush->SetColor(app.theme.text);

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -197,8 +197,9 @@ render_document:
         app.drawCalls++;
     }
 
-    ID2D1StrokeStyle* dashedStrokeStyle = nullptr;
-    if (std::any_of(
+    // Dashed stroke is a factory object: create once, reuse every frame
+    if (!app.dashedStrokeStyle &&
+        std::any_of(
             app.layoutConnectors.begin(), app.layoutConnectors.end(),
             [](const App::LayoutConnector& connector) { return connector.dashed; })) {
         D2D1_STROKE_STYLE_PROPERTIES properties = {
@@ -211,8 +212,9 @@ render_document:
             0.0f,
         };
         app.d2dFactory->CreateStrokeStyle(
-            properties, nullptr, 0, &dashedStrokeStyle);
+            properties, nullptr, 0, &app.dashedStrokeStyle);
     }
+    ID2D1StrokeStyle* dashedStrokeStyle = app.dashedStrokeStyle;
 
     for (const auto& connector : app.layoutConnectors) {
         if (connector.bounds.bottom < viewportTop - cullMargin ||
@@ -265,39 +267,49 @@ render_document:
             }
         }
     }
-    if (dashedStrokeStyle) dashedStrokeStyle->Release();
-
-    auto drawPolygon = [&](const D2D1_POINT_2F* points, size_t count,
-                           const App::LayoutShape& shape) {
+    // Draws a cached polygon geometry (built lazily in local space) at the
+    // shape's screen position via a translation transform
+    auto drawPolygon = [&](const D2D1_POINT_2F* localPoints, size_t count,
+                           App::LayoutShape& shape) {
         if (count < 3) return;
 
-        ID2D1PathGeometry* geometry = nullptr;
-        if (FAILED(app.d2dFactory->CreatePathGeometry(&geometry)) || !geometry) return;
-
-        ID2D1GeometrySink* sink = nullptr;
-        if (SUCCEEDED(geometry->Open(&sink)) && sink) {
-            sink->BeginFigure(points[0], D2D1_FIGURE_BEGIN_FILLED);
-            sink->AddLines(points + 1, static_cast<UINT32>(count - 1));
-            sink->EndFigure(D2D1_FIGURE_END_CLOSED);
-            sink->Close();
-            sink->Release();
-
-            if (shape.fill.a > 0.0f) {
-                app.brush->SetColor(shape.fill);
-                app.renderTarget->FillGeometry(geometry, app.brush);
-                app.drawCalls++;
-            }
-            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
-                app.brush->SetColor(shape.stroke);
-                app.renderTarget->DrawGeometry(
-                    geometry, app.brush, shape.strokeWidth);
-                app.drawCalls++;
+        if (!shape.geometry) {
+            ID2D1PathGeometry* geometry = nullptr;
+            if (FAILED(app.d2dFactory->CreatePathGeometry(&geometry)) || !geometry) return;
+            ID2D1GeometrySink* sink = nullptr;
+            if (SUCCEEDED(geometry->Open(&sink)) && sink) {
+                sink->BeginFigure(localPoints[0], D2D1_FIGURE_BEGIN_FILLED);
+                sink->AddLines(localPoints + 1, static_cast<UINT32>(count - 1));
+                sink->EndFigure(D2D1_FIGURE_END_CLOSED);
+                sink->Close();
+                sink->Release();
+                shape.geometry = geometry;
+            } else {
+                geometry->Release();
+                return;
             }
         }
-        geometry->Release();
+
+        D2D1_MATRIX_3X2_F previous;
+        app.renderTarget->GetTransform(&previous);
+        app.renderTarget->SetTransform(
+            D2D1::Matrix3x2F::Translation(shape.rect.left - app.scrollX,
+                                          shape.rect.top - app.scrollY) * previous);
+        if (shape.fill.a > 0.0f) {
+            app.brush->SetColor(shape.fill);
+            app.renderTarget->FillGeometry(shape.geometry, app.brush);
+            app.drawCalls++;
+        }
+        if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+            app.brush->SetColor(shape.stroke);
+            app.renderTarget->DrawGeometry(
+                shape.geometry, app.brush, shape.strokeWidth);
+            app.drawCalls++;
+        }
+        app.renderTarget->SetTransform(previous);
     };
 
-    for (const auto& shape : app.layoutShapes) {
+    for (auto& shape : app.layoutShapes) {
         if (shape.rect.bottom < viewportTop - cullMargin ||
             shape.rect.top > viewportBottom + cullMargin ||
             shape.rect.right < viewportLeft - cullMargin ||
@@ -312,28 +324,29 @@ render_document:
             shape.rect.bottom - app.scrollY);
 
         if (shape.type == App::LayoutShapeType::Diamond) {
-            float centerX = (rect.left + rect.right) * 0.5f;
-            float centerY = (rect.top + rect.bottom) * 0.5f;
+            float w = shape.rect.right - shape.rect.left;
+            float h = shape.rect.bottom - shape.rect.top;
             D2D1_POINT_2F points[] = {
-                D2D1::Point2F(centerX, rect.top),
-                D2D1::Point2F(rect.right, centerY),
-                D2D1::Point2F(centerX, rect.bottom),
-                D2D1::Point2F(rect.left, centerY),
+                D2D1::Point2F(w * 0.5f, 0),
+                D2D1::Point2F(w, h * 0.5f),
+                D2D1::Point2F(w * 0.5f, h),
+                D2D1::Point2F(0, h * 0.5f),
             };
             drawPolygon(points, 4, shape);
             continue;
         }
 
         if (shape.type == App::LayoutShapeType::Hexagon) {
-            float inset = (rect.right - rect.left) * 0.18f;
-            float centerY = (rect.top + rect.bottom) * 0.5f;
+            float w = shape.rect.right - shape.rect.left;
+            float h = shape.rect.bottom - shape.rect.top;
+            float inset = w * 0.18f;
             D2D1_POINT_2F points[] = {
-                D2D1::Point2F(rect.left + inset, rect.top),
-                D2D1::Point2F(rect.right - inset, rect.top),
-                D2D1::Point2F(rect.right, centerY),
-                D2D1::Point2F(rect.right - inset, rect.bottom),
-                D2D1::Point2F(rect.left + inset, rect.bottom),
-                D2D1::Point2F(rect.left, centerY),
+                D2D1::Point2F(inset, 0),
+                D2D1::Point2F(w - inset, 0),
+                D2D1::Point2F(w, h * 0.5f),
+                D2D1::Point2F(w - inset, h),
+                D2D1::Point2F(inset, h),
+                D2D1::Point2F(0, h * 0.5f),
             };
             drawPolygon(points, 6, shape);
             continue;
@@ -810,6 +823,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (app && app->d2dFactory) {
                 app->width = LOWORD(lParam);
                 app->height = HIWORD(lParam);
+                app->clearEditorLineLayoutCache();
                 // Resize the target in place: device resources (image and
                 // diagram bitmaps) stay valid, unlike a full recreation
                 if (!app->renderTarget ||
@@ -913,6 +927,12 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 } else {
                     KillTimer(hwnd, TIMER_NOTIFICATION);
                 }
+            }
+            if (wParam == TIMER_IMAGE_REFLOW && app) {
+                // One relayout for however many images arrived since armed
+                KillTimer(hwnd, TIMER_IMAGE_REFLOW);
+                app->layoutDirty = true;
+                InvalidateRect(hwnd, nullptr, FALSE);
             }
             if (wParam == TIMER_ZOOM_APPLY && app) {
                 if (app->zoomFactor != app->appliedZoomFactor) {

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -124,6 +124,11 @@ static void rollbackTo(App& app, const LayoutSnapshot& s) {
             app.layoutTextRuns[i].layout->Release();
         }
     }
+    for (size_t i = s.shapes; i < app.layoutShapes.size(); i++) {
+        if (app.layoutShapes[i].geometry) {
+            app.layoutShapes[i].geometry->Release();
+        }
+    }
     app.layoutTextRuns.resize(s.textRuns);
     app.layoutRects.resize(s.rects);
     app.layoutLines.resize(s.lines);
@@ -523,13 +528,16 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
 
         // Measure the whole element once: cluster metrics give every break
         // unit's width without creating one IDWriteTextLayout per unit.
+        // The measurement layout is kept alive: when the element ends up as
+        // a single segment (no wrap — the common case), it IS the segment's
+        // layout and no second CreateTextLayout happens.
         std::vector<float> cumW(text.length() + 1, -1.0f);
         std::vector<bool> isBoundary(text.length() + 1, false);
         cumW[0] = 0.0f;
         isBoundary[0] = true;
         isBoundary[text.length()] = true;
+        LayoutInfo measureInfo = createLayout(app, text, format, lineHeight, app.bodyTypography);
         {
-            LayoutInfo measureInfo = createLayout(app, text, format, lineHeight, app.bodyTypography);
             if (measureInfo.layout) {
                 UINT32 clusterCount = 0;
                 measureInfo.layout->GetClusterMetrics(nullptr, 0, &clusterCount);
@@ -549,7 +557,6 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                         }
                     }
                 }
-                measureInfo.layout->Release();
             }
             // Fill positions that fall inside clusters (break opportunities
             // never land there)
@@ -572,7 +579,21 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
             segOpen = false;
             if (segEnd <= segStart) { segWords.clear(); return; }
             std::wstring_view segText(text.data() + segStart, segEnd - segStart);
-            LayoutInfo info = createLayout(app, segText, format, lineHeight, app.bodyTypography);
+
+            // Single-segment element: the measurement layout already shaped
+            // exactly this text (a space-only tail draws nothing) — hand it
+            // over instead of shaping a second time
+            bool coversAll = segStart == 0 && measureInfo.layout != nullptr;
+            for (size_t i = segEnd; coversAll && i < text.length(); i++) {
+                if (text[i] != L' ') coversAll = false;
+            }
+            LayoutInfo info;
+            if (coversAll) {
+                info = measureInfo;
+                measureInfo.layout = nullptr;
+            } else {
+                info = createLayout(app, segText, format, lineHeight, app.bodyTypography);
+            }
             float segWidth = widthOf(segStart, segEnd);
             if (hasBg) {
                 app.layoutRects.push_back({
@@ -679,6 +700,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
             pos = bp;
         }
         flushSegment(lastWordEnd);
+        if (measureInfo.layout) measureInfo.layout->Release();
 
         app.docText += text;
 
@@ -1730,6 +1752,11 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
     std::vector<float> colWidths(colCount, minColWidth);
     std::vector<float> rowHeights(rows.size(), lineHeight + cellPadding * 2);
     std::vector<std::vector<int>> cellAligns(rows.size(), std::vector<int>(colCount, 0));
+    // Per-cell natural width + plain-text flag: a simple cell that fits its
+    // final column is exactly one line tall, so the height-measuring trial
+    // layout in pass 1b can be skipped for it entirely
+    std::vector<std::vector<float>> cellNatural(rows.size(), std::vector<float>(colCount, 0.0f));
+    std::vector<std::vector<uint8_t>> cellSimple(rows.size(), std::vector<uint8_t>(colCount, 0));
 
     for (size_t r = 0; r < rows.size(); r++) {
         const auto& row = rows[r];
@@ -1763,6 +1790,9 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
             }
             float needed = textWidth + cellPadding * 2 + 6.0f * scale;
             if (needed > colWidths[c]) colWidths[c] = needed;
+            cellNatural[r][c] = needed;
+            cellSimple[r][c] = cell->children.size() == 1 &&
+                               cell->children[0]->type == ElementType::Text;
         }
     }
 
@@ -1827,6 +1857,10 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
         for (size_t c = 0; c < row->children.size() && c < (size_t)colCount; c++) {
             const auto& cell = row->children[c];
             if (cell->children.empty()) continue;
+
+            // A plain-text cell whose natural width fits the column is one
+            // line tall — no trial layout needed (the common case)
+            if (cellSimple[r][c] && cellNatural[r][c] <= colWidths[c]) continue;
 
             float cellW = colWidths[c] - cellPadding * 2;
             LayoutSnapshot snap = takeSnapshot(app);
@@ -2182,9 +2216,10 @@ void completeAsyncImage(App& app, void* asyncResult) {
     app.imageCache[result->src] = entry;
     delete result;
 
-    // Reflow with the real image dimensions
-    app.layoutDirty = true;
-    if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
+    // Reflow with the real image dimensions — but coalesced: several images
+    // finishing close together (the common case when a document loads) get
+    // one relayout on the timer instead of a full document layout each
+    if (app.hwnd) SetTimer(app.hwnd, TIMER_IMAGE_REFLOW, 60, nullptr);
 }
 
 void ensureLayoutComplete(App& app) {


### PR DESCRIPTION
Second profiling round (instrumented per-block-type accumulators + external review findings). DirectWrite `CreateTextLayout` was ~65% of all layout time (27k calls on the stress document), so every change here removes redundant shaping or caches paint resources:

| Change | Effect |
|---|---|
| Single-segment inline elements reuse their measurement layout | largest win — the common case shapes once, not twice |
| Simple fitting table cells skip the pass-1b trial layout | tables no longer triple-shape plain cells |
| Image arrivals coalesce into one relayout (60 ms timer) | N images → 1 relayout instead of N full relayouts |
| Dashed stroke style cached; mermaid polygon geometries cached per shape (local space, shift-immune) | no per-frame factory object churn |
| Editor line layouts cached, invalidated on text/format/width/wrap changes | cursor blink stops reshaping every visible line |

**Measured:** stress-document cumulative layout **109.7 → 78.7 ms (−28%)**; edit-mode idle CPU **46.9 ms/5 s → 0**. Draw calls identical, and renders are pixel-identical (0 sampled diffs) on the nested-spans, CJK-fallback, cn-test, and table stress views. Editor typing/caret/selection verified interactively. Tests green.

Deliberately not done: viewport-cull bucketing (finding: linear scan costs 0.5 ms/paint at 64 KB — reordering the draw arrays risks painter's-algorithm stacking regressions for no measurable win at realistic document sizes).