### PR TITLE
Obsidian wiki links

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -11,6 +11,8 @@
 
 #include <windowsx.h>
 #include <shellapi.h>
+#include <cwctype>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <algorithm>
@@ -877,6 +879,41 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     }
 }
 
+// Resolves an Obsidian [[wiki link]] target against the current file's
+// folder and opens it: the name as written, then with .md / .markdown
+// appended, then a case-insensitive scan of the directory listing.
+static void openWikiLink(App& app, const std::string& target) {
+    if (app.editMode || app.currentFile.empty()) return;
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    std::wstring wideTarget = toWide(target);
+    fs::path dir = fs::path(toWide(app.currentFile)).parent_path();
+
+    auto tryOpen = [&](const fs::path& p) {
+        return fs::exists(p, ec) && !fs::is_directory(p, ec) &&
+               openDocumentInViewer(app, p.wstring());
+    };
+    if (tryOpen(dir / wideTarget)) return;
+    if (tryOpen(dir / (wideTarget + L".md"))) return;
+    if (tryOpen(dir / (wideTarget + L".markdown"))) return;
+
+    auto lower = [](std::wstring s) {
+        for (auto& c : s) c = (wchar_t)std::towlower(c);
+        return s;
+    };
+    std::wstring want = lower(wideTarget);
+    for (const auto& entry : fs::directory_iterator(dir, ec)) {
+        if (!entry.is_regular_file(ec)) continue;
+        std::wstring stem = lower(entry.path().stem().wstring());
+        std::wstring name = lower(entry.path().filename().wstring());
+        if (stem == want || name == want) {
+            if (openDocumentInViewer(app, entry.path().wstring())) return;
+        }
+    }
+    // Target doesn't exist: leave the document as-is (a viewer doesn't
+    // create notes the way Obsidian would)
+}
+
 // Task checkbox under the mouse, or nullptr (viewer mode only)
 static const App::TaskRect* taskRectAt(const App& app) {
     if (app.editMode) return nullptr;
@@ -1221,7 +1258,11 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 app.hasSelection = false;
             } else if (!app.hoveredLink.empty()) {
                 // It was just a click on a link
-                handleLinkClick(app);
+                if (app.hoveredLink.rfind("wiki:", 0) == 0) {
+                    openWikiLink(app, app.hoveredLink.substr(5));
+                } else {
+                    handleLinkClick(app);
+                }
                 app.hasSelection = false;
             } else {
                 app.hasSelection = false;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -492,6 +492,73 @@ static void splitInlineExtensions(const ElementPtr& parent) {
     if (changed) parent->children = std::move(rebuilt);
 }
 
+// Obsidian [[wiki links]]: [[Target]] and [[Target|shown text]] become
+// Link elements with a wiki: scheme URL; the click handler resolves the
+// target against the current file's folder. Runs after the extension
+// splitter, skipping code the same way.
+static void splitWikiLinks(const ElementPtr& parent) {
+    if (parent->type == ElementType::Code ||
+        parent->type == ElementType::CodeBlock ||
+        parent->type == ElementType::MermaidDiagram ||
+        parent->type == ElementType::Link) {
+        return;
+    }
+
+    std::vector<ElementPtr> rebuilt;
+    bool changed = false;
+    for (auto& child : parent->children) {
+        if (child->type != ElementType::Text) {
+            splitWikiLinks(child);
+            rebuilt.push_back(child);
+            continue;
+        }
+
+        const std::string& text = child->text;
+        size_t cursor = 0;
+        bool any = false;
+        while (true) {
+            size_t open = text.find("[[", cursor);
+            if (open == std::string::npos) break;
+            size_t close = text.find("]]", open + 2);
+            if (close == std::string::npos) break;
+            std::string inner = text.substr(open + 2, close - open - 2);
+            if (inner.empty() || inner.find('\n') != std::string::npos) {
+                cursor = open + 2;
+                continue;
+            }
+            std::string target = inner, shown = inner;
+            size_t pipe = inner.find('|');
+            if (pipe != std::string::npos) {
+                target = inner.substr(0, pipe);
+                shown = inner.substr(pipe + 1);
+            }
+            if (target.empty() || shown.empty()) {
+                cursor = open + 2;
+                continue;
+            }
+            any = true;
+            if (open > cursor) {
+                rebuilt.push_back(makeTextElement(text.substr(cursor, open - cursor), parent.get()));
+            }
+            auto link = std::make_shared<Element>(ElementType::Link);
+            link->parent = parent.get();
+            link->url = "wiki:" + target;
+            link->children.push_back(makeTextElement(shown, link.get()));
+            rebuilt.push_back(std::move(link));
+            cursor = close + 2;
+        }
+        if (!any) {
+            rebuilt.push_back(child);
+            continue;
+        }
+        changed = true;
+        if (cursor < text.size()) {
+            rebuilt.push_back(makeTextElement(text.substr(cursor), parent.get()));
+        }
+    }
+    if (changed) parent->children = std::move(rebuilt);
+}
+
 } // namespace
 
 MarkdownParser::MarkdownParser() = default;
@@ -543,6 +610,7 @@ ParseResult MarkdownParser::parse(const std::string& markdown) {
 
     ctx.flushText();
     splitInlineExtensions(ctx.root);
+    splitWikiLinks(ctx.root);
     detectGitHubAlerts(ctx.root);
     result.root = ctx.root;
     result.success = true;


### PR DESCRIPTION
`[[Note Name]]` and `[[Note Name|display text]]` now render as links and navigate on click. Resolution against the current file's folder, in order: the target as written, `.md` appended, `.markdown` appended, then a case-insensitive scan of the directory listing (so `[[second note]]` finds `Second Note.md`). Implemented as a post-parse pass mirroring the inline-extension splitter — code spans, code blocks, mermaid, and existing links are excluded. A missing target is a silent no-op: a viewer shouldn't create notes the way Obsidian does. Verified: link rendering, alias display, click navigation both directions, case-insensitive match. Tests green.