### PR TITLE
Context menu: fix Select All after a drag selection, hover over code blocks

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -305,6 +305,27 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     app.mouseX = GET_X_LPARAM(lParam);
     app.mouseY = GET_Y_LPARAM(lParam);
 
+    // Context menu open: hover tracks menu items only — document hover
+    // (code-block copy button, link underline) stays suppressed underneath
+    if (app.showContextMenu) {
+        bool repaint = false;
+        int item = contextMenuItemAt(app, (float)app.mouseX, (float)app.mouseY);
+        if (item != app.hoveredContextMenuItem) {
+            app.hoveredContextMenuItem = item;
+            repaint = true;
+        }
+        if (app.hoveredCodeBlock != -1) {
+            app.hoveredCodeBlock = -1;
+            repaint = true;
+        }
+        if (!app.hoveredLink.empty()) {
+            app.hoveredLink.clear();
+            repaint = true;
+        }
+        if (repaint) InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     // Help overlay scrollbar dragging
     if (app.helpScrollbarDragging) {
         float maxScroll = std::max(0.0f, app.helpContentHeight - app.helpVisibleHeight);
@@ -550,6 +571,10 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
                 app.selectedText.clear();
                 extractText(app.root, app.selectedText);
                 app.hasSelection = true;
+                // Equal coords are the renderer's select-all signal; a stale
+                // drag range would re-extract the old selection every frame
+                app.selStartX = app.selEndX = 0;
+                app.selStartY = app.selEndY = 0;
             }
             break;
         case CTX_EDIT:
@@ -1213,6 +1238,10 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                     app.selectedText.clear();
                     extractText(app.root, app.selectedText);
                     app.hasSelection = true;
+                    // Equal coords signal select-all to the renderer; clear
+                    // any drag range so it doesn't overwrite the selection
+                    app.selStartX = app.selEndX = 0;
+                    app.selStartY = app.selEndY = 0;
                 }
                 break;
             }

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1069,6 +1069,8 @@ void openContextMenu(App& app, float x, float y) {
     app.showContextMenu = true;
     app.hoveredContextMenuItem = -1;
     app.contextMenuAnimation = 0.0f;
+    app.hoveredCodeBlock = -1;
+    app.hoveredLink.clear();
 }
 
 void renderContextMenu(App& app) {


### PR DESCRIPTION
Fixes the two bugs found using #62 for real:

**Select All with an existing selection did nothing.** The renderer detects select-all by `selStartX == selEndX && selStartY == selEndY` and otherwise re-extracts `selectedText` from the drag range every frame — so selecting all with a drag selection active was silently overwritten one frame later. The menu action and keyboard Ctrl+A (same latent bug) now reset the drag coords. Verified: drag-select a paragraph → menu → Select All → the whole document highlights.

**Menu hover broke over code blocks.** Document hover logic kept running under the open menu: the code block's copy button engaged beneath the menu, and menu-entry highlights only repainted when document hover state happened to change. While the menu is open, mousemove now updates menu hover exclusively (with its own invalidation) and suppresses code-block/link hover; opening the menu clears any engaged hover state. Verified: menu over a code block hover-highlights entries, no copy button.

Tests green.