### PR TITLE
Folder-wide search results beside the search bar

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -32,6 +32,7 @@ inline int64_t usElapsed(Clock::time_point start) {
 #define TIMER_NOTIFICATION 4
 #define TIMER_ZOOM_APPLY 5
 #define TIMER_IMAGE_REFLOW 6
+#define TIMER_FOLDER_SEARCH 7
 
 // Posted to continue an incomplete document layout in time-budgeted chunks
 #define WM_APP_LAYOUT_CHUNK (WM_APP + 1)
@@ -44,6 +45,10 @@ inline int64_t usElapsed(Clock::time_point start) {
 // software render target used for the instant first paint is then swapped
 // for a hardware one (cheap now that the driver is warm)
 #define WM_APP_GPU_READY (WM_APP + 3)
+
+// Posted by the folder-search worker with its scan results
+// (lParam = FolderScanMsg*, ownership transfers to the handler)
+#define WM_APP_FOLDER_SEARCH (WM_APP + 4)
 
 // Startup metrics
 struct StartupMetrics {
@@ -122,6 +127,8 @@ struct Settings {
     bool followSystemTheme = false;
     int lightThemeIndex = 0;   // Paper
     int darkThemeIndex = 5;    // Midnight
+    // Search results from sibling markdown files in the search overlay
+    bool folderSearchEnabled = true;
 };
 
 // Application state
@@ -370,6 +377,28 @@ struct App {
     };
     std::vector<SearchMatch> searchMatches;
     bool overText = false;
+
+    // Folder-wide search: sibling .md files matching the current query,
+    // filled by a worker thread and shown beside the search bar
+    bool folderSearchEnabled = true;
+    int folderSearchGeneration = 0;
+    struct FolderMatch {
+        std::wstring snippet;
+        size_t matchStart = 0;
+        size_t matchLen = 0;
+    };
+    struct FolderFileResult {
+        std::wstring fileName;
+        std::wstring fullPath;
+        std::vector<FolderMatch> matches;  // first few only
+        int totalMatches = 0;
+    };
+    std::vector<FolderFileResult> folderResults;
+    struct FolderResultHit {
+        D2D1_RECT_F rect{};
+        int fileIndex = -1;
+    };
+    std::vector<FolderResultHit> folderResultHits;  // rebuilt each paint
 
     // Text selection
     bool selecting = false;

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -24,6 +24,11 @@ enum ContextMenuItem {
     CTX_ITEM_COUNT
 };
 void renderContextMenu(App& app);
+
+// Folder-wide search results beside the search bar; the toggle button sits
+// at the bar's right edge (geometry shared with input hit-testing)
+void renderFolderSearchResults(App& app);
+bool folderSearchToggleAt(const App& app, float x, float y);
 // Opens at (x, y) client coordinates, clamped so the menu stays on screen
 void openContextMenu(App& app, float x, float y);
 // Item index under the point, or -1 (separators and gaps count as none)

--- a/include/search.h
+++ b/include/search.h
@@ -7,4 +7,10 @@ void performSearch(App& app);
 void mapSearchMatchesToLayout(App& app);
 void scrollToCurrentMatch(App& app);
 
+// Folder-wide search: scans sibling .md files for the current query on a
+// worker thread; results arrive via WM_APP_FOLDER_SEARCH
+void startFolderSearchScan(App& app);
+void completeFolderSearch(App& app, void* results);
+void clearFolderSearch(App& app);
+
 #endif // TINTA_SEARCH_H

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -562,6 +562,7 @@ static void closeSearchIfOpen(App& app) {
     app.searchQuery.clear();
     app.searchMatches.clear();
     app.searchAnimation = 0;
+    clearFolderSearch(app);
     updateBlinkTimer(app);
 }
 
@@ -699,6 +700,41 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             return;
         }
         // Fall through for preview pane clicks
+    }
+
+    // Folder search: the bar's toggle button and result-panel clicks
+    if (app.showSearch && !app.editMode) {
+        float clickX = (float)GET_X_LPARAM(lParam);
+        float clickY = (float)GET_Y_LPARAM(lParam);
+        if (folderSearchToggleAt(app, clickX, clickY)) {
+            app.folderSearchEnabled = !app.folderSearchEnabled;
+            if (!app.folderSearchEnabled) {
+                clearFolderSearch(app);
+            } else {
+                performSearch(app);  // re-arms the scan timer
+            }
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
+        }
+        for (const auto& hit : app.folderResultHits) {
+            if (clickX >= hit.rect.left && clickX <= hit.rect.right &&
+                clickY >= hit.rect.top && clickY <= hit.rect.bottom &&
+                hit.fileIndex >= 0 && hit.fileIndex < (int)app.folderResults.size()) {
+                // Open the file and land on the first match of the same query
+                if (openDocumentInViewer(app, app.folderResults[hit.fileIndex].fullPath)) {
+                    app.folderResults.clear();
+                    app.folderResultHits.clear();
+                    ensureLayoutComplete(app);
+                    performSearch(app);
+                    if (!app.searchMatches.empty()) {
+                        app.searchCurrentIndex = 0;
+                        scrollToCurrentMatch(app);
+                    }
+                }
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+        }
     }
 
     // Help overlay: check scrollbar click
@@ -1383,6 +1419,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 app.searchQuery.clear();
                 app.searchMatches.clear();
                 app.searchAnimation = 0;
+                clearFolderSearch(app);
                 updateBlinkTimer(app);
                 InvalidateRect(hwnd, nullptr, FALSE);
                 return;
@@ -1480,6 +1517,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                     app.searchQuery.clear();
                     app.searchMatches.clear();
                     app.searchAnimation = 0;
+                    clearFolderSearch(app);
                     updateBlinkTimer(app);
                 } else if (app.showFolderBrowser) {
                     app.showFolderBrowser = false;

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -807,7 +807,10 @@ render_document:
     }
 
     // Render overlays (search overlay handled separately for edit mode)
-    if (app.showSearch && !app.editMode) renderSearchOverlay(app);
+    if (app.showSearch && !app.editMode) {
+        renderSearchOverlay(app);
+        renderFolderSearchResults(app);
+    }
     if (app.showFolderBrowser) renderFolderBrowser(app);
     if (app.showToc) renderToc(app);
     if (app.showContextMenu) renderContextMenu(app);
@@ -956,6 +959,10 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                     KillTimer(hwnd, TIMER_NOTIFICATION);
                 }
             }
