### PR TITLE
Right-click context menu

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -263,6 +263,17 @@ struct App {
     bool folderBrowserInputSelectAll = false; // Whole input selected: next keystroke replaces it
     bool folderBrowserInputError = false;    // Last commit failed (bad path/name): red border
 
+    // Right-click context menu overlay
+    bool showContextMenu = false;
+    // The mouse-up of a menu-item click must not reach the overlay handlers:
+    // an action that opens the TOC or theme chooser would otherwise be
+    // closed instantly by its own click's release landing "outside the panel"
+    bool swallowNextMouseUp = false;
+    float contextMenuX = 0.0f;        // Top-left, clamped into the window
+    float contextMenuY = 0.0f;
+    int hoveredContextMenuItem = -1;
+    float contextMenuAnimation = 0.0f;
+
     // Help overlay
     bool showHelp = false;
     float helpAnimation = 0.0f;

--- a/include/input.h
+++ b/include/input.h
@@ -10,6 +10,7 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam);
 void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam);
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam);
 void handleKeyDown(App& app, HWND hwnd, WPARAM wParam);
+void handleContextMenu(App& app, HWND hwnd, LPARAM lParam);
 void handleCharInput(App& app, HWND hwnd, WPARAM wParam);
 void handleDropFiles(App& app, HWND hwnd, WPARAM wParam);
 void handleFileWatchTimer(App& app, HWND hwnd);

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -9,4 +9,25 @@ void renderToc(App& app);
 void renderThemeChooser(App& app);
 void renderHelpOverlay(App& app);
 
+// Right-click context menu: theme-drawn like the other overlays.
+// Item indices are shared between rendering and input handling.
+enum ContextMenuItem {
+    CTX_COPY = 0,
+    CTX_SELECT_ALL,
+    CTX_EDIT,
+    CTX_SEARCH,
+    CTX_TOC,
+    CTX_BROWSE,
+    CTX_REVEAL,
+    CTX_THEME,
+    CTX_HELP,
+    CTX_ITEM_COUNT
+};
+void renderContextMenu(App& app);
+// Opens at (x, y) client coordinates, clamped so the menu stays on screen
+void openContextMenu(App& app, float x, float y);
+// Item index under the point, or -1 (separators and gaps count as none)
+int contextMenuItemAt(const App& app, float x, float y);
+bool contextMenuItemEnabled(const App& app, int item);
+
 #endif // TINTA_OVERLAYS_H

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -7,6 +7,7 @@
 #include "d2d_init.h"
 #include "settings.h"
 #include "render.h"
+#include "overlays.h"
 
 #include <windowsx.h>
 #include <shellapi.h>
@@ -197,6 +198,11 @@ static void applyZoomDelta(App& app, float delta) {
 }
 
 void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    if (app.showContextMenu) {
+        app.showContextMenu = false;
+        app.contextMenuAnimation = 0;
+        app.hoveredContextMenuItem = -1;
+    }
     bool ctrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
     float delta = (float)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
 
@@ -517,7 +523,126 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     }
 }
 
