### PR TITLE
New documents open in their own window; N starts the new-file flow

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -279,6 +279,7 @@ struct App {
     int folderBrowserNaming = 0;             // 0 = off, 1 = naming a new file, 2 = a new folder
     std::wstring folderBrowserInput;         // Single-line buffer shared by both inputs
     bool folderBrowserInputSelectAll = false; // Whole input selected: next keystroke replaces it
+    bool folderInputJustOpened = false;      // Swallow the WM_CHAR of the key that opened it
     bool folderBrowserInputError = false;    // Last commit failed (bad path/name): red border
 
     // Right-click context menu overlay

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -14,6 +14,7 @@ void renderHelpOverlay(App& app);
 enum ContextMenuItem {
     CTX_COPY = 0,
     CTX_SELECT_ALL,
+    CTX_NEW,
     CTX_EDIT,
     CTX_SEARCH,
     CTX_TOC,

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -53,6 +53,43 @@ static bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
     return true;
 }
 
+// Spawns a second Tinta window, offset from this one, showing the given
+// document in edit mode (#74: creating a note no longer replaces the
+// document you were reading)
+static void launchDocumentWindow(const std::wstring& fullPath) {
+    wchar_t exePath[MAX_PATH];
+    if (!GetModuleFileNameW(nullptr, exePath, MAX_PATH)) return;
+    std::wstring params = L"--cascade --edit \"" + fullPath + L"\"";
+    ShellExecuteW(nullptr, L"open", exePath, params.c_str(), nullptr, SW_SHOWNORMAL);
+}
+
+// N key / context menu: open the folder browser with the new-file naming
+// row already active
+static void startNewFileFlow(App& app, HWND hwnd) {
+    if (!app.showFolderBrowser) {
+        app.showFolderBrowser = true;
+        app.folderBrowserAnimation = 0;
+        if (!app.currentFile.empty()) {
+            app.folderBrowserPath = getDirectoryFromFile(app.currentFile);
+        } else {
+            wchar_t cwd[MAX_PATH];
+            if (GetCurrentDirectoryW(MAX_PATH, cwd)) {
+                app.folderBrowserPath = cwd;
+            }
+        }
+        populateFolderItems(app);
+    }
+    app.folderBrowserNaming = 1;  // new file
+    app.folderBrowserInput.clear();
+    app.folderBrowserInputSelectAll = false;
+    app.folderBrowserInputError = false;
+    app.folderInputJustOpened = true;
+    app.folderBrowserScroll = 0.0f;
+    updateBlinkTimer(app);
+    resetCursorBlink(app);
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
 // --- Folder browser path/name input (#52) ---
 
 static void closeFolderBrowserInput(App& app) {
@@ -175,12 +212,13 @@ static void commitFolderBrowserNaming(App& app) {
         return;
     }
     CloseHandle(h);
-    if (openDocumentInViewer(app, fullPath)) {
-        closeFolderBrowserInput(app);
-        app.showFolderBrowser = false;
-        app.folderBrowserAnimation = 0;
-        enterEditMode(app);
-    }
+    // The new note opens in its own window, offset from this one, so the
+    // document being read stays exactly where it is (#74)
+    closeFolderBrowserInput(app);
+    app.showFolderBrowser = false;
+    app.folderBrowserAnimation = 0;
+    launchDocumentWindow(fullPath);
+    if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
 }
 
 // Ctrl+wheel zoom. The scroll anchor scales immediately, but text format
@@ -589,6 +627,10 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
                 app.selStartX = app.selEndX = 0;
                 app.selStartY = app.selEndY = 0;
             }
+            break;
+        case CTX_NEW:
+            closeSearchIfOpen(app);
+            startNewFileFlow(app, hwnd);
             break;
         case CTX_EDIT:
             closeSearchIfOpen(app);
@@ -1542,6 +1584,12 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                     PostQuitMessage(0);
                 }
                 break;
+            case 'N':
+                // New file: folder browser with the naming row active (#74)
+                if (!app.showSearch && !app.showThemeChooser && !app.showToc) {
+                    startNewFileFlow(app, hwnd);
+                }
+                break;
             case 'B':
                 // B to toggle folder browser
                 if (!app.showSearch && !app.showThemeChooser && !app.showToc) {
@@ -1667,6 +1715,11 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
 
     if (app.showFolderBrowser &&
         (app.folderBrowserEditingPath || app.folderBrowserNaming != 0)) {
+        if (app.folderInputJustOpened) {
+            // The keystroke that opened this input must not type into it
+            app.folderInputJustOpened = false;
+            return;
+        }
         wchar_t ch = (wchar_t)wParam;
         if (ch >= 32 && ch != 127) {
             if (app.folderBrowserInputSelectAll) {

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1155,6 +1155,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     std::string inputFile;
     bool lightMode = false;
     bool forceRegister = false;
+    bool cascadeWindow = false;   // offset from the saved position (new-file windows)
+    bool startInEditMode = false; // open straight into the editor
 
     int argc;
     LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
@@ -1166,6 +1168,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
             app.showStats = true;
         } else if (arg == L"/register" || arg == L"--register") {
             forceRegister = true;
+        } else if (arg == L"--cascade") {
+            cascadeWindow = true;
+        } else if (arg == L"--edit") {
+            startInEditMode = true;
         } else if (arg[0] != L'-' && arg[0] != L'/') {
             // Convert to UTF-8
             int len = WideCharToMultiByte(CP_UTF8, 0, arg.c_str(), -1, nullptr, 0, nullptr, nullptr);
@@ -1241,6 +1247,13 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
                 windowY = CW_USEDEFAULT;
             }
         }
+    }
+
+    // A window spawned for a newly created document steps down-right from
+    // the saved position so it does not cover the window that spawned it
+    if (cascadeWindow && windowX != CW_USEDEFAULT && windowY != CW_USEDEFAULT) {
+        windowX += 40;
+        windowY += 40;
     }
 
     app.hwnd = CreateWindowExW(
@@ -1343,6 +1356,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.metrics.showWindowUs = usElapsed(t0);
 
     app.metrics.totalStartupUs = usElapsed(startupStart);
+
+    // New-file windows open straight into the editor
+    if (startInEditMode) {
+        enterEditMode(app);
+    }
 
     // First frame is on screen — now pay for the GPU in the background
     startGpuWarmup();

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1037,6 +1037,7 @@ struct ContextMenuEntry {
 const ContextMenuEntry CTX_ENTRIES[CTX_ITEM_COUNT] = {
     { L"Copy",               L"Ctrl+C", false },
     { L"Select All",         L"Ctrl+A", true  },
+    { L"New File",           L"N",      false },
     { L"Edit",               L":",      false },
     { L"Search",             L"F",      false },
     { L"Table of Contents",  L"Tab",    true  },


### PR DESCRIPTION
Two of the three requests from #74:

**Creating a note no longer replaces what you're reading.** Naming a new file and pressing Enter now spawns a second Tinta window, cascaded 40 px down-right from the current one, opening the new note in edit mode (`--cascade --edit` command-line flags on the spawned instance). The window you were reading stays exactly where it was. At ~130 ms per instance, extra windows are cheap.

**N is the new-file shortcut.** It opens the folder browser with the naming row already focused — N, type a name, Enter, start writing, right hand never leaves the keyboard. Also added as **New File** in the right-click menu. The opening keystroke is swallowed (same pattern as the search bar) so the N doesn't type into the name field.

The third request (PDF export) is under design discussion — tracked separately.

Verified: original window keeps its document; the new window opens cascaded in edit mode with the created file; N → name → Enter flow works end to end. Tests green.