### PR TITLE
Clickable task lists

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -445,6 +445,14 @@ struct App {
         bool directed = true;
         bool dashed = false;
     };
+    // Clickable task checkboxes (document coordinates)
+    struct TaskRect {
+        D2D1_RECT_F rect{};
+        size_t markOffset = SIZE_MAX;  // source offset of the [x]/[ ] mark char
+        bool checked = false;
+    };
+    std::vector<TaskRect> taskRects;
+
     std::vector<LayoutTextRun> layoutTextRuns;
     std::vector<LayoutRect> layoutRects;
     std::vector<LayoutLine> layoutLines;
@@ -585,6 +593,7 @@ struct App {
         layoutShapes.clear();
         layoutConnectors.clear();
         layoutBitmaps.clear();
+        taskRects.clear();
         linkRects.clear();
         codeBlocks.clear();
         textRects.clear();

--- a/include/markdown.h
+++ b/include/markdown.h
@@ -56,6 +56,9 @@ struct Element {
     int level = 0;            // for headings (1-6)
     bool ordered = false;     // for lists
     int start = 1;            // for ordered lists
+    bool isTask = false;      // list item is a - [ ] / - [x] task
+    bool taskChecked = false;
+    size_t taskMarkOffset = SIZE_MAX;  // byte offset of the mark char in the source
     std::string language;     // for code blocks
     int align = 0;            // for table cells (0=default, 1=left, 2=center, 3=right)
     int col_count = 0;        // for tables (number of columns)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -877,6 +877,54 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     }
 }
 
+// Task checkbox under the mouse, or nullptr (viewer mode only)
+static const App::TaskRect* taskRectAt(const App& app) {
+    if (app.editMode) return nullptr;
+    float docX = (app.mouseX - documentViewportX(app)) + app.scrollX;
+    float docY = app.mouseY + app.scrollY;
+    for (const auto& task : app.taskRects) {
+        if (docX >= task.rect.left && docX <= task.rect.right &&
+            docY >= task.rect.top && docY <= task.rect.bottom) {
+            return &task;
+        }
+    }
+    return nullptr;
+}
+
+// Flips a - [ ] / - [x] mark in the file on disk. Parse offsets were
+// computed on CR-stripped text, so the position is remapped against the
+// raw bytes; the neighbors are verified so a file that changed since the
+// last layout is left alone. The file watcher then reloads the view.
+static void toggleTaskOnDisk(App& app, HWND hwnd, size_t markOffset, bool wasChecked) {
+    if (app.currentFile.empty()) return;
+    std::wstring widePath = toWide(app.currentFile);
+    std::ifstream in(widePath, std::ios::binary);
+    if (!in) return;
+    std::string disk((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    in.close();
+
+    size_t translated = 0, diskPos = std::string::npos;
+    for (size_t i = 0; i < disk.size(); i++) {
+        if (disk[i] == '\r') continue;
+        if (translated == markOffset) { diskPos = i; break; }
+        translated++;
+    }
+    if (diskPos == std::string::npos || diskPos == 0 || diskPos + 1 >= disk.size()) return;
+    char c = disk[diskPos];
+    bool checked = (c == 'x' || c == 'X');
+    if (disk[diskPos - 1] != '[' || disk[diskPos + 1] != ']' ||
+        checked != wasChecked || (!checked && c != ' ')) {
+        return;
+    }
+    disk[diskPos] = checked ? ' ' : 'x';
+
+    std::ofstream out(widePath, std::ios::binary | std::ios::trunc);
+    if (!out) return;
+    out.write(disk.data(), (std::streamsize)disk.size());
+    out.close();
+    handleFileWatchTimer(app, hwnd);  // reload immediately instead of on the timer
+}
+
 // True when (mouseX, mouseY) is on the hovered code block's copy button
 static bool codeCopyButtonAt(const App& app, int mouseX, int mouseY) {
     if (app.hoveredCodeBlock < 0 ||
@@ -1167,6 +1215,10 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             int dy = abs(app.mouseY - app.lastClickY);
             if (dx > 5 || dy > 5) {
                 app.hasSelection = true;
+            } else if (const App::TaskRect* task = taskRectAt(app)) {
+                // Click on a task checkbox: flip the mark in the file
+                toggleTaskOnDisk(app, hwnd, task->markOffset, task->checked);
+                app.hasSelection = false;
             } else if (!app.hoveredLink.empty()) {
                 // It was just a click on a link
                 handleLinkClick(app);

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -110,9 +110,16 @@ static int enterBlockCallback(MD_BLOCKTYPE type, void* detail, void* userdata) {
             break;
         }
 
-        case MD_BLOCK_LI:
+        case MD_BLOCK_LI: {
             elem = std::make_shared<Element>(ElementType::ListItem);
+            auto* li = static_cast<MD_BLOCK_LI_DETAIL*>(detail);
+            if (li && li->is_task) {
+                elem->isTask = true;
+                elem->taskChecked = (li->task_mark == 'x' || li->task_mark == 'X');
+                elem->taskMarkOffset = li->task_mark_offset;
+            }
             break;
+        }
 
         case MD_BLOCK_HR:
             elem = std::make_shared<Element>(ElementType::HorizontalRule);

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -101,7 +101,7 @@ static void addTextRun(App& app, LayoutInfo&& info, const D2D1_POINT_2F& pos,
 
 struct LayoutSnapshot {
     size_t textRuns, rects, lines, shapes, connectors;
-    size_t links, textRects, lineBuckets, docTextLen;
+    size_t links, textRects, lineBuckets, docTextLen, tasks;
 };
 
 static LayoutSnapshot takeSnapshot(App& app) {
@@ -114,7 +114,8 @@ static LayoutSnapshot takeSnapshot(App& app) {
         app.linkRects.size(),
         app.textRects.size(),
         app.lineBuckets.size(),
-        app.docText.size()
+        app.docText.size(),
+        app.taskRects.size()
     };
 }
 
@@ -138,6 +139,7 @@ static void rollbackTo(App& app, const LayoutSnapshot& s) {
     app.textRects.resize(s.textRects);
     app.lineBuckets.resize(s.lineBuckets);
     app.docText.resize(s.docTextLen);
+    app.taskRects.resize(s.tasks);
 }
 
 static void shiftLayoutItems(App& app, const LayoutSnapshot& from, float dx) {
@@ -183,6 +185,10 @@ static void shiftLayoutItems(App& app, const LayoutSnapshot& from, float dx) {
         auto& b = app.lineBuckets[i];
         b.minX += dx;
         b.maxX += dx;
+    }
+    for (size_t i = from.tasks; i < app.taskRects.size(); i++) {
+        app.taskRects[i].rect.left += dx;
+        app.taskRects[i].rect.right += dx;
     }
 }
 
@@ -1465,13 +1471,47 @@ static void layoutList(App& app, const ElementPtr& elem, float& y, float indent,
     for (const auto& child : elem->children) {
         if (child->type != ElementType::ListItem) continue;
 
-        std::wstring marker = elem->ordered ?
-            std::to_wstring(itemNum++) + L"." : L"\x2022";
+        if (child->isTask) {
+            // Task item: a clickable checkbox replaces the bullet
+            float box = 15.0f * scale;
+            float boxX = indent + 1.0f * scale;
+            float boxY = y + 4.0f * scale;
+            D2D1_RECT_F boxRect = D2D1::RectF(boxX, boxY, boxX + box, boxY + box);
+            if (child->taskChecked) {
+                app.layoutRects.push_back({boxRect, app.theme.accent});
+                D2D1_COLOR_F mark = app.theme.isDark
+                    ? D2D1::ColorF(0.08f, 0.08f, 0.10f) : D2D1::ColorF(1, 1, 1);
+                app.layoutLines.push_back({
+                    D2D1::Point2F(boxX + box * 0.24f, boxY + box * 0.52f),
+                    D2D1::Point2F(boxX + box * 0.44f, boxY + box * 0.74f),
+                    mark, 2.0f * scale});
+                app.layoutLines.push_back({
+                    D2D1::Point2F(boxX + box * 0.44f, boxY + box * 0.74f),
+                    D2D1::Point2F(boxX + box * 0.78f, boxY + box * 0.28f),
+                    mark, 2.0f * scale});
+            } else {
+                D2D1_COLOR_F edge = app.theme.blockquoteBorder;
+                float w = 1.2f * scale;
+                app.layoutLines.push_back({{boxX, boxY}, {boxX + box, boxY}, edge, w});
+                app.layoutLines.push_back({{boxX, boxY + box}, {boxX + box, boxY + box}, edge, w});
+                app.layoutLines.push_back({{boxX, boxY}, {boxX, boxY + box}, edge, w});
+                app.layoutLines.push_back({{boxX + box, boxY}, {boxX + box, boxY + box}, edge, w});
+            }
+            if (child->taskMarkOffset != SIZE_MAX) {
+                app.taskRects.push_back({
+                    D2D1::RectF(boxX - 4 * scale, boxY - 4 * scale,
+                                boxX + box + 4 * scale, boxY + box + 4 * scale),
+                    child->taskMarkOffset, child->taskChecked});
+            }
+        } else {
+            std::wstring marker = elem->ordered ?
+                std::to_wstring(itemNum++) + L"." : L"\x2022";
 
-        LayoutInfo info = createLayout(app, marker, app.textFormat, 24.0f, app.bodyTypography);
-        D2D1_POINT_2F pos = D2D1::Point2F(indent, y);
-        D2D1_RECT_F bounds = D2D1::RectF(indent, y, indent + listIndent, y + 24);
-        addTextRun(app, std::move(info), pos, bounds, app.theme.text, 0, 0, false);
+            LayoutInfo info = createLayout(app, marker, app.textFormat, 24.0f, app.bodyTypography);
+            D2D1_POINT_2F pos = D2D1::Point2F(indent, y);
+            D2D1_RECT_F bounds = D2D1::RectF(indent, y, indent + listIndent, y + 24);
+            addTextRun(app, std::move(info), pos, bounds, app.theme.text, 0, 0, false);
+        }
 
         bool hasBlockChildren = false;
         for (const auto& itemChild : child->children) {


### PR DESCRIPTION
`- [ ]` / `- [x]` items now render as real checkboxes — md4c's `MD_FLAG_TASKLISTS` was enabled but the LI detail was ignored, so task marks just vanished into plain bullets. Checked boxes fill with the theme accent + checkmark; open ones draw an outline.

**Clicking a checkbox updates the file**: the mark's parse offset is remapped against the raw disk bytes (parse content is CR-stripped, so CRLF files need the walk), the `[`/`]` neighbors and current mark are verified so a file modified since the last layout is left untouched, and the file-watcher reload runs immediately for instant visual feedback. Editor mode is excluded — the editor owns the buffer while editing.

Verified interactively: checked/unchecked/plain items render correctly, clicking flips the mark on disk and the view updates in place. Tests green.