### PR TITLE
Zen mode: F11 borderless fullscreen with a centered reading column

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -241,6 +241,9 @@ struct App {
     bool zoomApplyPending = false;   // TIMER_ZOOM_APPLY armed to coalesce zoom ticks
     bool darkMode = true;
     bool showStats = false;
+    // Zen mode: borderless fullscreen with a centered reading column (F11)
+    bool zenMode = false;
+    WINDOWPLACEMENT zenRestorePlacement{};
     bool followSystemTheme = false;
     int lightThemeIndex = 0;
     int darkThemeIndex = 5;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1185,6 +1185,29 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     app.selecting = false;
 }
 
+// Zen mode: borderless fullscreen + centered reading column (F11)
+static void toggleZenMode(App& app, HWND hwnd) {
+    app.zenMode = !app.zenMode;
+    if (app.zenMode) {
+        app.zenRestorePlacement.length = sizeof(WINDOWPLACEMENT);
+        GetWindowPlacement(hwnd, &app.zenRestorePlacement);
+        MONITORINFO mi = { sizeof(mi) };
+        GetMonitorInfoW(MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST), &mi);
+        SetWindowLongW(hwnd, GWL_STYLE, WS_POPUP | WS_VISIBLE);
+        SetWindowPos(hwnd, HWND_TOP, mi.rcMonitor.left, mi.rcMonitor.top,
+                     mi.rcMonitor.right - mi.rcMonitor.left,
+                     mi.rcMonitor.bottom - mi.rcMonitor.top,
+                     SWP_FRAMECHANGED | SWP_SHOWWINDOW);
+    } else {
+        SetWindowLongW(hwnd, GWL_STYLE, WS_OVERLAPPEDWINDOW | WS_VISIBLE);
+        SetWindowPlacement(hwnd, &app.zenRestorePlacement);
+        SetWindowPos(hwnd, nullptr, 0, 0, 0, 0,
+                     SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAMECHANGED);
+    }
+    app.layoutDirty = true;
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
 void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     float pageSize = app.height * 0.8f;
     float maxScroll = std::max(0.0f, app.contentHeight - app.height);
@@ -1374,9 +1397,14 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 } else if (app.showThemeChooser) {
                     app.showThemeChooser = false;
                     app.themeChooserAnimation = 0;
+                } else if (app.zenMode) {
+                    toggleZenMode(app, hwnd);
                 } else {
                     PostQuitMessage(0);
                 }
+                break;
+            case VK_F11:
+                toggleZenMode(app, hwnd);
                 break;
             case 'Q':
                 if (!app.showThemeChooser && !app.showSearch && !app.showFolderBrowser && !app.showToc) {

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2110,6 +2110,12 @@ bool layoutBegin(App& app) {
 
     app.layoutIndent = 40.0f * scale;
     app.layoutMaxWidth = layoutWidth - app.layoutIndent * 2;
+    // Zen mode: a centered reading column instead of the full width
+    if (app.zenMode) {
+        float column = std::min(app.layoutMaxWidth, 760.0f * scale);
+        app.layoutIndent = (layoutWidth - column) / 2.0f;
+        app.layoutMaxWidth = column;
+    }
     app.layoutCursorY = 20.0f * scale;
     app.layoutNextBlock = 0;
     app.layoutComplete = false;


### PR DESCRIPTION
F11 toggles zen mode: borderless fullscreen (monitor-sized `WS_POPUP`, placement saved and restored exactly) with the document re-laid-out into a centered reading column capped at 760 px DPI-scaled — a classic ~80-character measure regardless of how wide the monitor is. Esc exits zen mode before falling through to quit. Verified on a 5120×1440 ultrawide: full-bleed background, centered column, exact window restore.