### PR TITLE
Follow the Windows light/dark preference

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -117,6 +117,11 @@ struct Settings {
     bool hasAskedFileAssociation = false;
     bool editorShowPreview = true;
     bool editorWordWrap = false;
+    // Auto theme: follow the Windows light/dark preference with a preferred
+    // theme for each mode
+    bool followSystemTheme = false;
+    int lightThemeIndex = 0;   // Paper
+    int darkThemeIndex = 5;    // Midnight
 };
 
 // Application state
@@ -236,6 +241,9 @@ struct App {
     bool zoomApplyPending = false;   // TIMER_ZOOM_APPLY armed to coalesce zoom ticks
     bool darkMode = true;
     bool showStats = false;
+    bool followSystemTheme = false;
+    int lightThemeIndex = 0;
+    int darkThemeIndex = 5;
     int currentThemeIndex = 5;  // Default to "Midnight" (first dark theme)
     D2DTheme theme = THEMES[5];
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1068,6 +1068,28 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         float cardHeight = (panelHeight - dpi(app, 130.0f)) / 5;
         float cardPadding = dpi(app, 8.0f);
 
+        // "Follow Windows" toggle (label + switch, must match render geometry)
+        {
+            float togW = dpi(app, 34.0f);
+            float togH = dpi(app, 18.0f);
+            float togX = panelX + panelWidth - dpi(app, 30.0f) - togW;
+            float togY = panelY + dpi(app, 24.0f);
+            if (clickX >= togX - dpi(app, 130.0f) && clickX <= togX + togW &&
+                clickY >= togY - dpi(app, 4.0f) && clickY <= togY + togH + dpi(app, 4.0f)) {
+                app.followSystemTheme = !app.followSystemTheme;
+                if (app.followSystemTheme) {
+                    // Adopt the current theme as this mode's preference, then
+                    // snap to whatever the system mode wants
+                    if (app.theme.isDark) app.darkThemeIndex = app.currentThemeIndex;
+                    else app.lightThemeIndex = app.currentThemeIndex;
+                    PostMessageW(hwnd, WM_SETTINGCHANGE, 0,
+                                 (LPARAM)L"ImmersiveColorSet");
+                }
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+        }
+
         int clickedTheme = -1;
         for (int i = 0; i < THEME_COUNT; i++) {
             const D2DTheme& t = THEMES[i];
@@ -1090,6 +1112,12 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
         if (clickedTheme >= 0) {
             applyTheme(app, clickedTheme);
+            // While auto mode is on, picking a card records it as the
+            // preference for that card's light/dark class
+            if (app.followSystemTheme) {
+                if (THEMES[clickedTheme].isDark) app.darkThemeIndex = clickedTheme;
+                else app.lightThemeIndex = clickedTheme;
+            }
             app.showThemeChooser = false;
             app.themeChooserAnimation = 0;
         }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -56,6 +56,22 @@ static void startGpuWarmup() {
     }).detach();
 }
 
+// Windows light/dark preference (Settings > Personalization > Colors)
+static bool systemPrefersLight() {
+    DWORD value = 1, size = sizeof(value);
+    if (RegGetValueW(HKEY_CURRENT_USER,
+            L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+            L"AppsUseLightTheme", RRF_RT_REG_DWORD, nullptr, &value, &size) != ERROR_SUCCESS) {
+        return true;
+    }
+    return value != 0;
+}
+
+// The theme the auto mode wants right now
+static int autoThemeIndex(const App& app) {
+    return systemPrefersLight() ? app.lightThemeIndex : app.darkThemeIndex;
+}
+
 // Forward declarations
 LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 void render(App& app);
@@ -837,6 +853,17 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             }
             return 0;
 
+        case WM_SETTINGCHANGE:
+            // Windows switched light/dark mode
+            if (app && app->followSystemTheme && lParam &&
+                wcscmp((const wchar_t*)lParam, L"ImmersiveColorSet") == 0) {
+                int want = autoThemeIndex(*app);
+                if (want != app->currentThemeIndex) {
+                    applyTheme(*app, want);
+                }
+            }
+            return 0;
+
         case WM_DPICHANGED:
             if (app) {
                 UINT dpi = HIWORD(wParam);
@@ -996,6 +1023,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.zoomFactor = app->zoomFactor;
                 settings.editorShowPreview = app->editorShowPreview;
                 settings.editorWordWrap = app->editorWordWrap;
+                settings.followSystemTheme = app->followSystemTheme;
+                settings.lightThemeIndex = app->lightThemeIndex;
+                settings.darkThemeIndex = app->darkThemeIndex;
 
                 // Get window placement for position/size/maximized state
                 WINDOWPLACEMENT wp = {};
@@ -1095,8 +1125,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
 
     // Load saved settings
     Settings savedSettings = loadSettings();
-    app.currentThemeIndex = savedSettings.themeIndex;
-    app.theme = THEMES[savedSettings.themeIndex];
+    app.followSystemTheme = savedSettings.followSystemTheme;
+    app.lightThemeIndex = savedSettings.lightThemeIndex;
+    app.darkThemeIndex = savedSettings.darkThemeIndex;
+    int startTheme = app.followSystemTheme ? autoThemeIndex(app)
+                                           : savedSettings.themeIndex;
+    app.currentThemeIndex = startTheme;
+    app.theme = THEMES[startTheme];
     app.darkMode = app.theme.isDark;
     app.zoomFactor = savedSettings.zoomFactor;
     app.editorShowPreview = savedSettings.editorShowPreview;

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -666,6 +666,35 @@ void renderThemeChooser(App& app) {
             D2D1::RectF(panelX, panelY + dpi(app, 15.0f), panelX + panelWidth, panelY + dpi(app, 55.0f)), app.brush);
     }
 