+            if (wParam == TIMER_FOLDER_SEARCH && app) {
+                KillTimer(hwnd, TIMER_FOLDER_SEARCH);
+                startFolderSearchScan(*app);
+            }
             if (wParam == TIMER_IMAGE_REFLOW && app) {
                 // One relayout for however many images arrived since armed
                 KillTimer(hwnd, TIMER_IMAGE_REFLOW);
@@ -982,6 +989,11 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case WM_CONTEXTMENU:
             if (app) handleContextMenu(*app, hwnd, lParam);
+            return 0;
+
+        case WM_APP_FOLDER_SEARCH:
+            // Folder search worker finished (handler takes ownership)
+            if (app) completeFolderSearch(*app, (void*)lParam);
             return 0;
 
         case WM_APP_GPU_READY:
@@ -1026,6 +1038,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.followSystemTheme = app->followSystemTheme;
                 settings.lightThemeIndex = app->lightThemeIndex;
                 settings.darkThemeIndex = app->darkThemeIndex;
+                settings.folderSearchEnabled = app->folderSearchEnabled;
 
                 // Get window placement for position/size/maximized state
                 WINDOWPLACEMENT wp = {};
@@ -1128,6 +1141,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.followSystemTheme = savedSettings.followSystemTheme;
     app.lightThemeIndex = savedSettings.lightThemeIndex;
     app.darkThemeIndex = savedSettings.darkThemeIndex;
+    app.folderSearchEnabled = savedSettings.folderSearchEnabled;
     int startTheme = app.followSystemTheme ? autoThemeIndex(app)
                                            : savedSettings.themeIndex;
     app.currentThemeIndex = startTheme;

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1184,3 +1184,184 @@ void renderContextMenu(App& app) {
         }
     }
 }
