### PR TITLE
Print and PDF export via the Windows print pipeline (#74)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SOURCES
     src/mermaid.cpp
     src/document.cpp
     src/inline_style.cpp
+    src/print.cpp
 )
 
 set(HEADERS
@@ -69,6 +70,7 @@ set(HEADERS
     include/mermaid.h
     include/document.h
     include/inline_style.h
+    include/print.h
 )
 
 # Windows resource file (icon)
@@ -95,6 +97,7 @@ target_link_libraries(tinta PRIVATE
     imm32
     d3d11
     dwmapi
+    comdlg32
 )
 
 target_compile_definitions(tinta PRIVATE UNICODE _UNICODE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ target_link_libraries(tinta PRIVATE
     d3d11
     dwmapi
     comdlg32
+    winspool
 )
 
 target_compile_definitions(tinta PRIVATE UNICODE _UNICODE

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 - **10 beautiful themes** - 5 light and 5 dark themes to choose from
 - **Hardware-accelerated** - Smooth text rendering via DirectWrite
 - **Word wrap** - Optional soft wrap in the editor (Ctrl+W)
-- **Focused editing** - Hide the preview pane while writing (Ctrl+P)
+- **Focused editing** - Hide the preview pane while writing (Ctrl+E)
 - **Native Mermaid flowcharts** - Render `.mmd` files and fenced `mermaid` blocks without a web engine
 - **Rich tables** - Tables with bold, italic, code, and clickable links in cells
 - **Folder browser** - Press B to browse and open Markdown or Mermaid files
@@ -98,7 +98,8 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 | `:` | Enter edit mode |
 | `ESC` `ESC` | Exit edit mode |
 | `Ctrl+S` | Save (in edit mode) |
-| `Ctrl+P` | Show/hide preview pane (in edit mode) |
+| `Ctrl+P` | Print / export to PDF |
+| `Ctrl+E` | Show/hide preview pane (in edit mode) |
 | `Ctrl+W` | Toggle word wrap (in edit mode) |
 | `Q` | Quit |
 

--- a/include/app.h
+++ b/include/app.h
@@ -304,6 +304,28 @@ struct App {
     float helpScrollbarDragStartY = 0;
     float helpScrollbarDragStartScroll = 0;
 
+    // Print preview overlay. While it is open the document is held in print
+    // layout — width, theme, zoom and scroll are hijacked by enterPrintLayout —
+    // and the real screen state lives in printSaved. Screen dimensions and UI
+    // scale must therefore be read from printSaved, not app.width/contentScale.
+    struct PrintSavedView {
+        int width = 0, height = 0;
+        float contentScale = 1.0f, zoomFactor = 1.0f, appliedZoomFactor = 1.0f;
+        float scrollX = 0, scrollY = 0, targetScrollX = 0, targetScrollY = 0;
+        D2DTheme theme{};
+    };
+    bool showPrintPreview = false;
+    PrintSavedView printSaved;
+    std::vector<float> printPreviewBounds;    // page boundaries in doc Y (pages + 1)
+    int printPreviewPage = 0;
+    float printPreviewPageW = 794.0f;         // page size in DIPs (A4 fallback)
+    float printPreviewPageH = 1123.0f;
+    float printPreviewFit = 1.0f;             // page DIPs -> screen pixels
+    std::vector<uint8_t> printPreviewPixels;  // current page, premultiplied BGRA
+    unsigned printPreviewPxW = 0, printPreviewPxH = 0;
+    D2D1_RECT_F printPreviewPrintBtn{};       // hit rects (set during render)
+    D2D1_RECT_F printPreviewCancelBtn{};
+
     // Table of contents overlay
     bool showToc = false;
     float tocAnimation = 0.0f;  // 0 to 1 for slide-in from right

--- a/include/app.h
+++ b/include/app.h
@@ -323,8 +323,18 @@ struct App {
     float printPreviewFit = 1.0f;             // page DIPs -> screen pixels
     std::vector<uint8_t> printPreviewPixels;  // current page, premultiplied BGRA
     unsigned printPreviewPxW = 0, printPreviewPxH = 0;
+    int printPreviewPaper = -1;               // index into PRINT_PAPERS (-1: detect)
+    bool printPreviewLandscape = false;
     D2D1_RECT_F printPreviewPrintBtn{};       // hit rects (set during render)
     D2D1_RECT_F printPreviewCancelBtn{};
+    D2D1_RECT_F printPreviewPaperBtn[4]{};
+    D2D1_RECT_F printPreviewOrientBtn[2]{};   // 0 portrait, 1 landscape
+
+    // Blocks wider than the printable area (mermaid diagrams, wide tables)
+    // are shrunk uniformly to fit the margins when printing; each band is a
+    // vertical slice of the document drawn at `scale` about its own top-left
+    struct PrintShrinkBand { float top, bottom, scale; };
+    std::vector<PrintShrinkBand> printShrinkBands;
 
     // Table of contents overlay
     bool showToc = false;

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -8,6 +8,8 @@ void renderFolderBrowser(App& app);
 void renderToc(App& app);
 void renderThemeChooser(App& app);
 void renderHelpOverlay(App& app);
+// Full-frame print preview; render() short-circuits to this while it is open
+void renderPrintPreview(App& app);
 
 // Right-click context menu: theme-drawn like the other overlays.
 // Item indices are shared between rendering and input handling.

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -15,6 +15,7 @@ enum ContextMenuItem {
     CTX_COPY = 0,
     CTX_SELECT_ALL,
     CTX_NEW,
+    CTX_PRINT,
     CTX_EDIT,
     CTX_SEARCH,
     CTX_TOC,

--- a/include/print.h
+++ b/include/print.h
@@ -9,6 +9,15 @@
 // dedicated light print palette regardless of the active theme.
 bool printDocument(App& app);
 
+// Print preview overlay: Ctrl+P opens it, the user flips through the
+// paginated pages, then confirms into the printer dialog or cancels.
+// Pages are previewed at the default printer's paper size (A4 fallback);
+// printDocument re-paginates for whatever printer is finally chosen.
+void openPrintPreview(App& app, HWND hwnd);
+void closePrintPreview(App& app, HWND hwnd);
+void printPreviewSetPage(App& app, int page);   // clamps and re-rasterizes
+void printPreviewConfirm(App& app, HWND hwnd);  // close overlay, run the dialog
+
 // Debug/testing: renders each paginated page to <outDir>\page-N.png using
 // the same layout and pagination as printing. Returns the page count.
 int printDebugPages(App& app, const std::wstring& outDir);

--- a/include/print.h
+++ b/include/print.h
@@ -1,0 +1,16 @@
+#ifndef TINTA_PRINT_H
+#define TINTA_PRINT_H
+
+#include "app.h"
+
+// Prints the current document through the Windows print pipeline
+// (ID2D1PrintControl). The user picks any installed printer — including
+// "Microsoft Print to PDF" — from the standard dialog. Rendering uses a
+// dedicated light print palette regardless of the active theme.
+bool printDocument(App& app);
+
+// Debug/testing: renders each paginated page to <outDir>\page-N.png using
+// the same layout and pagination as printing. Returns the page count.
+int printDebugPages(App& app, const std::wstring& outDir);
+
+#endif // TINTA_PRINT_H

--- a/include/print.h
+++ b/include/print.h
@@ -18,6 +18,24 @@ void closePrintPreview(App& app, HWND hwnd);
 void printPreviewSetPage(App& app, int page);   // clamps and re-rasterizes
 void printPreviewConfirm(App& app, HWND hwnd);  // close overlay, run the dialog
 
+// Paper formats offered by the preview. The choice is preset into the
+// printer dialog's DEVMODE, and the dialog's final answer still wins.
+struct PrintPaper {
+    const wchar_t* name;
+    float w, h;      // portrait DIPs at 96/inch
+    short dmPaper;   // DMPAPER_* constant
+};
+inline constexpr PrintPaper PRINT_PAPERS[] = {
+    {L"A4",     794.0f,  1123.0f, 9},   // DMPAPER_A4
+    {L"Letter", 816.0f,  1056.0f, 1},   // DMPAPER_LETTER
+    {L"Legal",  816.0f,  1344.0f, 5},   // DMPAPER_LEGAL
+    {L"A3",     1123.0f, 1587.0f, 8},   // DMPAPER_A3
+};
+inline constexpr int PRINT_PAPER_COUNT = 4;
+
+// Re-paginates the open preview for a new paper size / orientation
+void printPreviewSetFormat(App& app, int paper, bool landscape);
+
 // Debug/testing: renders each paginated page to <outDir>\page-N.png using
 // the same layout and pagination as printing. Returns the page count.
 int printDebugPages(App& app, const std::wstring& outDir);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -975,15 +975,11 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 return;
             }
-            case 'P': {
-                // Print the document as currently edited, saved or not
-                editorReparse(app);
-                printDocument(app);
-                app.clearEditorLineLayoutCache();
-                app.editorRowMetricsWidth = -1.0f;
-                InvalidateRect(hwnd, nullptr, FALSE);
+            case 'P':
+                // Print preview of the document as currently edited, saved
+                // or not (openPrintPreview re-parses; Ctrl+E is the pane)
+                openPrintPreview(app, hwnd);
                 return;
-            }
             case 'E': {
                 app.editorShowPreview = !app.editorShowPreview;
                 app.clearEditorLineLayoutCache();

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -5,6 +5,7 @@
 #include "render.h"
 #include "d2d_init.h"
 #include "search.h"
+#include "print.h"
 
 #include <fstream>
 #include <sstream>
@@ -975,6 +976,15 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 return;
             }
             case 'P': {
+                // Print the document as currently edited, saved or not
+                editorReparse(app);
+                printDocument(app);
+                app.clearEditorLineLayoutCache();
+                app.editorRowMetricsWidth = -1.0f;
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+            case 'E': {
                 app.editorShowPreview = !app.editorShowPreview;
                 app.clearEditorLineLayoutCache();
                 if (app.editorShowPreview) {
@@ -984,8 +994,8 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 app.editorRowMetricsWidth = -1.0f;  // pane width changed
                 app.editorNotificationMsg = app.editorShowPreview
-                    ? L"Preview shown (Ctrl+P to hide)"
-                    : L"Preview hidden (Ctrl+P to show)";
+                    ? L"Preview shown (Ctrl+E to hide)"
+                    : L"Preview hidden (Ctrl+E to show)";
                 app.showEditModeNotification = true;
                 app.editModeNotificationAlpha = 1.0f;
                 app.editModeNotificationStart = std::chrono::steady_clock::now();

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1496,10 +1496,8 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     if (ctrl) {
         switch (wParam) {
             case 'P':
-                // Print (viewer mode; Ctrl+P in edit mode toggles the preview)
-                if (!app.editMode) {
-                    printDocument(app);
-                }
+                // Print (edit mode handles its own Ctrl+P in the editor path)
+                printDocument(app);
                 break;
             case 'A': {
                 // Select All - extract all text from document

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -8,6 +8,7 @@
 #include "settings.h"
 #include "render.h"
 #include "overlays.h"
+#include "print.h"
 
 #include <windowsx.h>
 #include <shellapi.h>
@@ -631,6 +632,10 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
         case CTX_NEW:
             closeSearchIfOpen(app);
             startNewFileFlow(app, hwnd);
+            break;
+        case CTX_PRINT:
+            closeSearchIfOpen(app);
+            printDocument(app);
             break;
         case CTX_EDIT:
             closeSearchIfOpen(app);
@@ -1490,6 +1495,12 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
 
     if (ctrl) {
         switch (wParam) {
+            case 'P':
+                // Print (viewer mode; Ctrl+P in edit mode toggles the preview)
+                if (!app.editMode) {
+                    printDocument(app);
+                }
+                break;
             case 'A': {
                 // Select All - extract all text from document
                 if (app.root) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1084,7 +1084,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         return;
     }
 
-    // Print preview: only the two buttons are clickable
+    // Print preview: buttons and format chips
     if (app.showPrintPreview) {
         float mx = (float)GET_X_LPARAM(lParam);
         float my = (float)GET_Y_LPARAM(lParam);
@@ -1093,8 +1093,22 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         };
         if (hit(app.printPreviewPrintBtn)) {
             printPreviewConfirm(app, hwnd);
-        } else if (hit(app.printPreviewCancelBtn)) {
+            return;
+        }
+        if (hit(app.printPreviewCancelBtn)) {
             closePrintPreview(app, hwnd);
+            return;
+        }
+        for (int i = 0; i < PRINT_PAPER_COUNT; i++) {
+            if (hit(app.printPreviewPaperBtn[i])) {
+                printPreviewSetFormat(app, i, app.printPreviewLandscape);
+                return;
+            }
+        }
+        if (hit(app.printPreviewOrientBtn[0])) {
+            printPreviewSetFormat(app, app.printPreviewPaper, false);
+        } else if (hit(app.printPreviewOrientBtn[1])) {
+            printPreviewSetFormat(app, app.printPreviewPaper, true);
         }
         return;
     }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -239,6 +239,12 @@ static void applyZoomDelta(App& app, float delta) {
 }
 
 void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    // Print preview: the wheel flips pages
+    if (app.showPrintPreview) {
+        int delta = GET_WHEEL_DELTA_WPARAM(wParam);
+        printPreviewSetPage(app, app.printPreviewPage + (delta < 0 ? 1 : -1));
+        return;
+    }
     if (app.showContextMenu) {
         app.showContextMenu = false;
         app.contextMenuAnimation = 0;
@@ -345,6 +351,10 @@ void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     app.mouseX = GET_X_LPARAM(lParam);
     app.mouseY = GET_Y_LPARAM(lParam);
+
+    // Print preview: no hover states; document hit-testing below would run
+    // against print-layout coordinates anyway
+    if (app.showPrintPreview) return;
 
     // Context menu open: hover tracks menu items only — document hover
     // (code-block copy button, link underline) stays suppressed underneath
@@ -635,7 +645,7 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
             break;
         case CTX_PRINT:
             closeSearchIfOpen(app);
-            printDocument(app);
+            openPrintPreview(app, hwnd);
             break;
         case CTX_EDIT:
             closeSearchIfOpen(app);
@@ -703,7 +713,7 @@ void handleContextMenu(App& app, HWND hwnd, LPARAM lParam) {
     // Viewer mode only, and never on top of a modal overlay. The search
     // bar is fine — it shares the viewport rather than covering it.
     if (app.editMode || app.showThemeChooser || app.showToc ||
-        app.showFolderBrowser || app.showHelp) {
+        app.showFolderBrowser || app.showHelp || app.showPrintPreview) {
         return;
     }
 
@@ -720,6 +730,9 @@ void handleContextMenu(App& app, HWND hwnd, LPARAM lParam) {
 }
 
 void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    // Print preview: buttons act on the release; nothing else to press
+    if (app.showPrintPreview) return;
+
     // Context menu: a click lands on an item or dismisses the menu; either
     // way the click is consumed
     if (app.showContextMenu) {
@@ -1070,6 +1083,21 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         app.swallowNextMouseUp = false;
         return;
     }
+
+    // Print preview: only the two buttons are clickable
+    if (app.showPrintPreview) {
+        float mx = (float)GET_X_LPARAM(lParam);
+        float my = (float)GET_Y_LPARAM(lParam);
+        auto hit = [&](const D2D1_RECT_F& r) {
+            return mx >= r.left && mx <= r.right && my >= r.top && my <= r.bottom;
+        };
+        if (hit(app.printPreviewPrintBtn)) {
+            printPreviewConfirm(app, hwnd);
+        } else if (hit(app.printPreviewCancelBtn)) {
+            closePrintPreview(app, hwnd);
+        }
+        return;
+    }
     // Help scrollbar release
     if (app.helpScrollbarDragging) {
         app.helpScrollbarDragging = false;
@@ -1389,6 +1417,34 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     float maxScroll = std::max(0.0f, app.contentHeight - app.height);
     bool ctrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
 
+    // Print preview captures the whole keyboard while open
+    if (app.showPrintPreview) {
+        switch (wParam) {
+            case VK_ESCAPE:
+                closePrintPreview(app, hwnd);
+                break;
+            case VK_RETURN:
+                printPreviewConfirm(app, hwnd);
+                break;
+            case 'P':  // a second Ctrl+P also proceeds to the dialog
+                if (ctrl) printPreviewConfirm(app, hwnd);
+                break;
+            case VK_NEXT: case VK_DOWN: case VK_RIGHT: case VK_SPACE: case 'J':
+                printPreviewSetPage(app, app.printPreviewPage + 1);
+                break;
+            case VK_PRIOR: case VK_UP: case VK_LEFT: case 'K':
+                printPreviewSetPage(app, app.printPreviewPage - 1);
+                break;
+            case VK_HOME:
+                printPreviewSetPage(app, 0);
+                break;
+            case VK_END:
+                printPreviewSetPage(app, (int)app.printPreviewBounds.size() - 2);
+                break;
+        }
+        return;
+    }
+
     // Edit mode: Ctrl+C with preview pane selection should copy from preview
     if (app.editMode) {
         if (ctrl && wParam == 'C' && app.hasSelection && !app.selectedText.empty()) {
@@ -1496,8 +1552,9 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     if (ctrl) {
         switch (wParam) {
             case 'P':
-                // Print (edit mode handles its own Ctrl+P in the editor path)
-                printDocument(app);
+                // Print preview (edit mode handles its own Ctrl+P in the
+                // editor path)
+                openPrintPreview(app, hwnd);
                 break;
             case 'A': {
                 // Select All - extract all text from document
@@ -1699,6 +1756,9 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
 }
 
 void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
+    // Print preview: all shortcuts are handled as key-downs
+    if (app.showPrintPreview) return;
+
     // Edit mode: ':' enters edit mode, otherwise route to editor
     if (app.editMode) {
         handleEditorCharInput(app, hwnd, wParam);

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -83,6 +83,14 @@ void render(App& app) {
     app.renderTarget->BeginDraw();
     app.drawCalls = 0;
 
+    // Print preview replaces the whole frame: the document is in print
+    // layout while it is open, so the normal paths would draw nonsense
+    if (app.showPrintPreview) {
+        renderPrintPreview(app);
+        app.renderTarget->EndDraw();
+        return;
+    }
+
     if (app.layoutDirty) {
         if (app.editMode && !app.editorShowPreview) {
             // Preview hidden: defer document layout until it's shown again
@@ -842,6 +850,13 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
         case WM_SIZE:
             if (app && app->d2dFactory) {
+                // The preview's geometry is stale after a resize: restore
+                // the document at the new size and close the overlay
+                if (app->showPrintPreview) {
+                    app->printSaved.width = LOWORD(lParam);
+                    app->printSaved.height = HIWORD(lParam);
+                    closePrintPreview(*app, hwnd);
+                }
                 app->width = LOWORD(lParam);
                 app->height = HIWORD(lParam);
                 app->clearEditorLineLayoutCache();
@@ -870,6 +885,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case WM_DPICHANGED:
             if (app) {
+                if (app->showPrintPreview) closePrintPreview(*app, hwnd);
                 UINT dpi = HIWORD(wParam);
                 app->contentScale = dpi / 96.0f;
 

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -28,6 +28,7 @@
 #include "overlays.h"
 #include "input.h"
 #include "editor.h"
+#include "print.h"
 
 static App* g_app = nullptr;
 
@@ -1157,6 +1158,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     bool forceRegister = false;
     bool cascadeWindow = false;   // offset from the saved position (new-file windows)
     bool startInEditMode = false; // open straight into the editor
+    std::wstring printPagesDir;   // debug: render print pages as PNGs and exit
 
     int argc;
     LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
@@ -1172,6 +1174,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
             cascadeWindow = true;
         } else if (arg == L"--edit") {
             startInEditMode = true;
+        } else if (arg == L"--printpages" && i + 1 < argc) {
+            printPagesDir = argv[++i];
         } else if (arg[0] != L'-' && arg[0] != L'/') {
             // Convert to UTF-8
             int len = WideCharToMultiByte(CP_UTF8, 0, arg.c_str(), -1, nullptr, 0, nullptr, nullptr);
@@ -1360,6 +1364,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     // New-file windows open straight into the editor
     if (startInEditMode) {
         enterEditMode(app);
+    }
+
+    // Debug: rasterize the print pagination to PNGs and exit
+    if (!printPagesDir.empty()) {
+        int pages = printDebugPages(app, printPagesDir);
+        wchar_t msg[64];
+        swprintf_s(msg, L"printpages: %d", pages);
+        OutputDebugStringW(msg);
+        return pages > 0 ? 0 : 1;
     }
 
     // First frame is on screen — now pay for the GPU in the background

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -941,7 +941,10 @@ void renderHelpOverlay(App& app) {
         return lineH + sectionHeaderExtra + entryCount * lineH + sectionGap;
     };
     float footerH = dpi(app, 35.0f);
-    float totalContentHeight = sectionHeight(6) + sectionHeight(7) + sectionHeight(3) + sectionHeight(4) + footerH;
+    float totalContentHeight = sectionHeight((int)_countof(navEntries)) +
+                               sectionHeight((int)_countof(overlayEntries)) +
+                               sectionHeight((int)_countof(editEntries)) +
+                               sectionHeight((int)_countof(generalEntries)) + footerH;
 
     // Scrollable area
     float contentTopY = titleBottomY + dpi(app, 10.0f);
@@ -992,10 +995,10 @@ void renderHelpOverlay(App& app) {
         y += sectionGap;
     };
 
-    drawSection(L"NAVIGATION", navEntries, 6);
-    drawSection(L"VIEW", overlayEntries, 7);
-    drawSection(L"EDITING", editEntries, 3);
-    drawSection(L"GENERAL", generalEntries, 4);
+    drawSection(L"NAVIGATION", navEntries, (int)_countof(navEntries));
+    drawSection(L"VIEW", overlayEntries, (int)_countof(overlayEntries));
+    drawSection(L"EDITING", editEntries, (int)_countof(editEntries));
+    drawSection(L"GENERAL", generalEntries, (int)_countof(generalEntries));
 
     // Footer hint
     normalFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1,6 +1,7 @@
 #include "overlays.h"
 #include "utils.h"
 #include "d2d_init.h"
+#include "print.h"
 
 #include <chrono>
 #include <algorithm>
@@ -1439,6 +1440,49 @@ void renderPrintPreview(App& app) {
         app.renderTarget->DrawText(label, (UINT32)wcslen(label), uiFmt,
             D2D1::RectF(0, 0, w, topBarH), app.brush);
     }
+
+    // Format chips: paper sizes top-left, orientation top-right. The active
+    // chip fills with the accent color.
+    auto drawChip = [&](const D2D1_RECT_F& rect, const wchar_t* text, bool active) {
+        float cr = 5.0f * ui;
+        if (active) {
+            app.brush->SetColor(th.accent);
+            app.renderTarget->FillRoundedRectangle(
+                D2D1::RoundedRect(rect, cr, cr), app.brush);
+        } else {
+            D2D1_COLOR_F bc = th.text;
+            bc.a = 0.35f;
+            app.brush->SetColor(bc);
+            app.renderTarget->DrawRoundedRectangle(
+                D2D1::RoundedRect(rect, cr, cr), app.brush, 1.0f);
+        }
+        if (uiFmt) {
+            app.brush->SetColor(active ? D2D1::ColorF(1.0f, 1.0f, 1.0f) : th.text);
+            uiFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+            app.renderTarget->DrawText(text, (UINT32)wcslen(text), uiFmt, rect, app.brush);
+        }
+    };
+
+    float chipH = 26.0f * ui;
+    float chipY = (topBarH - chipH) / 2.0f;
+    float chipGap = 8.0f * ui;
+    float paperW = 64.0f * ui;
+    float px2 = 24.0f * ui;
+    for (int i = 0; i < PRINT_PAPER_COUNT; i++) {
+        D2D1_RECT_F rect = D2D1::RectF(px2, chipY, px2 + paperW, chipY + chipH);
+        app.printPreviewPaperBtn[i] = rect;
+        drawChip(rect, PRINT_PAPERS[i].name, i == app.printPreviewPaper);
+        px2 += paperW + chipGap;
+    }
+    float orientW = 88.0f * ui;
+    D2D1_RECT_F landR = D2D1::RectF(w - 24.0f * ui - orientW, chipY,
+                                    w - 24.0f * ui, chipY + chipH);
+    D2D1_RECT_F portR = D2D1::RectF(landR.left - chipGap - orientW, chipY,
+                                    landR.left - chipGap, chipY + chipH);
+    app.printPreviewOrientBtn[0] = portR;
+    app.printPreviewOrientBtn[1] = landR;
+    drawChip(portR, L"Portrait", !app.printPreviewLandscape);
+    drawChip(landR, L"Landscape", app.printPreviewLandscape);
 
     // Buttons, bottom right
     float btnH = 34.0f * ui;

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1371,3 +1371,114 @@ void renderFolderSearchResults(App& app) {
     }
 }
 
+
+// --- Print preview ---
+//
+// Replaces the whole frame while open: the document itself is re-laid-out
+// at page width in the print palette, so the normal render paths would draw
+// nonsense underneath. Chrome is styled with the SAVED screen theme and
+// scale — app.theme and app.contentScale hold the print palette and 1.0
+// while the preview is active, so dpi(app, ...) cannot be used here.
+
+void renderPrintPreview(App& app) {
+    const auto& sv = app.printSaved;
+    float w = (float)sv.width, h = (float)sv.height;
+    float ui = sv.contentScale;
+    const D2DTheme& th = sv.theme;
+
+    app.brush->SetColor(th.background);
+    app.renderTarget->FillRectangle(D2D1::RectF(0, 0, w, h), app.brush);
+
+    float topBarH = 52.0f * ui;
+    float bottomBarH = 64.0f * ui;
+
+    // Current page, uploaded from the CPU rasterization. Preview repaints
+    // are interaction-driven, so the per-paint upload cost is irrelevant.
+    if (!app.printPreviewPixels.empty() && app.printPreviewPxW && app.printPreviewPxH) {
+        ID2D1Bitmap* bmp = nullptr;
+        app.renderTarget->CreateBitmap(
+            D2D1::SizeU(app.printPreviewPxW, app.printPreviewPxH),
+            app.printPreviewPixels.data(), app.printPreviewPxW * 4,
+            D2D1::BitmapProperties(D2D1::PixelFormat(
+                DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED)),
+            &bmp);
+        if (bmp) {
+            float pw = (float)app.printPreviewPxW, ph = (float)app.printPreviewPxH;
+            float px = (w - pw) / 2.0f;
+            float py = topBarH + (h - topBarH - bottomBarH - ph) / 2.0f;
+            for (int i = 3; i >= 1; i--) {  // soft shadow ring
+                app.brush->SetColor(D2D1::ColorF(0, 0, 0, 0.06f * i));
+                app.renderTarget->DrawRectangle(
+                    D2D1::RectF(px - i, py - i, px + pw + i, py + ph + i),
+                    app.brush, 1.5f);
+            }
+            app.renderTarget->DrawBitmap(bmp,
+                D2D1::RectF(px, py, px + pw, py + ph),
+                1.0f, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR);
+            bmp->Release();
+        }
+    }
+
+    IDWriteTextFormat* uiFmt = nullptr;
+    IDWriteTextFormat* btnFmt = nullptr;
+    app.dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr,
+        DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+        13.0f * ui, L"en-us", &uiFmt);
+    app.dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr,
+        DWRITE_FONT_WEIGHT_SEMI_BOLD, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+        13.0f * ui, L"en-us", &btnFmt);
+
+    int pageCount = (int)app.printPreviewBounds.size() - 1;
+    if (uiFmt) {
+        uiFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+        uiFmt->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+        wchar_t label[64];
+        swprintf_s(label, L"Print preview \x2014 page %d of %d",
+                   app.printPreviewPage + 1, pageCount > 0 ? pageCount : 1);
+        app.brush->SetColor(th.text);
+        app.renderTarget->DrawText(label, (UINT32)wcslen(label), uiFmt,
+            D2D1::RectF(0, 0, w, topBarH), app.brush);
+    }
+
+    // Buttons, bottom right
+    float btnH = 34.0f * ui;
+    float printW = 110.0f * ui, cancelW = 90.0f * ui;
+    float gap = 12.0f * ui, margin = 24.0f * ui;
+    float by = h - bottomBarH + (bottomBarH - btnH) / 2.0f;
+    D2D1_RECT_F printR = D2D1::RectF(w - margin - printW, by, w - margin, by + btnH);
+    D2D1_RECT_F cancelR = D2D1::RectF(printR.left - gap - cancelW, by,
+                                      printR.left - gap, by + btnH);
+    app.printPreviewPrintBtn = printR;
+    app.printPreviewCancelBtn = cancelR;
+
+    float r = 6.0f * ui;
+    app.brush->SetColor(th.accent);
+    app.renderTarget->FillRoundedRectangle(D2D1::RoundedRect(printR, r, r), app.brush);
+    D2D1_COLOR_F borderC = th.text;
+    borderC.a = 0.4f;
+    app.brush->SetColor(borderC);
+    app.renderTarget->DrawRoundedRectangle(D2D1::RoundedRect(cancelR, r, r), app.brush, 1.0f);
+
+    if (btnFmt) {
+        btnFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+        btnFmt->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+        app.brush->SetColor(D2D1::ColorF(1.0f, 1.0f, 1.0f));
+        app.renderTarget->DrawText(L"Print\x2026", 6, btnFmt, printR, app.brush);
+        app.brush->SetColor(th.text);
+        app.renderTarget->DrawText(L"Cancel", 6, btnFmt, cancelR, app.brush);
+    }
+
+    // Hint, bottom left
+    if (uiFmt) {
+        uiFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+        D2D1_COLOR_F hintC = th.text;
+        hintC.a = 0.5f;
+        app.brush->SetColor(hintC);
+        const wchar_t* hint = L"Scroll or PgUp/PgDn to flip pages \x2022 Enter to print \x2022 Esc to close";
+        app.renderTarget->DrawText(hint, (UINT32)wcslen(hint), uiFmt,
+            D2D1::RectF(margin, h - bottomBarH, cancelR.left - gap, h), app.brush);
+    }
+
+    if (uiFmt) uiFmt->Release();
+    if (btnFmt) btnFmt->Release();
+}

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -914,7 +914,7 @@ void renderHelpOverlay(App& app) {
     const HelpEntry editEntries[] = {
         {L":",             L"Enter edit mode"},
         {L"Ctrl+S",       L"Save (in edit mode)"},
-        {L"Ctrl+P",       L"Show / hide preview pane"},
+        {L"Ctrl+E",       L"Show / hide preview pane"},
         {L"Ctrl+W",       L"Toggle word wrap"},
         {L"ESC ESC",      L"Exit edit mode"},
     };
@@ -922,6 +922,7 @@ void renderHelpOverlay(App& app) {
     const HelpEntry generalEntries[] = {
         {L"Ctrl+A",       L"Select all text"},
         {L"Ctrl+C",       L"Copy selection"},
+        {L"Ctrl+P",       L"Print / PDF"},
         {L"ESC",          L"Close overlay / Quit"},
         {L"Q",            L"Quit"},
     };

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1038,6 +1038,7 @@ const ContextMenuEntry CTX_ENTRIES[CTX_ITEM_COUNT] = {
     { L"Copy",               L"Ctrl+C", false },
     { L"Select All",         L"Ctrl+A", true  },
     { L"New File",           L"N",      false },
+    { L"Print / PDF",        L"Ctrl+P", false },
     { L"Edit",               L":",      false },
     { L"Search",             L"F",      false },
     { L"Table of Contents",  L"Tab",    true  },

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -9,6 +9,7 @@
 #include <wincodec.h>
 #include <winspool.h>
 
+#include <algorithm>
 #include <cstring>
 
 #include <cmath>
@@ -37,9 +38,10 @@ D2DTheme printTheme() {
 
 using SavedView = App::PrintSavedView;
 
-// Re-layouts the document at page-content width, 96 DPI, zoom 1, in the
-// print palette. Restores everything in leavePrintLayout.
-void enterPrintLayout(App& app, float contentWidthDips, SavedView& saved) {
+// Saves the screen view state and switches to the print palette at 96 DPI,
+// zoom 1. layoutAtPrintWidth does the actual re-layout; leavePrintLayout
+// restores everything.
+void enterPrintLayout(App& app, SavedView& saved) {
     saved.width = app.width;
     saved.height = app.height;
     saved.contentScale = app.contentScale;
@@ -51,14 +53,91 @@ void enterPrintLayout(App& app, float contentWidthDips, SavedView& saved) {
     saved.targetScrollY = app.targetScrollY;
     saved.theme = app.theme;
 
-    app.width = (int)contentWidthDips;
-    app.height = 4000;  // layout does not clip vertically; any tall value
     app.contentScale = 1.0f;
     app.zoomFactor = 1.0f;
     app.theme = printTheme();
     updateTextFormats(app);
+}
+
+// Blocks wider than the printable area cannot reflow (mermaid diagrams and
+// tables have fixed layouts), so they print shrunk to fit the margins. Each
+// overflowing primitive seeds a vertical band that grows to swallow every
+// primitive it overlaps — the whole diagram or table scales together about
+// its own top-left, leaving whitespace below rather than moving later
+// content (pagination keeps using the unscaled bounds).
+void computeShrinkBands(App& app, float contentW) {
+    app.printShrinkBands.clear();
+    const float eps = 0.5f;
+
+    struct Item { float top, bottom, right; };
+    std::vector<Item> items;
+    items.reserve(app.layoutRects.size() + app.layoutLines.size() +
+                  app.layoutConnectors.size() + app.layoutShapes.size() +
+                  app.layoutBitmaps.size() + app.layoutTextRuns.size());
+    for (const auto& r : app.layoutRects)
+        items.push_back({r.rect.top, r.rect.bottom, r.rect.right});
+    for (const auto& l : app.layoutLines)
+        items.push_back({std::min(l.p1.y, l.p2.y), std::max(l.p1.y, l.p2.y),
+                         std::max(l.p1.x, l.p2.x)});
+    for (const auto& c : app.layoutConnectors)
+        items.push_back({c.bounds.top, c.bounds.bottom, c.bounds.right});
+    for (const auto& s : app.layoutShapes)
+        items.push_back({s.rect.top, s.rect.bottom, s.rect.right});
+    for (const auto& b : app.layoutBitmaps)
+        items.push_back({b.destRect.top, b.destRect.bottom, b.destRect.right});
+    for (const auto& t : app.layoutTextRuns)
+        items.push_back({t.bounds.top, t.bounds.bottom, t.bounds.right});
+
+    // Seed bands from overflowing items
+    struct Band { float top, bottom, right; };
+    std::vector<Band> bands;
+    for (const auto& it : items) {
+        if (it.right <= contentW + eps) continue;
+        bands.push_back({it.top, it.bottom, it.right});
+    }
+    if (bands.empty()) return;
+
+    // Grow bands over everything they vertically overlap, then merge bands
+    // that grew into each other; repeat until stable
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (auto& b : bands) {
+            for (const auto& it : items) {
+                if (it.bottom <= b.top + eps || it.top >= b.bottom - eps) continue;
+                if (it.top < b.top)       { b.top = it.top;       changed = true; }
+                if (it.bottom > b.bottom) { b.bottom = it.bottom; changed = true; }
+                if (it.right > b.right)   { b.right = it.right;   changed = true; }
+            }
+        }
+        std::sort(bands.begin(), bands.end(),
+                  [](const Band& a, const Band& b) { return a.top < b.top; });
+        for (size_t i = 0; i + 1 < bands.size();) {
+            if (bands[i + 1].top < bands[i].bottom - eps) {
+                bands[i].bottom = std::max(bands[i].bottom, bands[i + 1].bottom);
+                bands[i].right = std::max(bands[i].right, bands[i + 1].right);
+                bands.erase(bands.begin() + i + 1);
+                changed = true;
+            } else {
+                i++;
+            }
+        }
+    }
+
+    for (const auto& b : bands) {
+        float scale = std::max(0.1f, contentW / b.right);
+        app.printShrinkBands.push_back({b.top, b.bottom, scale});
+    }
+}
+
+// Re-layouts the document at page-content width and finds the oversized
+// blocks that need shrinking
+void layoutAtPrintWidth(App& app, float contentWidthDips) {
+    app.width = (int)contentWidthDips;
+    app.height = 4000;  // layout does not clip vertically; any tall value
     app.layoutDirty = true;
     ensureLayoutComplete(app);
+    computeShrinkBands(app, contentWidthDips);
 }
 
 void leavePrintLayout(App& app, const SavedView& saved) {
@@ -97,6 +176,9 @@ std::vector<float> computePageBreaks(const App& app, float pageContentH) {
             for (const auto& line : app.lineBuckets) consider(line.top, line.bottom);
             for (const auto& bmp : app.layoutBitmaps) consider(bmp.destRect.top, bmp.destRect.bottom);
             for (const auto& shape : app.layoutShapes) consider(shape.rect.top, shape.rect.bottom);
+            // Shrink bands page-break as a unit: a scaled diagram split
+            // across pages would render discontinuously
+            for (const auto& band : app.printShrinkBands) consider(band.top, band.bottom);
             if (adjusted == proposed) break;
             proposed = adjusted;
         }
@@ -129,29 +211,54 @@ void drawDocumentRange(App& app, ID2D1DeviceContext* dc,
     float dx = offsetX;
     float dy = offsetY - yStart;
 
+    // Oversized blocks draw scaled about their band's top-left; the band
+    // transform composes with whatever transform the caller set (the
+    // preview rasterizer scales the whole page to display resolution)
+    D2D1_MATRIX_3X2_F baseTransform;
+    dc->GetTransform(&baseTransform);
+    auto applyBand = [&](float top, float bottom) {
+        for (const auto& band : app.printShrinkBands) {
+            if (top >= band.top - 0.5f && bottom <= band.bottom + 0.5f) {
+                dc->SetTransform(
+                    D2D1::Matrix3x2F::Scale(band.scale, band.scale,
+                        D2D1::Point2F(dx, band.top + dy)) * baseTransform);
+                return true;
+            }
+        }
+        return false;
+    };
+    auto resetBand = [&](bool wasBanded) {
+        if (wasBanded) dc->SetTransform(baseTransform);
+    };
+
     for (const auto& rect : app.layoutRects) {
         if (!inRange(rect.rect.top, rect.rect.bottom)) continue;
+        bool banded = applyBand(rect.rect.top, rect.rect.bottom);
         brush->SetColor(rect.color);
         dc->FillRectangle(
             D2D1::RectF(rect.rect.left + dx, rect.rect.top + dy,
                         rect.rect.right + dx, rect.rect.bottom + dy),
             brush);
+        resetBand(banded);
     }
 
     for (const auto& line : app.layoutLines) {
         float top = std::min(line.p1.y, line.p2.y);
         float bottom = std::max(line.p1.y, line.p2.y);
         if (!inRange(top, bottom)) continue;
+        bool banded = applyBand(top, bottom);
         brush->SetColor(line.color);
         dc->DrawLine(D2D1::Point2F(line.p1.x + dx, line.p1.y + dy),
                      D2D1::Point2F(line.p2.x + dx, line.p2.y + dy),
                      brush, line.stroke);
+        resetBand(banded);
     }
 
     // Mermaid connectors (with arrowheads and dashing)
     for (const auto& connector : app.layoutConnectors) {
         if (!inRange(connector.bounds.top, connector.bounds.bottom)) continue;
         if (connector.points.size() < 2) continue;
+        bool banded = applyBand(connector.bounds.top, connector.bounds.bottom);
         brush->SetColor(connector.color);
         for (size_t i = 1; i < connector.points.size(); i++) {
             const auto& from = connector.points[i - 1];
@@ -182,6 +289,7 @@ void drawDocumentRange(App& app, ID2D1DeviceContext* dc,
                              brush, connector.stroke);
             }
         }
+        resetBand(banded);
     }
 
     // Mermaid node shapes
@@ -210,24 +318,21 @@ void drawDocumentRange(App& app, ID2D1DeviceContext* dc,
 
     for (const auto& shape : app.layoutShapes) {
         if (!inRange(shape.rect.top, shape.rect.bottom)) continue;
+        bool banded = applyBand(shape.rect.top, shape.rect.bottom);
         D2D1_RECT_F r = D2D1::RectF(shape.rect.left + dx, shape.rect.top + dy,
                                     shape.rect.right + dx, shape.rect.bottom + dy);
         if (shape.type == App::LayoutShapeType::Diamond) {
             float cx = (r.left + r.right) * 0.5f, cy = (r.top + r.bottom) * 0.5f;
             D2D1_POINT_2F pts[] = {{cx, r.top}, {r.right, cy}, {cx, r.bottom}, {r.left, cy}};
             fillStrokePolygon(pts, 4, shape);
-            continue;
-        }
-        if (shape.type == App::LayoutShapeType::Hexagon) {
+        } else if (shape.type == App::LayoutShapeType::Hexagon) {
             float inset = (r.right - r.left) * 0.18f;
             float cy = (r.top + r.bottom) * 0.5f;
             D2D1_POINT_2F pts[] = {{r.left + inset, r.top}, {r.right - inset, r.top},
                                    {r.right, cy}, {r.right - inset, r.bottom},
                                    {r.left + inset, r.bottom}, {r.left, cy}};
             fillStrokePolygon(pts, 6, shape);
-            continue;
-        }
-        if (shape.type == App::LayoutShapeType::Ellipse) {
+        } else if (shape.type == App::LayoutShapeType::Ellipse) {
             D2D1_ELLIPSE e = D2D1::Ellipse(
                 D2D1::Point2F((r.left + r.right) * 0.5f, (r.top + r.bottom) * 0.5f),
                 (r.right - r.left) * 0.5f, (r.bottom - r.top) * 0.5f);
@@ -236,10 +341,8 @@ void drawDocumentRange(App& app, ID2D1DeviceContext* dc,
                 brush->SetColor(shape.stroke);
                 dc->DrawEllipse(e, brush, shape.strokeWidth);
             }
-            continue;
-        }
-        if (shape.type == App::LayoutShapeType::RoundedRectangle ||
-            shape.type == App::LayoutShapeType::Stadium) {
+        } else if (shape.type == App::LayoutShapeType::RoundedRectangle ||
+                   shape.type == App::LayoutShapeType::Stadium) {
             float radius = shape.type == App::LayoutShapeType::Stadium
                 ? (r.bottom - r.top) * 0.5f : shape.radius;
             D2D1_ROUNDED_RECT rr = D2D1::RoundedRect(r, radius, radius);
@@ -248,32 +351,37 @@ void drawDocumentRange(App& app, ID2D1DeviceContext* dc,
                 brush->SetColor(shape.stroke);
                 dc->DrawRoundedRectangle(rr, brush, shape.strokeWidth);
             }
-            continue;
+        } else {
+            if (shape.fill.a > 0.0f) { brush->SetColor(shape.fill); dc->FillRectangle(r, brush); }
+            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                brush->SetColor(shape.stroke);
+                dc->DrawRectangle(r, brush, shape.strokeWidth);
+            }
         }
-        if (shape.fill.a > 0.0f) { brush->SetColor(shape.fill); dc->FillRectangle(r, brush); }
-        if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
-            brush->SetColor(shape.stroke);
-            dc->DrawRectangle(r, brush, shape.strokeWidth);
-        }
+        resetBand(banded);
     }
 
     // Images
     for (const auto& bmp : app.layoutBitmaps) {
         if (!bmp.bitmap) continue;
         if (!inRange(bmp.destRect.top, bmp.destRect.bottom)) continue;
+        bool banded = applyBand(bmp.destRect.top, bmp.destRect.bottom);
         dc->DrawBitmap(bmp.bitmap,
             D2D1::RectF(bmp.destRect.left + dx, bmp.destRect.top + dy,
                         bmp.destRect.right + dx, bmp.destRect.bottom + dy),
             1.0f, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR);
+        resetBand(banded);
     }
 
     // Text
     for (const auto& run : app.layoutTextRuns) {
         if (!run.layout) continue;
         if (!inRange(run.bounds.top, run.bounds.bottom)) continue;
+        bool banded = applyBand(run.bounds.top, run.bounds.bottom);
         brush->SetColor(run.color);
         dc->DrawTextLayout(D2D1::Point2F(run.pos.x + dx, run.pos.y + dy),
                            run.layout, brush);
+        resetBand(banded);
     }
 }
 
@@ -385,7 +493,8 @@ int renderPages(App& app, const PageGeometry& geo, EmitFn emitPage) {
     if (!device) return -1;
 
     SavedView saved{};
-    enterPrintLayout(app, geo.contentW, saved);
+    enterPrintLayout(app, saved);
+    layoutAtPrintWidth(app, geo.contentW);
 
     std::vector<float> breaks = computePageBreaks(app, geo.contentH);
     breaks.push_back(app.contentHeight + 1.0f);  // final page sentinel
@@ -437,7 +546,28 @@ bool printDocument(App& app) {
     pd.lStructSize = sizeof(pd);
     pd.hwndOwner = app.hwnd;
     pd.Flags = PD_RETURNDC | PD_NOPAGENUMS | PD_NOSELECTION | PD_USEDEVMODECOPIESANDCOLLATE;
+
+    // Preset the preview's paper and orientation; whatever the user picks
+    // in the dialog still wins (the geometry is re-read from the DC)
+    if (app.printPreviewPaper >= 0) {
+        pd.hDevMode = GlobalAlloc(GHND, sizeof(DEVMODEW));
+        if (pd.hDevMode) {
+            auto* dm = (DEVMODEW*)GlobalLock(pd.hDevMode);
+            if (dm) {
+                dm->dmSize = sizeof(DEVMODEW);
+                dm->dmSpecVersion = DM_SPECVERSION;
+                dm->dmFields = DM_ORIENTATION | DM_PAPERSIZE;
+                dm->dmOrientation = app.printPreviewLandscape
+                    ? DMORIENT_LANDSCAPE : DMORIENT_PORTRAIT;
+                dm->dmPaperSize = PRINT_PAPERS[app.printPreviewPaper].dmPaper;
+                GlobalUnlock(pd.hDevMode);
+            }
+        }
+    }
+
     if (!PrintDlgW(&pd) || !pd.hDC) {
+        if (pd.hDevMode) GlobalFree(pd.hDevMode);
+        if (pd.hDevNames) GlobalFree(pd.hDevNames);
         return false;  // cancelled
     }
 
@@ -500,19 +630,20 @@ bool printDocument(App& app) {
     return ok;
 }
 
-void openPrintPreview(App& app, HWND hwnd) {
-    if (app.showPrintPreview || !app.root || !app.deviceContext) return;
-    if (app.editMode) {
-        editorReparse(app);  // include unsaved edits in the preview and printout
-    }
+// Lays out, paginates, fits and rasterizes for the currently selected
+// paper format. Assumes enterPrintLayout has already run.
+static void refreshPreviewLayout(App& app) {
+    const PrintPaper& paper = PRINT_PAPERS[app.printPreviewPaper];
+    float pageW = app.printPreviewLandscape ? paper.h : paper.w;
+    float pageH = app.printPreviewLandscape ? paper.w : paper.h;
+    app.printPreviewPageW = pageW;
+    app.printPreviewPageH = pageH;
+    float contentW = pageW - kPageMarginDips * 2;
+    float contentH = pageH - kPageMarginDips * 2;
 
-    PageGeometry geo = defaultPageGeometry();
-    app.printPreviewPageW = geo.pageW;
-    app.printPreviewPageH = geo.pageH;
+    layoutAtPrintWidth(app, contentW);
 
-    enterPrintLayout(app, geo.contentW, app.printSaved);
-
-    std::vector<float> breaks = computePageBreaks(app, geo.contentH);
+    std::vector<float> breaks = computePageBreaks(app, contentH);
     app.printPreviewBounds.clear();
     app.printPreviewBounds.push_back(0.0f);
     for (float b : breaks) app.printPreviewBounds.push_back(b);
@@ -523,14 +654,58 @@ void openPrintPreview(App& app, HWND hwnd) {
     float availW = app.printSaved.width - 80.0f * ui;
     float availH = app.printSaved.height - 130.0f * ui;
     app.printPreviewFit = std::max(0.05f,
-        std::min(availW / geo.pageW, availH / geo.pageH));
-    app.printPreviewPxW = (unsigned)(geo.pageW * app.printPreviewFit);
-    app.printPreviewPxH = (unsigned)(geo.pageH * app.printPreviewFit);
+        std::min(availW / pageW, availH / pageH));
+    app.printPreviewPxW = (unsigned)(pageW * app.printPreviewFit);
+    app.printPreviewPxH = (unsigned)(pageH * app.printPreviewFit);
 
+    int pageCount = (int)app.printPreviewBounds.size() - 1;
+    app.printPreviewPage = std::max(0, std::min(app.printPreviewPage, pageCount - 1));
+    rasterizePreviewPage(app, app.printPreviewPage);
+}
+
+// First open: start from the default printer's paper, matched to the
+// closest offered format
+static void detectDefaultFormat(App& app) {
+    PageGeometry geo = defaultPageGeometry();
+    bool landscape = geo.pageW > geo.pageH;
+    float w = landscape ? geo.pageH : geo.pageW;
+    float h = landscape ? geo.pageW : geo.pageH;
+    int best = 0;
+    float bestDiff = 1e9f;
+    for (int i = 0; i < PRINT_PAPER_COUNT; i++) {
+        float diff = std::fabs(w - PRINT_PAPERS[i].w) + std::fabs(h - PRINT_PAPERS[i].h);
+        if (diff < bestDiff) { bestDiff = diff; best = i; }
+    }
+    app.printPreviewPaper = best;
+    app.printPreviewLandscape = landscape;
+}
+
+void openPrintPreview(App& app, HWND hwnd) {
+    if (app.showPrintPreview || !app.root || !app.deviceContext) return;
+    if (app.editMode) {
+        editorReparse(app);  // include unsaved edits in the preview and printout
+    }
+    if (app.printPreviewPaper < 0) detectDefaultFormat(app);
+
+    enterPrintLayout(app, app.printSaved);
     app.printPreviewPage = 0;
-    rasterizePreviewPage(app, 0);
+    refreshPreviewLayout(app);
     app.showPrintPreview = true;
     InvalidateRect(hwnd, nullptr, FALSE);
+}
+
+void printPreviewSetFormat(App& app, int paper, bool landscape) {
+    paper = std::max(0, std::min(paper, PRINT_PAPER_COUNT - 1));
+    if (!app.showPrintPreview) {
+        app.printPreviewPaper = paper;
+        app.printPreviewLandscape = landscape;
+        return;
+    }
+    if (paper == app.printPreviewPaper && landscape == app.printPreviewLandscape) return;
+    app.printPreviewPaper = paper;
+    app.printPreviewLandscape = landscape;
+    refreshPreviewLayout(app);
+    if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
 }
 
 void closePrintPreview(App& app, HWND hwnd) {

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -1,11 +1,15 @@
 #include "print.h"
 #include "render.h"
 #include "d2d_init.h"
+#include "editor.h"
 #include "utils.h"
 
 #include <commdlg.h>
 #include <documenttarget.h>
 #include <wincodec.h>
+#include <winspool.h>
+
+#include <cstring>
 
 #include <cmath>
 #include <string>
@@ -31,12 +35,7 @@ D2DTheme printTheme() {
     return t;
 }
 
-struct SavedView {
-    int width, height;
-    float contentScale, zoomFactor, appliedZoomFactor;
-    float scrollX, scrollY, targetScrollX, targetScrollY;
-    D2DTheme theme;
-};
+using SavedView = App::PrintSavedView;
 
 // Re-layouts the document at page-content width, 96 DPI, zoom 1, in the
 // print palette. Restores everything in leavePrintLayout.
@@ -283,6 +282,98 @@ struct PageGeometry {
     float contentW, contentH;    // inside the margins
 };
 
+// Paper size of the default printer, for previewing before the dialog runs.
+// printDocument re-reads the size from whatever printer is finally picked.
+PageGeometry defaultPageGeometry() {
+    PageGeometry geo{794.0f, 1123.0f, 0.0f, 0.0f};  // A4 fallback
+    wchar_t printer[256];
+    DWORD len = 256;
+    if (GetDefaultPrinterW(printer, &len)) {
+        HDC dc = CreateDCW(L"WINSPOOL", printer, nullptr, nullptr);
+        if (dc) {
+            float dpiX = (float)GetDeviceCaps(dc, LOGPIXELSX);
+            float dpiY = (float)GetDeviceCaps(dc, LOGPIXELSY);
+            float w = GetDeviceCaps(dc, PHYSICALWIDTH) * 96.0f / dpiX;
+            float h = GetDeviceCaps(dc, PHYSICALHEIGHT) * 96.0f / dpiY;
+            if (w >= 200 && h >= 200) {
+                geo.pageW = w;
+                geo.pageH = h;
+            }
+            DeleteDC(dc);
+        }
+    }
+    geo.contentW = geo.pageW - kPageMarginDips * 2;
+    geo.contentH = geo.pageH - kPageMarginDips * 2;
+    return geo;
+}
+
+// Rasterizes one page of the active print layout into the preview pixel
+// buffer at display resolution (page DIPs scaled by printPreviewFit), so
+// the preview stays crisp instead of downscaling a 96-DPI rendering.
+bool rasterizePreviewPage(App& app, int page) {
+    int pageCount = (int)app.printPreviewBounds.size() - 1;
+    if (page < 0 || page >= pageCount || !app.deviceContext) return false;
+    UINT pxW = app.printPreviewPxW, pxH = app.printPreviewPxH;
+    if (pxW == 0 || pxH == 0) return false;
+
+    ID2D1Device* device = nullptr;
+    app.deviceContext->GetDevice(&device);
+    if (!device) return false;
+    ID2D1DeviceContext* dc = nullptr;
+    device->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &dc);
+    device->Release();
+    if (!dc) return false;
+
+    D2D1_BITMAP_PROPERTIES1 targetProps = D2D1::BitmapProperties1(
+        D2D1_BITMAP_OPTIONS_TARGET,
+        D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED));
+    D2D1_BITMAP_PROPERTIES1 stagingProps = D2D1::BitmapProperties1(
+        D2D1_BITMAP_OPTIONS_CPU_READ | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+        D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED));
+    ID2D1Bitmap1* target = nullptr;
+    ID2D1Bitmap1* staging = nullptr;
+    dc->CreateBitmap(D2D1::SizeU(pxW, pxH), nullptr, 0, &targetProps, &target);
+    dc->CreateBitmap(D2D1::SizeU(pxW, pxH), nullptr, 0, &stagingProps, &staging);
+
+    bool ok = false;
+    if (target && staging) {
+        dc->SetTarget(target);
+        dc->BeginDraw();
+        dc->SetTransform(D2D1::Matrix3x2F::Scale(app.printPreviewFit, app.printPreviewFit));
+        dc->Clear(D2D1::ColorF(1.0f, 1.0f, 1.0f));
+        ID2D1SolidColorBrush* brush = nullptr;
+        dc->CreateSolidColorBrush(D2D1::ColorF(0, 0, 0), &brush);
+        if (brush) {
+            drawDocumentRange(app, dc, brush,
+                              app.printPreviewBounds[page],
+                              app.printPreviewBounds[page + 1],
+                              kPageMarginDips, kPageMarginDips);
+            brush->Release();
+        }
+        dc->SetTransform(D2D1::Matrix3x2F::Identity());
+        if (SUCCEEDED(dc->EndDraw())) {
+            D2D1_POINT_2U zero{0, 0};
+            D2D1_RECT_U all{0, 0, pxW, pxH};
+            D2D1_MAPPED_RECT mapped{};
+            if (SUCCEEDED(staging->CopyFromBitmap(&zero, target, &all)) &&
+                SUCCEEDED(staging->Map(D2D1_MAP_OPTIONS_READ, &mapped))) {
+                app.printPreviewPixels.resize((size_t)pxW * pxH * 4);
+                for (UINT row = 0; row < pxH; row++) {
+                    memcpy(app.printPreviewPixels.data() + (size_t)row * pxW * 4,
+                           mapped.bits + (size_t)row * mapped.pitch,
+                           (size_t)pxW * 4);
+                }
+                staging->Unmap();
+                ok = true;
+            }
+        }
+    }
+    if (staging) staging->Release();
+    if (target) target->Release();
+    dc->Release();
+    return ok;
+}
+
 // Runs layout + pagination + per-page drawing. emitPage receives a closed
 // command list per page. Returns page count, or -1 on failure.
 template <typename EmitFn>
@@ -407,6 +498,70 @@ bool printDocument(App& app) {
     }
     target->Release();
     return ok;
+}
+
+void openPrintPreview(App& app, HWND hwnd) {
+    if (app.showPrintPreview || !app.root || !app.deviceContext) return;
+    if (app.editMode) {
+        editorReparse(app);  // include unsaved edits in the preview and printout
+    }
+
+    PageGeometry geo = defaultPageGeometry();
+    app.printPreviewPageW = geo.pageW;
+    app.printPreviewPageH = geo.pageH;
+
+    enterPrintLayout(app, geo.contentW, app.printSaved);
+
+    std::vector<float> breaks = computePageBreaks(app, geo.contentH);
+    app.printPreviewBounds.clear();
+    app.printPreviewBounds.push_back(0.0f);
+    for (float b : breaks) app.printPreviewBounds.push_back(b);
+    app.printPreviewBounds.push_back(app.contentHeight + 1.0f);
+
+    // Fit the page between the header and the button bar
+    float ui = app.printSaved.contentScale;
+    float availW = app.printSaved.width - 80.0f * ui;
+    float availH = app.printSaved.height - 130.0f * ui;
+    app.printPreviewFit = std::max(0.05f,
+        std::min(availW / geo.pageW, availH / geo.pageH));
+    app.printPreviewPxW = (unsigned)(geo.pageW * app.printPreviewFit);
+    app.printPreviewPxH = (unsigned)(geo.pageH * app.printPreviewFit);
+
+    app.printPreviewPage = 0;
+    rasterizePreviewPage(app, 0);
+    app.showPrintPreview = true;
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
+void closePrintPreview(App& app, HWND hwnd) {
+    if (!app.showPrintPreview) return;
+    app.showPrintPreview = false;
+    leavePrintLayout(app, app.printSaved);
+    app.printPreviewPixels.clear();
+    app.printPreviewPixels.shrink_to_fit();
+    app.printPreviewBounds.clear();
+    if (app.editMode) {
+        // Editor line layouts were built against the print-layout formats
+        app.clearEditorLineLayoutCache();
+        app.editorRowMetricsWidth = -1.0f;
+    }
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
+void printPreviewSetPage(App& app, int page) {
+    if (!app.showPrintPreview) return;
+    int pageCount = (int)app.printPreviewBounds.size() - 1;
+    page = std::max(0, std::min(page, pageCount - 1));
+    if (page == app.printPreviewPage) return;
+    app.printPreviewPage = page;
+    rasterizePreviewPage(app, page);
+    if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
+}
+
+void printPreviewConfirm(App& app, HWND hwnd) {
+    if (!app.showPrintPreview) return;
+    closePrintPreview(app, hwnd);
+    printDocument(app);
 }
 
 int printDebugPages(App& app, const std::wstring& outDir) {

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -1,0 +1,490 @@
+#include "print.h"
+#include "render.h"
+#include "d2d_init.h"
+#include "utils.h"
+
+#include <commdlg.h>
+#include <documenttarget.h>
+#include <wincodec.h>
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+// --- Printing (#74) ---
+//
+// No PDF library: the document is re-laid-out at page width in a light
+// print palette and each page is replayed into a D2D command list handed
+// to ID2D1PrintControl. The Windows print pipeline does the rest — pick
+// "Microsoft Print to PDF" and the OS produces the PDF, with font
+// embedding (including CJK) handled by the driver.
+
+namespace {
+
+constexpr float kPageMarginDips = 72.0f;  // 0.75 in
+
+// Paper-derived palette with a true white page
+D2DTheme printTheme() {
+    D2DTheme t = THEMES[0];  // Paper (light)
+    t.background = D2D1::ColorF(1.0f, 1.0f, 1.0f);
+    t.codeBackground = hexColor(0xF4F4F4);
+    return t;
+}
+
+struct SavedView {
+    int width, height;
+    float contentScale, zoomFactor, appliedZoomFactor;
+    float scrollX, scrollY, targetScrollX, targetScrollY;
+    D2DTheme theme;
+};
+
+// Re-layouts the document at page-content width, 96 DPI, zoom 1, in the
+// print palette. Restores everything in leavePrintLayout.
+void enterPrintLayout(App& app, float contentWidthDips, SavedView& saved) {
+    saved.width = app.width;
+    saved.height = app.height;
+    saved.contentScale = app.contentScale;
+    saved.zoomFactor = app.zoomFactor;
+    saved.appliedZoomFactor = app.appliedZoomFactor;
+    saved.scrollX = app.scrollX;
+    saved.scrollY = app.scrollY;
+    saved.targetScrollX = app.targetScrollX;
+    saved.targetScrollY = app.targetScrollY;
+    saved.theme = app.theme;
+
+    app.width = (int)contentWidthDips;
+    app.height = 4000;  // layout does not clip vertically; any tall value
+    app.contentScale = 1.0f;
+    app.zoomFactor = 1.0f;
+    app.theme = printTheme();
+    updateTextFormats(app);
+    app.layoutDirty = true;
+    ensureLayoutComplete(app);
+}
+
+void leavePrintLayout(App& app, const SavedView& saved) {
+    app.width = saved.width;
+    app.height = saved.height;
+    app.contentScale = saved.contentScale;
+    app.zoomFactor = saved.zoomFactor;
+    app.theme = saved.theme;
+    updateTextFormats(app);
+    app.appliedZoomFactor = saved.appliedZoomFactor;
+    app.layoutDirty = true;
+    ensureLayoutComplete(app);
+    app.scrollX = saved.scrollX;
+    app.scrollY = saved.scrollY;
+    app.targetScrollX = saved.targetScrollX;
+    app.targetScrollY = saved.targetScrollY;
+    if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
+}
+
+// Page break positions in document Y. Breaks avoid slicing text lines,
+// images, and diagram shapes by pulling the cut above any straddling atom;
+// an atom taller than most of a page is sliced rather than looping.
+std::vector<float> computePageBreaks(const App& app, float pageContentH) {
+    std::vector<float> breaks;
+    float docEnd = app.contentHeight;
+    float y = 0.0f;
+
+    auto pullAbove = [&](float proposed, float pageTop) {
+        for (int pass = 0; pass < 4; pass++) {
+            float adjusted = proposed;
+            auto consider = [&](float top, float bottom) {
+                if (top < adjusted && bottom > adjusted && top > pageTop) {
+                    adjusted = top;
+                }
+            };
+            for (const auto& line : app.lineBuckets) consider(line.top, line.bottom);
+            for (const auto& bmp : app.layoutBitmaps) consider(bmp.destRect.top, bmp.destRect.bottom);
+            for (const auto& shape : app.layoutShapes) consider(shape.rect.top, shape.rect.bottom);
+            if (adjusted == proposed) break;
+            proposed = adjusted;
+        }
+        // Monster atom (taller than 70% of a page): slice it instead
+        if (proposed - pageTop < pageContentH * 0.3f) {
+            return pageTop + pageContentH;
+        }
+        return proposed;
+    };
+
+    while (y + pageContentH < docEnd) {
+        float next = pullAbove(y + pageContentH, y);
+        breaks.push_back(next);
+        y = next;
+    }
+    return breaks;  // implicit final page runs to docEnd
+}
+
+// Replays the cached layout for the document Y range [yStart, yEnd) into
+// the given device context, translated so yStart lands at offsetY. A
+// print-path sibling of render()'s document pass — selection, search, and
+// hover chrome intentionally excluded.
+void drawDocumentRange(App& app, ID2D1DeviceContext* dc,
+                       ID2D1SolidColorBrush* brush,
+                       float yStart, float yEnd,
+                       float offsetX, float offsetY) {
+    auto inRange = [&](float top, float bottom) {
+        return bottom >= yStart && top < yEnd;
+    };
+    float dx = offsetX;
+    float dy = offsetY - yStart;
+
+    for (const auto& rect : app.layoutRects) {
+        if (!inRange(rect.rect.top, rect.rect.bottom)) continue;
+        brush->SetColor(rect.color);
+        dc->FillRectangle(
+            D2D1::RectF(rect.rect.left + dx, rect.rect.top + dy,
+                        rect.rect.right + dx, rect.rect.bottom + dy),
+            brush);
+    }
+
+    for (const auto& line : app.layoutLines) {
+        float top = std::min(line.p1.y, line.p2.y);
+        float bottom = std::max(line.p1.y, line.p2.y);
+        if (!inRange(top, bottom)) continue;
+        brush->SetColor(line.color);
+        dc->DrawLine(D2D1::Point2F(line.p1.x + dx, line.p1.y + dy),
+                     D2D1::Point2F(line.p2.x + dx, line.p2.y + dy),
+                     brush, line.stroke);
+    }
+
+    // Mermaid connectors (with arrowheads and dashing)
+    for (const auto& connector : app.layoutConnectors) {
+        if (!inRange(connector.bounds.top, connector.bounds.bottom)) continue;
+        if (connector.points.size() < 2) continue;
+        brush->SetColor(connector.color);
+        for (size_t i = 1; i < connector.points.size(); i++) {
+            const auto& from = connector.points[i - 1];
+            const auto& to = connector.points[i];
+            dc->DrawLine(D2D1::Point2F(from.x + dx, from.y + dy),
+                         D2D1::Point2F(to.x + dx, to.y + dy),
+                         brush, connector.stroke,
+                         connector.dashed ? app.dashedStrokeStyle : nullptr);
+        }
+        if (connector.directed) {
+            const auto& tip = connector.points.back();
+            const auto& prev = connector.points[connector.points.size() - 2];
+            float vx = tip.x - prev.x, vy = tip.y - prev.y;
+            float len = std::sqrt(vx * vx + vy * vy);
+            if (len > 0.001f) {
+                vx /= len; vy /= len;
+                float wing = connector.arrowSize * 0.5f;
+                D2D1_POINT_2F left = D2D1::Point2F(
+                    tip.x - vx * connector.arrowSize + vy * wing,
+                    tip.y - vy * connector.arrowSize - vx * wing);
+                D2D1_POINT_2F right = D2D1::Point2F(
+                    tip.x - vx * connector.arrowSize - vy * wing,
+                    tip.y - vy * connector.arrowSize + vx * wing);
+                D2D1_POINT_2F screenTip = D2D1::Point2F(tip.x + dx, tip.y + dy);
+                dc->DrawLine(screenTip, D2D1::Point2F(left.x + dx, left.y + dy),
+                             brush, connector.stroke);
+                dc->DrawLine(screenTip, D2D1::Point2F(right.x + dx, right.y + dy),
+                             brush, connector.stroke);
+            }
+        }
+    }
+
+    // Mermaid node shapes
+    auto fillStrokePolygon = [&](const D2D1_POINT_2F* pts, size_t count,
+                                 const App::LayoutShape& shape) {
+        ID2D1PathGeometry* geometry = nullptr;
+        if (FAILED(app.d2dFactory->CreatePathGeometry(&geometry)) || !geometry) return;
+        ID2D1GeometrySink* sink = nullptr;
+        if (SUCCEEDED(geometry->Open(&sink)) && sink) {
+            sink->BeginFigure(pts[0], D2D1_FIGURE_BEGIN_FILLED);
+            sink->AddLines(pts + 1, (UINT32)(count - 1));
+            sink->EndFigure(D2D1_FIGURE_END_CLOSED);
+            sink->Close();
+            sink->Release();
+            if (shape.fill.a > 0.0f) {
+                brush->SetColor(shape.fill);
+                dc->FillGeometry(geometry, brush);
+            }
+            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                brush->SetColor(shape.stroke);
+                dc->DrawGeometry(geometry, brush, shape.strokeWidth);
+            }
+        }
+        geometry->Release();
+    };
+
+    for (const auto& shape : app.layoutShapes) {
+        if (!inRange(shape.rect.top, shape.rect.bottom)) continue;
+        D2D1_RECT_F r = D2D1::RectF(shape.rect.left + dx, shape.rect.top + dy,
+                                    shape.rect.right + dx, shape.rect.bottom + dy);
+        if (shape.type == App::LayoutShapeType::Diamond) {
+            float cx = (r.left + r.right) * 0.5f, cy = (r.top + r.bottom) * 0.5f;
+            D2D1_POINT_2F pts[] = {{cx, r.top}, {r.right, cy}, {cx, r.bottom}, {r.left, cy}};
+            fillStrokePolygon(pts, 4, shape);
+            continue;
+        }
+        if (shape.type == App::LayoutShapeType::Hexagon) {
+            float inset = (r.right - r.left) * 0.18f;
+            float cy = (r.top + r.bottom) * 0.5f;
+            D2D1_POINT_2F pts[] = {{r.left + inset, r.top}, {r.right - inset, r.top},
+                                   {r.right, cy}, {r.right - inset, r.bottom},
+                                   {r.left + inset, r.bottom}, {r.left, cy}};
+            fillStrokePolygon(pts, 6, shape);
+            continue;
+        }
+        if (shape.type == App::LayoutShapeType::Ellipse) {
+            D2D1_ELLIPSE e = D2D1::Ellipse(
+                D2D1::Point2F((r.left + r.right) * 0.5f, (r.top + r.bottom) * 0.5f),
+                (r.right - r.left) * 0.5f, (r.bottom - r.top) * 0.5f);
+            if (shape.fill.a > 0.0f) { brush->SetColor(shape.fill); dc->FillEllipse(e, brush); }
+            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                brush->SetColor(shape.stroke);
+                dc->DrawEllipse(e, brush, shape.strokeWidth);
+            }
+            continue;
+        }
+        if (shape.type == App::LayoutShapeType::RoundedRectangle ||
+            shape.type == App::LayoutShapeType::Stadium) {
+            float radius = shape.type == App::LayoutShapeType::Stadium
+                ? (r.bottom - r.top) * 0.5f : shape.radius;
+            D2D1_ROUNDED_RECT rr = D2D1::RoundedRect(r, radius, radius);
+            if (shape.fill.a > 0.0f) { brush->SetColor(shape.fill); dc->FillRoundedRectangle(rr, brush); }
+            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                brush->SetColor(shape.stroke);
+                dc->DrawRoundedRectangle(rr, brush, shape.strokeWidth);
+            }
+            continue;
+        }
+        if (shape.fill.a > 0.0f) { brush->SetColor(shape.fill); dc->FillRectangle(r, brush); }
+        if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+            brush->SetColor(shape.stroke);
+            dc->DrawRectangle(r, brush, shape.strokeWidth);
+        }
+    }
+
+    // Images
+    for (const auto& bmp : app.layoutBitmaps) {
+        if (!bmp.bitmap) continue;
+        if (!inRange(bmp.destRect.top, bmp.destRect.bottom)) continue;
+        dc->DrawBitmap(bmp.bitmap,
+            D2D1::RectF(bmp.destRect.left + dx, bmp.destRect.top + dy,
+                        bmp.destRect.right + dx, bmp.destRect.bottom + dy),
+            1.0f, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR);
+    }
+
+    // Text
+    for (const auto& run : app.layoutTextRuns) {
+        if (!run.layout) continue;
+        if (!inRange(run.bounds.top, run.bounds.bottom)) continue;
+        brush->SetColor(run.color);
+        dc->DrawTextLayout(D2D1::Point2F(run.pos.x + dx, run.pos.y + dy),
+                           run.layout, brush);
+    }
+}
+
+struct PageGeometry {
+    float pageW, pageH;          // full page in DIPs
+    float contentW, contentH;    // inside the margins
+};
+
+// Runs layout + pagination + per-page drawing. emitPage receives a closed
+// command list per page. Returns page count, or -1 on failure.
+template <typename EmitFn>
+int renderPages(App& app, const PageGeometry& geo, EmitFn emitPage) {
+    if (!app.deviceContext || !app.root) return -1;
+
+    ID2D1Device* device = nullptr;
+    app.deviceContext->GetDevice(&device);
+    if (!device) return -1;
+
+    SavedView saved{};
+    enterPrintLayout(app, geo.contentW, saved);
+
+    std::vector<float> breaks = computePageBreaks(app, geo.contentH);
+    breaks.push_back(app.contentHeight + 1.0f);  // final page sentinel
+
+    ID2D1DeviceContext* pageDc = nullptr;
+    device->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &pageDc);
+    int pages = 0;
+    bool ok = pageDc != nullptr;
+
+    float yStart = 0.0f;
+    for (size_t i = 0; ok && i < breaks.size(); i++) {
+        float yEnd = breaks[i];
+        ID2D1CommandList* commandList = nullptr;
+        if (FAILED(pageDc->CreateCommandList(&commandList)) || !commandList) {
+            ok = false;
+            break;
+        }
+        pageDc->SetTarget(commandList);
+        pageDc->BeginDraw();
+        pageDc->Clear(D2D1::ColorF(1.0f, 1.0f, 1.0f));
+        ID2D1SolidColorBrush* brush = nullptr;
+        pageDc->CreateSolidColorBrush(D2D1::ColorF(0, 0, 0), &brush);
+        if (brush) {
+            drawDocumentRange(app, pageDc, brush, yStart, yEnd,
+                              kPageMarginDips, kPageMarginDips);
+            brush->Release();
+        }
+        ok = SUCCEEDED(pageDc->EndDraw()) && SUCCEEDED(commandList->Close());
+        if (ok) {
+            ok = emitPage(commandList, pages);
+            pages++;
+        }
+        commandList->Release();
+        pageDc->SetTarget(nullptr);
+        yStart = yEnd;
+    }
+
+    if (pageDc) pageDc->Release();
+    device->Release();
+    leavePrintLayout(app, saved);
+    return ok ? pages : -1;
+}
+
+} // namespace
+
+bool printDocument(App& app) {
+    // Standard printer picker; PD_RETURNDC so the paper size can be read
+    PRINTDLGW pd{};
+    pd.lStructSize = sizeof(pd);
+    pd.hwndOwner = app.hwnd;
+    pd.Flags = PD_RETURNDC | PD_NOPAGENUMS | PD_NOSELECTION | PD_USEDEVMODECOPIESANDCOLLATE;
+    if (!PrintDlgW(&pd) || !pd.hDC) {
+        return false;  // cancelled
+    }
+
+    float dpiX = (float)GetDeviceCaps(pd.hDC, LOGPIXELSX);
+    float dpiY = (float)GetDeviceCaps(pd.hDC, LOGPIXELSY);
+    PageGeometry geo{};
+    geo.pageW = GetDeviceCaps(pd.hDC, PHYSICALWIDTH) * 96.0f / dpiX;
+    geo.pageH = GetDeviceCaps(pd.hDC, PHYSICALHEIGHT) * 96.0f / dpiY;
+    if (geo.pageW < 200 || geo.pageH < 200) {  // driver returned nonsense
+        geo.pageW = 794.0f;   // A4
+        geo.pageH = 1123.0f;
+    }
+    geo.contentW = geo.pageW - kPageMarginDips * 2;
+    geo.contentH = geo.pageH - kPageMarginDips * 2;
+
+    // Printer name from the DEVNAMES block
+    std::wstring printerName;
+    if (pd.hDevNames) {
+        auto* names = (DEVNAMES*)GlobalLock(pd.hDevNames);
+        if (names) {
+            printerName = (wchar_t*)names + names->wDeviceOffset;
+            GlobalUnlock(pd.hDevNames);
+        }
+    }
+    DeleteDC(pd.hDC);
+    if (pd.hDevMode) GlobalFree(pd.hDevMode);
+    if (pd.hDevNames) GlobalFree(pd.hDevNames);
+    if (printerName.empty()) return false;
+
+    IPrintDocumentPackageTargetFactory* factory = nullptr;
+    if (FAILED(CoCreateInstance(__uuidof(PrintDocumentPackageTargetFactory), nullptr,
+                                CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&factory)))) {
+        return false;
+    }
+    std::wstring jobName = L"Tinta - " + toWide(app.currentFile);
+    IPrintDocumentPackageTarget* target = nullptr;
+    HRESULT hr = factory->CreateDocumentPackageTargetForPrintJob(
+        printerName.c_str(), jobName.c_str(), nullptr, nullptr, &target);
+    factory->Release();
+    if (FAILED(hr) || !target) return false;
+
+    ID2D1Device* device = nullptr;
+    app.deviceContext->GetDevice(&device);
+    ID2D1PrintControl* printControl = nullptr;
+    if (device) {
+        device->CreatePrintControl(app.wicFactory, target, nullptr, &printControl);
+        device->Release();
+    }
+
+    bool ok = false;
+    if (printControl) {
+        int pages = renderPages(app, geo, [&](ID2D1CommandList* list, int) {
+            return SUCCEEDED(printControl->AddPage(
+                list, D2D1::SizeF(geo.pageW, geo.pageH), nullptr));
+        });
+        ok = pages > 0 && SUCCEEDED(printControl->Close());
+        printControl->Release();
+    }
+    target->Release();
+    return ok;
+}
+
+int printDebugPages(App& app, const std::wstring& outDir) {
+    PageGeometry geo{794.0f, 1123.0f, 794.0f - kPageMarginDips * 2,
+                     1123.0f - kPageMarginDips * 2};  // A4
+
+    ID2D1Device* device = nullptr;
+    app.deviceContext->GetDevice(&device);
+    if (!device) return -1;
+    ID2D1DeviceContext* rasterDc = nullptr;
+    device->CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &rasterDc);
+    device->Release();
+    if (!rasterDc) return -1;
+
+    UINT pw = (UINT)geo.pageW, ph = (UINT)geo.pageH;
+    D2D1_BITMAP_PROPERTIES1 targetProps = D2D1::BitmapProperties1(
+        D2D1_BITMAP_OPTIONS_TARGET,
+        D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED));
+    D2D1_BITMAP_PROPERTIES1 stagingProps = D2D1::BitmapProperties1(
+        D2D1_BITMAP_OPTIONS_CPU_READ | D2D1_BITMAP_OPTIONS_CANNOT_DRAW,
+        D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED));
+
+    ID2D1Bitmap1* pageBitmap = nullptr;
+    ID2D1Bitmap1* staging = nullptr;
+    rasterDc->CreateBitmap(D2D1::SizeU(pw, ph), nullptr, 0, &targetProps, &pageBitmap);
+    rasterDc->CreateBitmap(D2D1::SizeU(pw, ph), nullptr, 0, &stagingProps, &staging);
+    if (!pageBitmap || !staging) {
+        if (pageBitmap) pageBitmap->Release();
+        if (staging) staging->Release();
+        rasterDc->Release();
+        return -1;
+    }
+
+    CreateDirectoryW(outDir.c_str(), nullptr);
+
+    int pages = renderPages(app, geo, [&](ID2D1CommandList* list, int index) {
+        rasterDc->SetTarget(pageBitmap);
+        rasterDc->BeginDraw();
+        rasterDc->Clear(D2D1::ColorF(1.0f, 1.0f, 1.0f));
+        rasterDc->DrawImage(list);
+        if (FAILED(rasterDc->EndDraw())) return false;
+
+        D2D1_POINT_2U zero{0, 0};
+        D2D1_RECT_U all{0, 0, pw, ph};
+        if (FAILED(staging->CopyFromBitmap(&zero, pageBitmap, &all))) return false;
+        D2D1_MAPPED_RECT mapped{};
+        if (FAILED(staging->Map(D2D1_MAP_OPTIONS_READ, &mapped))) return false;
+
+        bool written = false;
+        IWICBitmapEncoder* encoder = nullptr;
+        IWICStream* stream = nullptr;
+        IWICBitmapFrameEncode* frame = nullptr;
+        std::wstring path = outDir + L"\\page-" + std::to_wstring(index + 1) + L".png";
+        if (app.wicFactory &&
+            SUCCEEDED(app.wicFactory->CreateStream(&stream)) &&
+            SUCCEEDED(stream->InitializeFromFilename(path.c_str(), GENERIC_WRITE)) &&
+            SUCCEEDED(app.wicFactory->CreateEncoder(GUID_ContainerFormatPng, nullptr, &encoder)) &&
+            SUCCEEDED(encoder->Initialize(stream, WICBitmapEncoderNoCache)) &&
+            SUCCEEDED(encoder->CreateNewFrame(&frame, nullptr)) &&
+            SUCCEEDED(frame->Initialize(nullptr))) {
+            frame->SetSize(pw, ph);
+            WICPixelFormatGUID fmt = GUID_WICPixelFormat32bppBGRA;
+            frame->SetPixelFormat(&fmt);
+            if (SUCCEEDED(frame->WritePixels(ph, mapped.pitch,
+                                             mapped.pitch * ph, mapped.bits)) &&
+                SUCCEEDED(frame->Commit()) && SUCCEEDED(encoder->Commit())) {
+                written = true;
+            }
+        }
+        if (frame) frame->Release();
+        if (encoder) encoder->Release();
+        if (stream) stream->Release();
+        staging->Unmap();
+        return written;
+    });
+
+    staging->Release();
+    pageBitmap->Release();
+    rasterDc->Release();
+    return pages;
+}


### PR DESCRIPTION
Implements the PDF-export ask from #74 without bundling a PDF library.

## How it works

- **Ctrl+P** in both viewer and edit mode (and a **Print / PDF** entry in the right-click menu) opens a **print preview**: the paginated document rendered page by page on a themed backdrop, with scroll / PgUp / PgDn / Home / End to flip pages and a page indicator. **Enter** or the **Print…** button proceeds to the standard Windows printer dialog; **Esc** or **Cancel** returns to the document. Printing from edit mode re-parses first, so unsaved edits are included.
- **Paper & orientation in the preview**: A4 / Letter / Legal / A3 chips and Portrait / Landscape chips re-paginate live. The choice is preset into the printer dialog (DEVMODE); whatever the dialog finally answers still wins, since page geometry is re-read from the printer DC. First open detects the default printer's paper.
- **Shrink-to-fit for oversized blocks**: mermaid diagrams and wide tables cannot reflow, so anything wider than the printable area used to clip at the right margin. Overflowing content now seeds vertical "shrink bands" that grow to cover the whole block; the entire diagram or table draws uniformly scaled to fit the margins, and pagination keeps a band on one page.
- Picking **Microsoft Print to PDF** in the dialog produces the PDF; any physical printer works the same way.
- The document is re-laid-out at page width in a dedicated light **print palette** (Paper theme on a true white page) regardless of the active screen theme — same convention Obsidian/Typora follow for export.
- Each page is replayed into a D2D command list and handed to `ID2D1PrintControl`, so output stays vector text — the print driver embeds fonts, including CJK.
- Preview pages are rasterized at display resolution from the cached print layout, so flipping pages costs a bitmap replay, not a re-layout.
- Zero binary bloat: links `comdlg32` and `winspool`, everything else was already in the pipeline.

## Keybinding change

Ctrl+P previously toggled the edit-mode preview pane. Print now owns Ctrl+P everywhere (the universal Windows convention); the pane toggle moves to **Ctrl+E**, echoing Obsidian's toggle-editing-view key. Help overlay and README updated.

Along the way: the help overlay hardcoded per-section row counts, which had already silently dropped Ctrl+W and ESC ESC from the EDITING section — counts now derive from the arrays via `_countof`.

## Testing

- Hidden `--printpages <dir>` flag rasterizes the exact print pagination to PNGs.
- Verified against the CJK compatibility doc (12 pages) and the full stress corpus: headings, tables, code blocks with syntax colors, mermaid flowcharts, images, and dense CJK text render correctly with clean page breaks; previously-clipped wide diagrams now scale to fit inside the margins.
- Preview flow verified via screenshot harness: open from the context menu, flip pages, jump to last page, switch to Landscape (37→46 pages) and A3 landscape (29 pages), Esc close, Cancel-button close — document and theme restore correctly every time.
- All ctest suites pass.

## Known v1 limits

- Remote images that have not finished loading are skipped from the preview and printout.
- Resizing the window or changing DPI closes the preview (reopen with Ctrl+P).
- Extremely wide diagrams (the stress corpus has one ~7 pages wide) scale very small — that is the honest trade-off of fitting them on one page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)