+
+// --- Right-click context menu ---
+
+static void closeContextMenu(App& app) {
+    app.showContextMenu = false;
+    app.contextMenuAnimation = 0.0f;
+    app.hoveredContextMenuItem = -1;
+}
+
+static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
+    switch (item) {
+        case CTX_COPY:
+            if (app.hasSelection && !app.selectedText.empty()) {
+                copyToClipboard(hwnd, app.selectedText);
+                app.hasSelection = false;
+                app.selectedText.clear();
+                app.showCopiedNotification = true;
+                app.copiedNotificationAlpha = 1.0f;
+                app.copiedNotificationStart = std::chrono::steady_clock::now();
+                startNotificationTimer(app);
+            }
+            break;
+        case CTX_SELECT_ALL:
+            if (app.root) {
+                app.selectedText.clear();
+                extractText(app.root, app.selectedText);
+                app.hasSelection = true;
+            }
+            break;
+        case CTX_EDIT:
+            enterEditMode(app);
+            break;
+        case CTX_SEARCH:
+            app.showSearch = true;
+            app.searchActive = true;
+            app.searchAnimation = 0;
+            app.searchQuery.clear();
+            app.searchMatches.clear();
+            app.searchCurrentIndex = 0;
+            app.searchJustOpened = false;
+            updateBlinkTimer(app);
+            break;
+        case CTX_TOC:
+            ensureLayoutComplete(app);
+            app.showToc = true;
+            app.tocAnimation = 0;
+            app.tocScroll = 0;
+            app.hoveredTocIndex = -1;
+            break;
+        case CTX_BROWSE:
+            app.showFolderBrowser = true;
+            closeFolderBrowserInput(app);
+            app.folderBrowserAnimation = 0;
+            if (!app.currentFile.empty()) {
+                app.folderBrowserPath = getDirectoryFromFile(app.currentFile);
+            } else {
+                wchar_t cwd[MAX_PATH];
+                if (GetCurrentDirectoryW(MAX_PATH, cwd)) {
+                    app.folderBrowserPath = cwd;
+                }
+            }
+            populateFolderItems(app);
+            break;
+        case CTX_REVEAL:
+            if (!app.currentFile.empty()) {
+                std::wstring widePath = toWide(app.currentFile);
+                wchar_t fullPath[MAX_PATH];
+                if (GetFullPathNameW(widePath.c_str(), MAX_PATH, fullPath, nullptr)) {
+                    std::wstring params = L"/select,\"" + std::wstring(fullPath) + L"\"";
+                    ShellExecuteW(nullptr, L"open", L"explorer.exe", params.c_str(),
+                                  nullptr, SW_SHOWNORMAL);
+                }
+            }
+            break;
+        case CTX_THEME:
+            app.showThemeChooser = true;
+            app.themeChooserAnimation = 0;
+            break;
+        case CTX_HELP:
+            app.showHelp = true;
+            app.helpAnimation = 0;
+            break;
+    }
+}
+
+void handleContextMenu(App& app, HWND hwnd, LPARAM lParam) {
+    // Viewer mode only, and never on top of another overlay
+    if (app.editMode || app.showSearch || app.showThemeChooser || app.showToc ||
+        app.showFolderBrowser || app.showHelp) {
+        return;
+    }
+
+    POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+    if (pt.x == -1 && pt.y == -1) {
+        // Keyboard menu key: open near the viewport center
+        pt.x = app.width / 2;
+        pt.y = app.height / 2;
+    } else {
+        ScreenToClient(hwnd, &pt);
+    }
+    openContextMenu(app, (float)pt.x, (float)pt.y);
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
 void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    // Context menu: a click lands on an item or dismisses the menu; either
+    // way the click is consumed
+    if (app.showContextMenu) {
+        int clickX = GET_X_LPARAM(lParam);
+        int clickY = GET_Y_LPARAM(lParam);
+        int item = contextMenuItemAt(app, (float)clickX, (float)clickY);
+        closeContextMenu(app);
+        app.swallowNextMouseUp = true;
+        if (item >= 0 && contextMenuItemEnabled(app, item)) {
+            invokeContextMenuAction(app, hwnd, item);
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     // Edit mode: route to editor or preview
     if (app.editMode) {
         int x = GET_X_LPARAM(lParam);
@@ -711,6 +836,11 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 }
 
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    // Release belonging to a context-menu item click: already handled
+    if (app.swallowNextMouseUp) {
+        app.swallowNextMouseUp = false;
+        return;
+    }
     // Help scrollbar release
     if (app.helpScrollbarDragging) {
         app.helpScrollbarDragging = false;
@@ -1129,8 +1259,11 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     } else {
         switch (wParam) {
             case VK_ESCAPE:
-                // Priority: Help > Search > FolderBrowser > TOC > Theme chooser > Quit
-                if (app.showHelp) {
+                // Priority: ContextMenu > Help > Search > FolderBrowser > TOC > Theme chooser > Quit
+                if (app.showContextMenu) {
+                    app.showContextMenu = false;
+                    app.contextMenuAnimation = 0;
+                } else if (app.showHelp) {
                     app.showHelp = false;
                     app.helpAnimation = 0;
                 } else if (app.showSearch) {

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -794,6 +794,7 @@ render_document:
     if (app.showSearch && !app.editMode) renderSearchOverlay(app);
     if (app.showFolderBrowser) renderFolderBrowser(app);
     if (app.showToc) renderToc(app);
+    if (app.showContextMenu) renderContextMenu(app);
     if (app.showThemeChooser) renderThemeChooser(app);
     if (app.showHelp) renderHelpOverlay(app);
 
@@ -950,6 +951,10 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             // A background image download finished: swap it into the cache
             // and reflow (handler takes ownership of the result)
             if (app) completeAsyncImage(*app, (void*)lParam);
+            return 0;
+
+        case WM_CONTEXTMENU:
+            if (app) handleContextMenu(*app, hwnd, lParam);
             return 0;
 
         case WM_APP_GPU_READY:

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -990,3 +990,166 @@ void renderHelpOverlay(App& app) {
             app.brush);
     }
 }
+
+// --- Right-click context menu ---
+//
+// Drawn in the current theme like the folder browser and theme chooser.
+// Every entry shows its keyboard shortcut, so the menu doubles as
+// discoverable documentation for the single-key commands.
+
+namespace {
+
+struct ContextMenuEntry {
+    const wchar_t* label;
+    const wchar_t* shortcut;
+    bool separatorAfter;
+};
+
+const ContextMenuEntry CTX_ENTRIES[CTX_ITEM_COUNT] = {
+    { L"Copy",               L"Ctrl+C", false },
+    { L"Select All",         L"Ctrl+A", true  },
+    { L"Edit",               L":",      false },
+    { L"Search",             L"F",      false },
+    { L"Table of Contents",  L"Tab",    true  },
+    { L"Browse Files",       L"B",      false },
+    { L"Reveal in Explorer", L"",       true  },
+    { L"Theme",              L"T",      false },
+    { L"Help",               L"?",      false },
+};
+
+float ctxItemHeight(const App& app) { return dpi(app, 30.0f); }
+float ctxSeparatorHeight(const App& app) { return dpi(app, 9.0f); }
+float ctxWidth(const App& app) { return dpi(app, 210.0f); }
+float ctxPadding(const App& app) { return dpi(app, 6.0f); }
+
+float ctxTotalHeight(const App& app) {
+    float h = ctxPadding(app) * 2;
+    for (const auto& entry : CTX_ENTRIES) {
+        h += ctxItemHeight(app);
+        if (entry.separatorAfter) h += ctxSeparatorHeight(app);
+    }
+    return h;
+}
+
+// Top y of the item at `index` relative to the menu top
+float ctxItemTop(const App& app, int index) {
+    float y = ctxPadding(app);
+    for (int i = 0; i < index; i++) {
+        y += ctxItemHeight(app);
+        if (CTX_ENTRIES[i].separatorAfter) y += ctxSeparatorHeight(app);
+    }
+    return y;
+}
+
+} // namespace
+
+bool contextMenuItemEnabled(const App& app, int item) {
+    switch (item) {
+        case CTX_COPY:   return app.hasSelection && !app.selectedText.empty();
+        case CTX_REVEAL: return !app.currentFile.empty();
+        default:         return item >= 0 && item < CTX_ITEM_COUNT;
+    }
+}
+
+int contextMenuItemAt(const App& app, float x, float y) {
+    if (x < app.contextMenuX || x > app.contextMenuX + ctxWidth(app)) return -1;
+    float rel = y - app.contextMenuY;
+    for (int i = 0; i < CTX_ITEM_COUNT; i++) {
+        float top = ctxItemTop(app, i);
+        if (rel >= top && rel < top + ctxItemHeight(app)) return i;
+    }
+    return -1;
+}
+
+void openContextMenu(App& app, float x, float y) {
+    float w = ctxWidth(app);
+    float h = ctxTotalHeight(app);
+    app.contextMenuX = std::max(0.0f, std::min(x, (float)app.width - w));
+    app.contextMenuY = std::max(0.0f, std::min(y, (float)app.height - h));
+    app.showContextMenu = true;
+    app.hoveredContextMenuItem = -1;
+    app.contextMenuAnimation = 0.0f;
+}
+
+void renderContextMenu(App& app) {
+    if (app.contextMenuAnimation < 1.0f) {
+        float prev = app.contextMenuAnimation;
+        app.contextMenuAnimation = std::min(1.0f, app.contextMenuAnimation + 0.25f);
+        if (app.contextMenuAnimation != prev)
+            InvalidateRect(app.hwnd, nullptr, FALSE);
+    }
+    float anim = app.contextMenuAnimation;
+
+    IDWriteTextFormat* format = app.folderBrowserFormat;
+    if (!format) return;
+
+    float x = app.contextMenuX;
+    float y = app.contextMenuY;
+    float w = ctxWidth(app);
+    float h = ctxTotalHeight(app);
+
+    D2D1_COLOR_F panelBg = app.theme.isDark ? hexColor(0x1E1E1E, 0.97f)
+                                            : hexColor(0xF8F8F8, 0.97f);
+    D2D1_COLOR_F borderColor = app.theme.isDark ? hexColor(0x3A3A40, 0.9f)
+                                                : hexColor(0xC8C8C8, 0.9f);
+    app.brush->SetColor(panelBg);
+    app.renderTarget->FillRoundedRectangle(
+        D2D1::RoundedRect(D2D1::RectF(x, y, x + w, y + h), 6, 6), app.brush);
+    app.brush->SetColor(borderColor);
+    app.renderTarget->DrawRoundedRectangle(
+        D2D1::RoundedRect(D2D1::RectF(x, y, x + w, y + h), 6, 6), app.brush, 1.0f);
+
+    app.hoveredContextMenuItem = contextMenuItemAt(app, app.mouseX, app.mouseY);
+
+    float pad = ctxPadding(app);
+    float itemH = ctxItemHeight(app);
+    float inset = dpi(app, 12.0f);
+    for (int i = 0; i < CTX_ITEM_COUNT; i++) {
+        float top = y + ctxItemTop(app, i);
+        bool enabled = contextMenuItemEnabled(app, i);
+
+        if (i == app.hoveredContextMenuItem && enabled) {
+            D2D1_COLOR_F hoverColor = app.theme.accent;
+            hoverColor.a = 0.18f * anim;
+            app.brush->SetColor(hoverColor);
+            app.renderTarget->FillRoundedRectangle(
+                D2D1::RoundedRect(
+                    D2D1::RectF(x + pad, top, x + w - pad, top + itemH), 4, 4),
+                app.brush);
+        }
+
+        D2D1_COLOR_F textColor = app.theme.text;
+        textColor.a = (enabled ? 1.0f : 0.35f) * anim;
+        app.brush->SetColor(textColor);
+        float textY = top + (itemH - dpi(app, 18.0f)) / 2;
+        app.renderTarget->DrawText(
+            CTX_ENTRIES[i].label, (UINT32)wcslen(CTX_ENTRIES[i].label), format,
+            D2D1::RectF(x + inset, textY, x + w - inset, top + itemH), app.brush);
+
+        if (CTX_ENTRIES[i].shortcut[0]) {
+            IDWriteTextLayout* hint = nullptr;
+            app.dwriteFactory->CreateTextLayout(
+                CTX_ENTRIES[i].shortcut, (UINT32)wcslen(CTX_ENTRIES[i].shortcut),
+                format, 1000.0f, itemH, &hint);
+            if (hint) {
+                DWRITE_TEXT_METRICS metrics{};
+                hint->GetMetrics(&metrics);
+                D2D1_COLOR_F hintColor = app.theme.text;
+                hintColor.a = 0.4f * anim;
+                app.brush->SetColor(hintColor);
+                app.renderTarget->DrawTextLayout(
+                    D2D1::Point2F(x + w - inset - metrics.width, textY),
+                    hint, app.brush);
+                hint->Release();
+            }
+        }
+
+        if (CTX_ENTRIES[i].separatorAfter) {
+            float sepY = top + itemH + ctxSeparatorHeight(app) * 0.5f;
+            app.brush->SetColor(borderColor);
+            app.renderTarget->DrawLine(
+                D2D1::Point2F(x + pad, sepY), D2D1::Point2F(x + w - pad, sepY),
+                app.brush, 1.0f);
+        }
+    }
+}


### PR DESCRIPTION
Adds the context menu requested in-session: theme-drawn like the folder browser and theme chooser (not a native Win32 menu — deliberate, to match Tinta's 10 in-app themes).

**Items**: Copy / Select All, Edit, Search, Table of Contents, Browse Files, Reveal in Explorer, Theme, Help — each with its keyboard shortcut right-aligned, so the menu doubles as shortcut documentation. Copy is disabled without a selection, Reveal in Explorer without a file.

**Behavior**: opens on right-click or the keyboard menu key (`WM_CONTEXTMENU`), position clamped into the window; hover highlight in the theme accent; Esc / wheel / click-outside dismiss; viewer mode only (never over another overlay).

**One subtle bug found while testing**: the TOC and theme-chooser click handling lives in mouse-UP — so a menu action opening the TOC was instantly closed by its own click's release landing "outside the panel". The release of a menu-item click is now swallowed.

Verified interactively: menu opens/renders in-theme (Copy correctly dimmed), Edit opens edit mode, TOC opens and stays open, click-outside dismisses, Esc dismisses. Tests green.