### PR TITLE
Hide YAML frontmatter instead of rendering it as a heading

### DIFF
--- a/src/document.cpp
+++ b/src/document.cpp
@@ -102,10 +102,50 @@ bool isSupportedDropPath(std::wstring_view path) {
     return isSupportedDocumentPath(path) || hasExtension(path, std::wstring_view(L".txt"));
 }
 
+// YAML frontmatter at the start of a file would otherwise render as a giant
+// setext heading — the closing --- promotes the block above it (#61). The
+// block is blanked in a copy rather than removed so byte offsets stay
+// aligned with the raw source for edit-preview sync and scroll anchors.
+// Only a block opened by --- on the very first line and closed by --- or
+// ... counts; an unclosed fence renders as ordinary markdown.
+static bool blankFrontmatter(const std::string& content, std::string& out) {
+    size_t start = 0;
+    if (content.compare(0, 3, "\xEF\xBB\xBF") == 0) start = 3;
+
+    auto isDelimiter = [&](size_t lineStart, size_t lineEnd, char c) {
+        size_t len = lineEnd - lineStart;
+        if (len > 0 && content[lineStart + len - 1] == '\r') len--;
+        return len == 3 && content[lineStart] == c &&
+               content[lineStart + 1] == c && content[lineStart + 2] == c;
+    };
+
+    size_t firstEol = content.find('\n', start);
+    if (firstEol == std::string::npos) return false;
+    if (!isDelimiter(start, firstEol, '-')) return false;
+
+    size_t pos = firstEol + 1;
+    while (pos <= content.size()) {
+        size_t eol = content.find('\n', pos);
+        size_t lineEnd = (eol == std::string::npos) ? content.size() : eol;
+        if (isDelimiter(pos, lineEnd, '-') || isDelimiter(pos, lineEnd, '.')) {
+            out = content;
+            for (size_t i = start; i < lineEnd; i++) {
+                if (out[i] != '\n' && out[i] != '\r') out[i] = ' ';
+            }
+            return true;
+        }
+        if (eol == std::string::npos) break;
+        pos = eol + 1;
+    }
+    return false;
+}
+
 qmd::ParseResult parseDocument(qmd::MarkdownParser& parser,
                                const std::string& content,
                                std::string_view path) {
     if (isMermaidDocumentPath(path)) return createMermaidDocument(content);
+    std::string cleaned;
+    if (blankFrontmatter(content, cleaned)) return parser.parse(cleaned);
     return parser.parse(content);
 }
 
@@ -113,5 +153,7 @@ qmd::ParseResult parseDocument(qmd::MarkdownParser& parser,
                                const std::string& content,
                                std::wstring_view path) {
     if (isMermaidDocumentPath(path)) return createMermaidDocument(content);
+    std::string cleaned;
+    if (blankFrontmatter(content, cleaned)) return parser.parse(cleaned);
     return parser.parse(content);
 }

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -1,5 +1,6 @@
 #include "document.h"
 
+#include <functional>
 #include <iostream>
 
 namespace {
@@ -109,6 +110,42 @@ int main() {
         check(hardBreaks == 3, "all three <br> variants become hard breaks");
         check(literalBr == 0, "no literal <br> text remains");
     }
+
+    // YAML frontmatter is hidden instead of rendering as a setext heading (#61)
+    auto fm = parseDocument(parser,
+        "---\ntitle: 'Barometer'\naliases:\ntags: [Barometer]\n---\n\n"
+        "[Link](https://example.com)\n", "notes.md");
+    check(fm.success, "frontmatter document parses");
+    if (fm.success) {
+        bool sawHeading = false, sawTitleText = false;
+        std::function<void(const qmd::ElementPtr&)> walk = [&](const qmd::ElementPtr& e) {
+            if (e->type == qmd::ElementType::Heading) sawHeading = true;
+            if (e->type == qmd::ElementType::Text &&
+                e->text.find("title:") != std::string::npos) sawTitleText = true;
+            for (const auto& ch : e->children) walk(ch);
+        };
+        walk(fm.root);
+        check(!sawHeading, "frontmatter does not become a heading");
+        check(!sawTitleText, "frontmatter keys are not rendered");
+        bool sawLink = false;
+        std::function<void(const qmd::ElementPtr&)> findLink = [&](const qmd::ElementPtr& e) {
+            if (e->type == qmd::ElementType::Link) sawLink = true;
+            for (const auto& ch : e->children) findLink(ch);
+        };
+        findLink(fm.root);
+        check(sawLink, "content after frontmatter renders");
+    }
+    auto unclosed = parseDocument(parser, "---\ntitle: x\nno closing fence\n", "notes.md");
+    check(unclosed.success && !unclosed.root->children.empty(),
+          "unclosed fence renders as ordinary markdown");
+    auto hrDoc = parseDocument(parser, "para\n\n---\n\nafter\n", "notes.md");
+    bool hrSurvives = false;
+    if (hrDoc.success) {
+        for (const auto& ch : hrDoc.root->children) {
+            if (ch->type == qmd::ElementType::HorizontalRule) hrSurvives = true;
+        }
+    }
+    check(hrSurvives, "a mid-document --- is still a horizontal rule");
 
     auto markdown = parseDocument(parser, "# Heading\n", "notes.md");
     check(markdown.success, "Markdown document still parses");


### PR DESCRIPTION
Fixes #61 — a YAML frontmatter block rendered as a giant setext heading (the closing `---` promotes the YAML lines above it into an H2 under CommonMark).

Went with option 1 from the report (hide it) — with one refinement: the block is **blanked in the parsed copy rather than removed**, so byte offsets stay aligned with the raw source. That keeps edit-preview scroll sync and internal scroll anchors correct, and edit mode still shows the frontmatter as editable source, matching how Obsidian's source view treats it.

Rules: only a block opened by `---` on the very first line (BOM tolerated) and closed by `---` or `...` counts as frontmatter. An unclosed fence renders as ordinary markdown; a `---` later in the document is still a horizontal rule. All covered by new parser tests, and verified against the exact sample file from the report — it now renders just the link.

Tests green (3/3 suites).