### PR TITLE
Title bar and window border follow the theme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ target_link_libraries(tinta PRIVATE
     ole32
     imm32
     d3d11
+    dwmapi
 )
 
 target_compile_definitions(tinta PRIVATE UNICODE _UNICODE

--- a/include/d2d_init.h
+++ b/include/d2d_init.h
@@ -5,6 +5,9 @@
 
 bool initD2D(App& app);
 void applyTheme(App& app, int themeIndex);
+// Tints the native title bar/border to the current theme (Windows 11;
+// Windows 10 falls back to the stock dark/light caption)
+void applyWindowChrome(App& app);
 void updateTextFormats(App& app);
 void updateOverlayFormats(App& app);
 void ensureThemePreviewFormats(App& app);

--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -2,6 +2,46 @@
 #include "utils.h"
 
 #include <objbase.h>
+#include <dwmapi.h>
+
+// Older SDK headers may lack these
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+#ifndef DWMWA_BORDER_COLOR
+#define DWMWA_BORDER_COLOR 34
+#endif
+#ifndef DWMWA_CAPTION_COLOR
+#define DWMWA_CAPTION_COLOR 35
+#endif
+#ifndef DWMWA_TEXT_COLOR
+#define DWMWA_TEXT_COLOR 36
+#endif
+
+void applyWindowChrome(App& app) {
+    if (!app.hwnd) return;
+
+    auto toColorref = [](const D2D1_COLOR_F& c) {
+        return RGB((BYTE)(c.r * 255.0f + 0.5f),
+                   (BYTE)(c.g * 255.0f + 0.5f),
+                   (BYTE)(c.b * 255.0f + 0.5f));
+    };
+
+    // Windows 10 fallback: at least pick the right caption variant
+    BOOL dark = app.theme.isDark ? TRUE : FALSE;
+    DwmSetWindowAttribute(app.hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                          &dark, sizeof(dark));
+
+    // Windows 11: exact theme colors (silently rejected on older builds)
+    COLORREF caption = toColorref(app.theme.background);
+    DwmSetWindowAttribute(app.hwnd, DWMWA_CAPTION_COLOR,
+                          &caption, sizeof(caption));
+    DwmSetWindowAttribute(app.hwnd, DWMWA_BORDER_COLOR,
+                          &caption, sizeof(caption));
+    COLORREF text = toColorref(app.theme.text);
+    DwmSetWindowAttribute(app.hwnd, DWMWA_TEXT_COLOR,
+                          &text, sizeof(text));
+}
 
 bool initD2D(App& app) {
     auto t0 = Clock::now();
@@ -53,6 +93,9 @@ void applyTheme(App& app, int themeIndex) {
     } else {
         updateTextFormats(app);
     }
+
+    // Title bar follows the theme
+    applyWindowChrome(app);
 
     // Force a redraw
     if (app.hwnd) {

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1258,6 +1258,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     // Get DPI using per-monitor aware API
     app.contentScale = GetDpiForWindow(app.hwnd) / 96.0f;
 
+    // Theme the native title bar before the window is ever shown
+    applyWindowChrome(app);
+
     // Initialize D2D
     if (!initD2D(app)) {
         MessageBoxW(nullptr, L"Failed to initialize Direct2D", L"Error", MB_OK);


### PR DESCRIPTION
The classic white Win32 caption clashed with every dark theme. The native title bar, caption text, and window border now take the current theme's exact colors via `DwmSetWindowAttribute` (`DWMWA_CAPTION_COLOR`/`TEXT_COLOR`/`BORDER_COLOR`, Windows 11), falling back to the stock immersive dark caption on Windows 10. Chosen over a fully custom-drawn title bar deliberately: native buttons, snap layouts, and accessibility keep working for ~40 lines instead of a subsystem. Applied pre-show (no white flash at startup) and on every theme change including auto-follow. Verified: dark and light themes both blend seamlessly.