+    // "Follow Windows" toggle, top-right of the panel. While it's on, picking
+    // a light card sets the light-mode preference and a dark card the dark
+    // one — the OS switch then flips between the two automatically.
+    if (app.folderBrowserFormat) {
+        float togW = dpi(app, 34.0f);
+        float togH = dpi(app, 18.0f);
+        float togX = panelX + panelWidth - dpi(app, 30.0f) - togW;
+        float togY = panelY + dpi(app, 24.0f);
+        bool on = app.followSystemTheme;
+
+        D2D1_COLOR_F trackColor = on ? hexColor(0x3FB950, 0.9f * anim)
+                                     : hexColor(0x4A4A52, 0.9f * anim);
+        app.brush->SetColor(trackColor);
+        app.renderTarget->FillRoundedRectangle(
+            D2D1::RoundedRect(D2D1::RectF(togX, togY, togX + togW, togY + togH),
+                              togH / 2, togH / 2), app.brush);
+        float knobR = togH / 2 - dpi(app, 2.0f);
+        float knobX = on ? togX + togW - togH / 2 : togX + togH / 2;
+        app.brush->SetColor(D2D1::ColorF(1, 1, 1, anim));
+        app.renderTarget->FillEllipse(
+            D2D1::Ellipse(D2D1::Point2F(knobX, togY + togH / 2), knobR, knobR),
+            app.brush);
+
+        app.brush->SetColor(D2D1::ColorF(1, 1, 1, 0.75f * anim));
+        app.renderTarget->DrawText(L"Follow Windows", 14, app.folderBrowserFormat,
+            D2D1::RectF(togX - dpi(app, 130.0f), togY + dpi(app, 1.0f),
+                        togX - dpi(app, 8.0f), togY + togH), app.brush);
+    }
+
     // Theme grid - 2 columns, 5 rows
     float gridStartY = panelY + dpi(app, 75.0f);
     float cardWidth = (panelWidth - dpi(app, 60.0f)) / 2;  // 2 columns with padding

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -38,6 +38,9 @@ void saveSettings(const Settings& settings) {
     file << "hasAskedFileAssociation=" << (settings.hasAskedFileAssociation ? 1 : 0) << "\n";
     file << "editorShowPreview=" << (settings.editorShowPreview ? 1 : 0) << "\n";
     file << "editorWordWrap=" << (settings.editorWordWrap ? 1 : 0) << "\n";
+    file << "followSystemTheme=" << (settings.followSystemTheme ? 1 : 0) << "\n";
+    file << "lightThemeIndex=" << settings.lightThemeIndex << "\n";
+    file << "darkThemeIndex=" << settings.darkThemeIndex << "\n";
 }
 
 Settings loadSettings() {
@@ -74,6 +77,14 @@ Settings loadSettings() {
         } else if (key == "windowHeight") {
             int h = std::stoi(value);
             if (h >= 200) settings.windowHeight = h;
+        } else if (key == "followSystemTheme") {
+            settings.followSystemTheme = (value == "1");
+        } else if (key == "lightThemeIndex") {
+            int idx = std::stoi(value);
+            if (idx >= 0 && idx < THEME_COUNT) settings.lightThemeIndex = idx;
+        } else if (key == "darkThemeIndex") {
+            int idx = std::stoi(value);
+            if (idx >= 0 && idx < THEME_COUNT) settings.darkThemeIndex = idx;
         } else if (key == "windowMaximized") {
             settings.windowMaximized = (value == "1");
         } else if (key == "hasAskedFileAssociation") {


### PR DESCRIPTION
Opt-in auto theme: a **Follow Windows** switch in the theme chooser (T). When enabled, Tinta tracks the Windows apps light/dark preference (`AppsUseLightTheme` + `WM_SETTINGCHANGE` / `ImmersiveColorSet`) and switches between a preferred light theme and preferred dark theme — defaults Paper/Midnight. Choosing a card while auto is on records it as that mode's preference, so 'auto' still expresses taste in both modes. Persisted in settings.ini.