+
+// --- Folder-wide search results ---
+//
+// Sibling markdown files matching the search query, shown as a panel under
+// the right end of the search bar: filename, a few highlighted snippet
+// lines each, and a +N counter. Clicking a file opens it at the match.
+
+namespace {
+
+// The toggle button hangs off the right edge of the search bar
+void folderToggleGeometry(const App& app, float& btnX, float& btnY, float& btnSize) {
+    float barWidth = std::min(dpi(app, 500.0f), app.width - dpi(app, 40.0f));
+    float barHeight = dpi(app, 44.0f);
+    float barX = ((float)app.width - barWidth) / 2;
+    float barY = dpi(app, 20.0f);
+    btnSize = dpi(app, 30.0f);
+    btnX = barX + barWidth + dpi(app, 8.0f);
+    btnY = barY + (barHeight - btnSize) / 2;
+}
+
+} // namespace
+
+bool folderSearchToggleAt(const App& app, float x, float y) {
+    if (!app.showSearch || app.editMode) return false;
+    float btnX, btnY, btnSize;
+    folderToggleGeometry(app, btnX, btnY, btnSize);
+    return x >= btnX && x <= btnX + btnSize && y >= btnY && y <= btnY + btnSize;
+}
+
+void renderFolderSearchResults(App& app) {
+    float anim = app.searchAnimation;
+    IDWriteTextFormat* fmt = app.folderBrowserFormat;
+
+    // Toggle button (always drawn with the bar so the feature is discoverable)
+    {
+        float btnX, btnY, btnSize;
+        folderToggleGeometry(app, btnX, btnY, btnSize);
+        D2D1_COLOR_F btnBg = app.theme.isDark ? hexColor(0x1E1E22, 0.95f * anim)
+                                              : hexColor(0xFFFFFF, 0.95f * anim);
+        app.brush->SetColor(btnBg);
+        app.renderTarget->FillRoundedRectangle(
+            D2D1::RoundedRect(D2D1::RectF(btnX, btnY, btnX + btnSize, btnY + btnSize),
+                              dpi(app, 6.0f), dpi(app, 6.0f)), app.brush);
+        D2D1_COLOR_F folderColor = app.folderSearchEnabled
+            ? app.theme.accent
+            : (app.theme.isDark ? hexColor(0x5A5A62) : hexColor(0xB0B0B6));
+        folderColor.a = anim;
+        app.brush->SetColor(folderColor);
+        float gx = btnX + dpi(app, 7.0f);
+        float gy = btnY + dpi(app, 9.0f);
+        app.renderTarget->FillRoundedRectangle(
+            D2D1::RoundedRect(D2D1::RectF(gx, gy + dpi(app, 3.0f), gx + dpi(app, 16.0f), gy + dpi(app, 13.0f)), 2, 2),
+            app.brush);
+        app.renderTarget->FillRectangle(
+            D2D1::RectF(gx, gy, gx + dpi(app, 7.0f), gy + dpi(app, 4.0f)), app.brush);
+        if (!app.folderSearchEnabled) {
+            // Slash = disabled
+            D2D1_COLOR_F slash = app.theme.isDark ? hexColor(0xF85149, anim) : hexColor(0xCF222E, anim);
+            app.brush->SetColor(slash);
+            app.renderTarget->DrawLine(
+                D2D1::Point2F(btnX + dpi(app, 6.0f), btnY + btnSize - dpi(app, 6.0f)),
+                D2D1::Point2F(btnX + btnSize - dpi(app, 6.0f), btnY + dpi(app, 6.0f)),
+                app.brush, 2.0f);
+        }
+    }
+
+    app.folderResultHits.clear();
+    if (!app.folderSearchEnabled || app.folderResults.empty() ||
+        app.searchQuery.empty() || !fmt) {
+        return;
+    }
+
+    float panelW = std::min(dpi(app, 460.0f), app.width * 0.35f);
+    float panelX = app.width - panelW - dpi(app, 16.0f);
+    float panelY = dpi(app, 20.0f) + dpi(app, 44.0f) + dpi(app, 12.0f);
+    float pad = dpi(app, 12.0f);
+    float headerH = dpi(app, 24.0f);
+    float lineH = dpi(app, 20.0f);
+    float moreH = dpi(app, 16.0f);
+    float sectionGap = dpi(app, 10.0f);
+    float maxBottom = app.height - dpi(app, 20.0f);
+
+    // Height first, so the panel can be drawn before its content
+    float contentH = pad;
+    size_t shownFiles = 0;
+    for (const auto& file : app.folderResults) {
+        float sectionH = headerH + file.matches.size() * lineH +
+            ((size_t)file.totalMatches > file.matches.size() ? moreH : 0.0f) + sectionGap;
+        if (panelY + contentH + sectionH + pad > maxBottom) break;
+        contentH += sectionH;
+        shownFiles++;
+    }
+    if (shownFiles == 0) return;
+    contentH += pad - sectionGap;
+
+    D2D1_ROUNDED_RECT panel = D2D1::RoundedRect(
+        D2D1::RectF(panelX, panelY, panelX + panelW, panelY + contentH),
+        dpi(app, 8.0f), dpi(app, 8.0f));
+    D2D1_COLOR_F panelBg = app.theme.isDark ? hexColor(0x18181C, 0.96f * anim)
+                                            : hexColor(0xFCFCFC, 0.97f * anim);
+    app.brush->SetColor(panelBg);
+    app.renderTarget->FillRoundedRectangle(panel, app.brush);
+    D2D1_COLOR_F borderColor = app.theme.isDark ? hexColor(0x3A3A40, 0.8f * anim)
+                                                : hexColor(0xC8C8C8, 0.8f * anim);
+    app.brush->SetColor(borderColor);
+    app.renderTarget->DrawRoundedRectangle(panel, app.brush, 1.0f);
+
+    float rowY = panelY + pad;
+    for (size_t i = 0; i < shownFiles; i++) {
+        const auto& file = app.folderResults[i];
+        float sectionTop = rowY;
+
+        D2D1_COLOR_F nameColor = app.theme.accent;
+        nameColor.a = anim;
+        app.brush->SetColor(nameColor);
+        app.renderTarget->DrawText(
+            file.fileName.c_str(), (UINT32)file.fileName.length(), fmt,
+            D2D1::RectF(panelX + pad, rowY, panelX + panelW - pad, rowY + headerH),
+            app.brush);
+        rowY += headerH;
+
+        for (const auto& match : file.matches) {
+            // Highlight behind the matched substring
+            std::wstring prefix = match.snippet.substr(0, match.matchStart);
+            std::wstring matched = match.snippet.substr(match.matchStart, match.matchLen);
+            float prefixW = prefix.empty() ? 0.0f : measureText(app, prefix, fmt);
+            float matchW = matched.empty() ? 0.0f : measureText(app, matched, fmt);
+            float textX = panelX + pad;
+            float availW = panelW - pad * 2;
+            if (prefixW + matchW > availW) {
+                // Keep the match visible: drop the head of the prefix
+                while (!prefix.empty() && prefixW + matchW > availW * 0.7f) {
+                    prefix.erase(0, 8);
+                    prefixW = prefix.empty() ? 0.0f : measureText(app, prefix, fmt);
+                }
+            }
+            D2D1_COLOR_F hl = app.theme.accent;
+            hl.a = 0.28f * anim;
+            app.brush->SetColor(hl);
+            app.renderTarget->FillRectangle(
+                D2D1::RectF(textX + prefixW, rowY + dpi(app, 1.0f),
+                            textX + prefixW + matchW, rowY + lineH - dpi(app, 1.0f)),
+                app.brush);
+
+            std::wstring shown = prefix + match.snippet.substr(match.matchStart);
+            D2D1_COLOR_F snippetColor = app.theme.text;
+            snippetColor.a = 0.85f * anim;
+            app.brush->SetColor(snippetColor);
+            app.renderTarget->DrawText(
+                shown.c_str(), (UINT32)shown.length(), fmt,
+                D2D1::RectF(textX, rowY + dpi(app, 1.0f), textX + availW, rowY + lineH),
+                app.brush);
+            rowY += lineH;
+        }
+
+        if ((size_t)file.totalMatches > file.matches.size()) {
+            wchar_t more[32];
+            swprintf_s(more, L"+%d more", file.totalMatches - (int)file.matches.size());
+            D2D1_COLOR_F moreColor = app.theme.text;
+            moreColor.a = 0.45f * anim;
+            app.brush->SetColor(moreColor);
+            app.renderTarget->DrawText(more, (UINT32)wcslen(more), fmt,
+                D2D1::RectF(panelX + pad, rowY, panelX + panelW - pad, rowY + moreH),
+                app.brush);
+            rowY += moreH;
+        }
+
+        app.folderResultHits.push_back({
+            D2D1::RectF(panelX, sectionTop, panelX + panelW, rowY), (int)i});
+
+        if (i + 1 < shownFiles) {
+            app.brush->SetColor(borderColor);
+            app.renderTarget->DrawLine(
+                D2D1::Point2F(panelX + pad, rowY + sectionGap / 2),
+                D2D1::Point2F(panelX + panelW - pad, rowY + sectionGap / 2),
+                app.brush, 1.0f);
+        }
+        rowY += sectionGap;
+    }
+}
+

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -3,16 +3,131 @@
 #include "render.h"
 
 #include <algorithm>
+#include <cwctype>
+#include <filesystem>
+#include <fstream>
 #include <limits>
+#include <thread>
 
 namespace {
 constexpr size_t kNoTextRect = std::numeric_limits<size_t>::max();
+
+struct FolderScanMsg {
+    int generation = 0;
+    std::vector<App::FolderFileResult> files;
+};
+
+std::wstring utf8ToWideString(const std::string& bytes) {
+    if (bytes.empty()) return {};
+    int len = MultiByteToWideChar(CP_UTF8, 0, bytes.data(), (int)bytes.size(), nullptr, 0);
+    if (len <= 0) return {};
+    std::wstring wide((size_t)len, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, bytes.data(), (int)bytes.size(), wide.data(), len);
+    return wide;
+}
+}
+
+void clearFolderSearch(App& app) {
+    app.folderSearchGeneration++;   // orphan any scan in flight
+    app.folderResults.clear();
+    app.folderResultHits.clear();
+    if (app.hwnd) KillTimer(app.hwnd, TIMER_FOLDER_SEARCH);
+}
+
+void startFolderSearchScan(App& app) {
+    if (app.editMode || !app.folderSearchEnabled || !app.showSearch ||
+        app.searchQuery.empty() || app.currentFile.empty()) {
+        return;
+    }
+    int generation = ++app.folderSearchGeneration;
+    std::wstring queryLower = toLower(app.searchQuery);
+    std::filesystem::path current(toWide(app.currentFile));
+    std::filesystem::path dir = current.parent_path();
+    std::wstring currentName = current.filename().wstring();
+    HWND hwnd = app.hwnd;
+
+    std::thread([generation, queryLower, dir, currentName, hwnd] {
+        auto* msg = new FolderScanMsg{generation, {}};
+        std::error_code ec;
+        int scanned = 0;
+        for (const auto& entry : std::filesystem::directory_iterator(dir, ec)) {
+            if (msg->files.size() >= 12 || scanned >= 200) break;
+            if (!entry.is_regular_file(ec)) continue;
+            std::wstring ext = entry.path().extension().wstring();
+            for (auto& c : ext) c = (wchar_t)std::towlower(c);
+            if (ext != L".md" && ext != L".markdown") continue;
+            if (_wcsicmp(entry.path().filename().c_str(), currentName.c_str()) == 0) continue;
+            if (entry.file_size(ec) > 1024 * 1024) continue;
+            scanned++;
+
+            std::ifstream file(entry.path(), std::ios::binary);
+            if (!file) continue;
+            std::string bytes((std::istreambuf_iterator<char>(file)),
+                              std::istreambuf_iterator<char>());
+            std::wstring content = utf8ToWideString(bytes);
+            std::wstring lower = content;
+            for (auto& c : lower) c = (wchar_t)std::towlower(c);
+
+            App::FolderFileResult result;
+            size_t pos = 0;
+            while ((pos = lower.find(queryLower, pos)) != std::wstring::npos) {
+                result.totalMatches++;
+                if (result.matches.size() < 3) {
+                    size_t lineStart = content.rfind(L'\n', pos);
+                    lineStart = (lineStart == std::wstring::npos) ? 0 : lineStart + 1;
+                    size_t lineEnd = content.find(L'\n', pos);
+                    if (lineEnd == std::wstring::npos) lineEnd = content.size();
+                    size_t snipStart = pos > lineStart + 40 ? pos - 40 : lineStart;
+                    size_t snipEnd = std::min(lineEnd, pos + queryLower.size() + 70);
+                    App::FolderMatch m;
+                    m.snippet = content.substr(snipStart, snipEnd - snipStart);
+                    for (auto& c : m.snippet) {
+                        if (c == L'\r' || c == L'\t') c = L' ';
+                    }
+                    m.matchStart = pos - snipStart;
+                    m.matchLen = queryLower.size();
+                    result.matches.push_back(std::move(m));
+                }
+                pos += queryLower.size();
+            }
+            if (result.totalMatches > 0) {
+                result.fileName = entry.path().filename().wstring();
+                result.fullPath = entry.path().wstring();
+                msg->files.push_back(std::move(result));
+            }
+        }
+        if (!PostMessageW(hwnd, WM_APP_FOLDER_SEARCH, 0, (LPARAM)msg)) delete msg;
+    }).detach();
+}
+
+void completeFolderSearch(App& app, void* results) {
+    auto* msg = static_cast<FolderScanMsg*>(results);
+    if (!msg) return;
+    if (msg->generation != app.folderSearchGeneration ||
+        !app.showSearch || app.editMode || !app.folderSearchEnabled) {
+        delete msg;
+        return;
+    }
+    app.folderResults = std::move(msg->files);
+    app.folderResultHits.clear();
+    delete msg;
+    if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
 }
 
 void performSearch(App& app) {
     app.searchMatches.clear();
     app.searchCurrentIndex = 0;
     app.searchMatchCursor = 0;
+
+    // Folder-wide results follow the query, debounced on a timer so fast
+    // typing doesn't spawn a scan per keystroke
+    if (!app.editMode && app.folderSearchEnabled && app.hwnd) {
+        if (app.searchQuery.empty()) {
+            clearFolderSearch(app);
+        } else if (!app.currentFile.empty()) {
+            SetTimer(app.hwnd, TIMER_FOLDER_SEARCH, 250, nullptr);
+        }
+    }
 
     if (app.searchQuery.empty() || !app.root) return;
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -41,6 +41,7 @@ void saveSettings(const Settings& settings) {
     file << "followSystemTheme=" << (settings.followSystemTheme ? 1 : 0) << "\n";
     file << "lightThemeIndex=" << settings.lightThemeIndex << "\n";
     file << "darkThemeIndex=" << settings.darkThemeIndex << "\n";
+    file << "folderSearchEnabled=" << (settings.folderSearchEnabled ? 1 : 0) << "\n";
 }
 
 Settings loadSettings() {
@@ -77,6 +78,8 @@ Settings loadSettings() {
         } else if (key == "windowHeight") {
             int h = std::stoi(value);
             if (h >= 200) settings.windowHeight = h;
+        } else if (key == "folderSearchEnabled") {
+            settings.folderSearchEnabled = (value == "1");
         } else if (key == "followSystemTheme") {
             settings.followSystemTheme = (value == "1");
         } else if (key == "lightThemeIndex") {


### PR DESCRIPTION
Searching now looks across the folder, not just the open document: a worker thread greps sibling `.md`/`.markdown` files for the query (250 ms debounce, ≤200 files, ≤1 MB each, current file excluded) and posts results to a panel under the right end of the search bar — per file: the name in accent, up to three snippet lines with the matched text highlighted, and a **+N more** counter. **Clicking a result opens that file and jumps straight to the first match** of the same query, and the panel re-scans for the new folder context.

**Disable-able as requested**: a folder icon button attached to the bar toggles the feature (red slash when off), persisted in settings.ini.

Robustness: results carry a generation counter so stale scans from fast typing are discarded; the scan thread owns only copies; results clear on search close and on toggle-off; case-insensitive matching consistent with in-document search.

Verified interactively: multi-file vault, snippets + highlights + counters correct, non-matching files absent, click-through opens at the match with the panel following the new context. Tests green.