### PR TITLE
Five UX improvements from #77: position memory, scroll sync, fast edit entry, horizontal scroll, remappable keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,33 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 | `Ctrl+W` | Toggle word wrap (in edit mode) |
 | `Q` | Quit |
 
+## Customization
+
+Settings live in a plain INI file at `%APPDATA%\Tinta\settings.ini` (theme,
+zoom, window placement, word wrap, and more — written on exit). The `[Keys]`
+section lets you remap the single-key shortcuts: change a value and restart
+Tinta. Accepted values are letters, digits, `Tab`, `Space`, `F1`–`F12`, or
+any single character.
+
+```ini
+[Keys]
+search=F
+browse=B
+toc=Tab
+theme=T
+stats=S
+quit=Q
+newfile=N
+zen=F11
+scrollup=K
+scrolldown=J
+edit=:
+help=?
+```
+
+Ctrl combos (save, print, copy, word wrap…) are fixed. The help overlay and
+context menu show whatever keys are currently bound.
+
 ## Building
 
 Requires Windows with Visual Studio 2019+ and CMake 3.15+.

--- a/include/app.h
+++ b/include/app.h
@@ -591,6 +591,7 @@ struct App {
     std::wstring editorText;
     bool editorDirty = false;
     std::vector<size_t> editorLineStarts;
+    float editorScrollX = 0.0f;  // horizontal scroll, non-wrap mode only (#77)
 
     // Editor view options (persisted)
     bool editorShowPreview = true;

--- a/include/app.h
+++ b/include/app.h
@@ -132,6 +132,8 @@ struct Settings {
     // Reading positions: most-recent-first, capped (#77)
     struct ReadingPosition { std::string path; float scrollY; };
     std::vector<ReadingPosition> readingPositions;
+    // [Keys] overrides from settings.ini: action name -> key name (#77)
+    std::vector<std::pair<std::string, std::string>> keyOverrides;
 };
 
 // Application state
@@ -306,6 +308,11 @@ struct App {
     bool helpScrollbarDragging = false;
     float helpScrollbarDragStartY = 0;
     float helpScrollbarDragStartScroll = 0;
+
+    // Resolved single-key bindings, indexed like KEY_ACTIONS (#77).
+    // Filled by applyKeymap from settings; slots beyond the action count
+    // stay zero.
+    unsigned keymap[16] = {};
 
     // Reading position restore (#77): applied once enough of the document is
     // laid out for the target to be reachable (chunked layout grows

--- a/include/app.h
+++ b/include/app.h
@@ -129,6 +129,9 @@ struct Settings {
     int darkThemeIndex = 5;    // Midnight
     // Search results from sibling markdown files in the search overlay
     bool folderSearchEnabled = true;
+    // Reading positions: most-recent-first, capped (#77)
+    struct ReadingPosition { std::string path; float scrollY; };
+    std::vector<ReadingPosition> readingPositions;
 };
 
 // Application state
@@ -303,6 +306,11 @@ struct App {
     bool helpScrollbarDragging = false;
     float helpScrollbarDragStartY = 0;
     float helpScrollbarDragStartScroll = 0;
+
+    // Reading position restore (#77): applied once enough of the document is
+    // laid out for the target to be reachable (chunked layout grows
+    // contentHeight, so applying immediately would clamp to a partial height)
+    float pendingScrollRestore = -1.0f;
 
     // Print preview overlay. While it is open the document is held in print
     // layout — width, theme, zoom and scroll are hijacked by enterPrintLayout —

--- a/include/settings.h
+++ b/include/settings.h
@@ -12,6 +12,41 @@ Settings loadSettings();
 void rememberReadingPosition(Settings& settings, const std::string& path, float scrollY);
 void persistReadingPosition(const std::string& path, float scrollY);
 float findReadingPosition(const Settings& settings, const std::string& path);
+
+// User-remappable single-key actions (#77), written to settings.ini as a
+// [Keys] section. Char actions trigger via WM_CHAR (edit ':', help '?');
+// the rest are WM_KEYDOWN virtual-key codes. Ctrl combos stay fixed.
+struct KeyActionDef {
+    const char* name;     // ini key
+    unsigned defaultKey;  // VK code, or character for isChar actions
+    bool isChar;
+};
+inline constexpr KeyActionDef KEY_ACTIONS[] = {
+    {"search",     'F',    false},
+    {"browse",     'B',    false},
+    {"toc",        VK_TAB, false},
+    {"theme",      'T',    false},
+    {"stats",      'S',    false},
+    {"quit",       'Q',    false},
+    {"newfile",    'N',    false},
+    {"zen",        VK_F11, false},
+    {"scrollup",   'K',    false},
+    {"scrolldown", 'J',    false},
+    {"edit",       ':',    true},
+    {"help",       '?',    true},
+};
+inline constexpr int KEY_ACTION_COUNT = 12;
+enum KeyActionIndex {
+    KA_SEARCH = 0, KA_BROWSE, KA_TOC, KA_THEME, KA_STATS, KA_QUIT,
+    KA_NEWFILE, KA_ZEN, KA_SCROLLUP, KA_SCROLLDOWN, KA_EDIT, KA_HELP
+};
+
+// Resolves settings.keyOverrides over the defaults into app.keymap
+void applyKeymap(App& app, const Settings& settings);
+// Key spelling used in settings.ini ("G", "Tab", "F5", ...)
+std::string keyIniName(unsigned key);
+// Same spelling as a wide string for overlay labels
+std::wstring keyLabel(unsigned key);
 bool registerFileAssociation();
 void openDefaultAppsSettings();
 void askAndRegisterFileAssociation(Settings& settings);

--- a/include/settings.h
+++ b/include/settings.h
@@ -6,6 +6,12 @@
 std::wstring getSettingsPath();
 void saveSettings(const Settings& settings);
 Settings loadSettings();
+
+// Reading position memory (#77): most-recent-first list capped in remember.
+// The persist/lookup helpers load and save settings.ini themselves.
+void rememberReadingPosition(Settings& settings, const std::string& path, float scrollY);
+void persistReadingPosition(const std::string& path, float scrollY);
+float findReadingPosition(const Settings& settings, const std::string& path);
 bool registerFileAssociation();
 void openDefaultAppsSettings();
 void askAndRegisterFileAssociation(Settings& settings);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -663,6 +663,17 @@ void enterEditMode(App& app) {
         }
     }
 
+    // Build the line→byte-offset table against the raw content so the
+    // preview scroll sync works immediately on entry: the anchors from the
+    // entry parse carry offsets into this exact byte stream (\r\n included),
+    // and until now the table only existed after the first reparse — which
+    // is why the panes stopped responding to each other right after ':'
+    app.editorLineByteOffsets.clear();
+    app.editorLineByteOffsets.push_back(0);
+    for (size_t i = 0; i < content.size(); i++) {
+        if (content[i] == '\n') app.editorLineByteOffsets.push_back(i + 1);
+    }
+
     app.editorText = std::move(normalized);
 
     rebuildLineStarts(app);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -509,6 +509,25 @@ static void editorEnsureCursorVisible(App& app) {
         app.editorScrollY = cursorY + lineHeight * 2 - app.height;
     }
     app.editorScrollY = std::max(0.0f, app.editorScrollY);
+
+    // Horizontal caret-follow: long unwrapped lines scroll sideways instead
+    // of disappearing under the pane separator (#77)
+    if (app.editorWordWrap) {
+        app.editorScrollX = 0.0f;
+    } else {
+        IDWriteTextLayout* layout = createEditorLineLayout(
+            app, app.editorLineStarts[line], getLineLength(app, line));
+        float cx = 0, cy = 0;
+        editorCaretXY(layout, app.editorCursorPos - app.editorLineStarts[line], cx, cy);
+        if (layout) layout->Release();
+        float viewW = editorTextMaxWidth(app) - dpi(app, 12.0f);  // caret + scrollbar slack
+        float margin = dpi(app, 8.0f);
+        if (cx < app.editorScrollX + margin) {
+            app.editorScrollX = std::max(0.0f, cx - margin);
+        } else if (cx > app.editorScrollX + viewW) {
+            app.editorScrollX = cx - viewW;
+        }
+    }
 }
 
 // --- Editor search ---
@@ -680,6 +699,7 @@ void enterEditMode(App& app) {
     app.editorCursorPos = 0;
     app.editorDesiredCol = -1;
     app.editorScrollY = 0;
+    app.editorScrollX = 0;
     app.editorHasSelection = false;
     app.editorDirty = false;
     app.undoStack.clear();
@@ -1350,7 +1370,8 @@ void editorPositionImeWindow(App& app, HWND hwnd) {
 
     COMPOSITIONFORM cf{};
     cf.dwStyle = CFS_POINT;
-    cf.ptCurrentPos.x = (LONG)(gutterWidth + padding + xOff);
+    cf.ptCurrentPos.x = (LONG)(gutterWidth + padding + xOff -
+                               (app.editorWordWrap ? 0.0f : app.editorScrollX));
     cf.ptCurrentPos.y = (LONG)(lineTop + yOff - app.editorScrollY + lineHeight);
     ImmSetCompositionWindow(himc, &cf);
     ImmReleaseContext(hwnd, himc);
@@ -1385,6 +1406,7 @@ static size_t editorPosFromClick(App& app, int x, int y) {
 
     float gutterWidth = dpi(app, 48.0f);
     float adjustedX = (float)x - gutterWidth - padding;
+    if (!app.editorWordWrap) adjustedX += app.editorScrollX;
     if (lineLen == 0) return lineStart;
     if (adjustedX <= 0.0f && !app.editorWordWrap) return lineStart;
     adjustedX = std::max(0.0f, adjustedX);
@@ -1549,6 +1571,12 @@ void handleEditorMouseMove(App& app, HWND hwnd, int x, int y) {
 }
 
 void handleEditorMouseWheel(App& app, HWND hwnd, float delta) {
+    // Shift+wheel pans long unwrapped lines horizontally (#77)
+    if (!app.editorWordWrap && (GetKeyState(VK_SHIFT) & 0x8000)) {
+        app.editorScrollX = std::max(0.0f, app.editorScrollX - delta * dpi(app, 60.0f));
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
     app.editorScrollY -= delta * dpi(app, 60.0f);
     app.editorScrollY = std::max(0.0f, app.editorScrollY);
     float maxScroll = std::max(0.0f, app.editorContentHeight - app.height);
@@ -1756,6 +1784,9 @@ void renderEditor(App& app, float editorWidth) {
 
     // Gutter width for line numbers
     float gutterWidth = dpi(app, 48.0f);
+    // Text origin shifts left as the pane scrolls horizontally; the gutter
+    // is repainted after the text so lines slide underneath it (#77)
+    float textBase = gutterWidth + padding - app.editorScrollX;
 
     // Search match scanning index (both sorted by position, so we advance together)
     size_t searchScanIdx = 0;
@@ -1780,26 +1811,17 @@ void renderEditor(App& app, float editorWidth) {
         // (CJK and other full-width characters are wider than charWidth)
         IDWriteTextLayout* lineLayout = cachedEditorLineLayout(app, lineStart, lineLen);
 
-        // Line number
-        wchar_t lineNum[16];
-        swprintf(lineNum, 16, L"%d", i + 1);
-        D2D1_COLOR_F gutterColor = app.theme.text;
-        gutterColor.a = 0.3f;
-        app.brush->SetColor(gutterColor);
-        app.renderTarget->DrawText(lineNum, (UINT32)wcslen(lineNum), app.editorTextFormat,
-            D2D1::RectF(dpi(app, 4.0f), lineY, gutterWidth - dpi(app, 4.0f), lineY + lineHeight), app.brush);
-
         // Selection highlight on this line
         if (app.editorHasSelection && selMax > lineStart && selMin < lineStart + lineLen + 1) {
             size_t hlStart = (selMin > lineStart) ? selMin - lineStart : 0;
             size_t hlEnd = std::min(selMax - lineStart, lineLen + 1);
-            float hlX1 = gutterWidth + padding + editorColToX(app, lineLayout, hlStart);
+            float hlX1 = textBase + editorColToX(app, lineLayout, hlStart);
             float hlX2;
             if (hlEnd > lineLen) {
                 // Selection includes the newline: extend one char past line end
-                hlX2 = gutterWidth + padding + editorColToX(app, lineLayout, lineLen) + charWidth;
+                hlX2 = textBase + editorColToX(app, lineLayout, lineLen) + charWidth;
             } else {
-                hlX2 = gutterWidth + padding + editorColToX(app, lineLayout, hlEnd);
+                hlX2 = textBase + editorColToX(app, lineLayout, hlEnd);
             }
             app.brush->SetColor(D2D1::ColorF(0.2f, 0.4f, 0.9f, 0.35f));
             app.renderTarget->FillRectangle(
@@ -1820,8 +1842,8 @@ void renderEditor(App& app, float editorWidth) {
                 size_t overlapStart = std::max(lineStart, m.startPos);
                 size_t overlapEnd = std::min(lineEnd, mEnd);
                 if (overlapStart < overlapEnd) {
-                    float hlX1 = gutterWidth + padding + editorColToX(app, lineLayout, overlapStart - lineStart);
-                    float hlX2 = gutterWidth + padding + editorColToX(app, lineLayout, overlapEnd - lineStart);
+                    float hlX1 = textBase + editorColToX(app, lineLayout, overlapStart - lineStart);
+                    float hlX2 = textBase + editorColToX(app, lineLayout, overlapEnd - lineStart);
 
                     bool isCurrent = ((int)si == app.editorSearchCurrentIndex);
                     if (isCurrent) {
@@ -1845,7 +1867,7 @@ void renderEditor(App& app, float editorWidth) {
         if (lineLayout) {
             app.brush->SetColor(app.theme.text);
             app.renderTarget->DrawTextLayout(
-                D2D1::Point2F(gutterWidth + padding, lineY), lineLayout, app.brush);
+                D2D1::Point2F(textBase, lineY), lineLayout, app.brush);
         }
 
     }
@@ -1857,12 +1879,27 @@ void renderEditor(App& app, float editorWidth) {
         size_t curLineStart = app.editorLineStarts[curLine];
         size_t curLineLen = getLineLength(app, curLine);
         IDWriteTextLayout* curLayout = cachedEditorLineLayout(app, curLineStart, curLineLen);
-        float curX = gutterWidth + padding + editorColToX(app, curLayout, std::min(curCol, curLineLen));
+        float curX = textBase + editorColToX(app, curLayout, std::min(curCol, curLineLen));
         float curY = padding + curLine * lineHeight - app.editorScrollY;
 
         app.brush->SetColor(app.theme.text);
         app.renderTarget->FillRectangle(
             D2D1::RectF(curX, curY, curX + dpi(app, 2.0f), curY + lineHeight), app.brush);
+    }
+
+    // Gutter last: horizontally scrolled text slides under it
+    app.brush->SetColor(app.theme.background);
+    app.renderTarget->FillRectangle(
+        D2D1::RectF(0, 0, gutterWidth, (float)app.height), app.brush);
+    D2D1_COLOR_F gutterColor = app.theme.text;
+    gutterColor.a = 0.3f;
+    app.brush->SetColor(gutterColor);
+    for (int i = firstVisible; i <= lastVisible && i < (int)app.editorLineStarts.size(); i++) {
+        float lineY = padding + i * lineHeight - app.editorScrollY;
+        wchar_t lineNum[16];
+        swprintf(lineNum, 16, L"%d", i + 1);
+        app.renderTarget->DrawText(lineNum, (UINT32)wcslen(lineNum), app.editorTextFormat,
+            D2D1::RectF(dpi(app, 4.0f), lineY, gutterWidth - dpi(app, 4.0f), lineY + lineHeight), app.brush);
     }
 
     // Update content height for scrolling

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -645,6 +645,24 @@ void enterEditMode(App& app) {
             normalized += app.editorText[i];
         }
     }
+    // Map the current reading position to a source line so the editor opens
+    // where the user was, not at the top (#77). Anchors carry UTF-8 source
+    // offsets; count newlines in the raw content to get the line number
+    // (unaffected by the \r\n normalization below).
+    size_t targetLine = 0;
+    if (app.scrollY > 1.0f && !app.scrollAnchors.empty()) {
+        size_t lo = 0, hi = app.scrollAnchors.size();
+        while (lo + 1 < hi) {
+            size_t mid = (lo + hi) / 2;
+            if (app.scrollAnchors[mid].renderedY <= app.scrollY) lo = mid;
+            else hi = mid;
+        }
+        size_t srcOffset = std::min(app.scrollAnchors[lo].sourceOffset, content.size());
+        for (size_t i = 0; i < srcOffset; i++) {
+            if (content[i] == '\n') targetLine++;
+        }
+    }
+
     app.editorText = std::move(normalized);
 
     rebuildLineStarts(app);
@@ -660,6 +678,21 @@ void enterEditMode(App& app) {
     app.editMode = true;
     app.escPressedOnce = false;
     app.confirmExitPending = false;
+
+    // Resume at the reading position rather than the top (#77)
+    if (targetLine > 0 && targetLine < app.editorLineStarts.size()) {
+        app.editorCursorPos = app.editorLineStarts[targetLine];
+        float lineHeight = app.editorTextFormat
+            ? app.editorTextFormat->GetFontSize() * 1.5f : 20.0f;
+        float row = (float)targetLine;
+        if (app.editorWordWrap) {
+            ensureEditorRowMetrics(app);
+            if (targetLine < app.editorRowStarts.size()) {
+                row = (float)app.editorRowStarts[targetLine];
+            }
+        }
+        app.editorScrollY = std::max(0.0f, row * lineHeight);
+    }
 
     // Disable file watch while editing
     KillTimer(app.hwnd, 1); // TIMER_FILE_WATCH = 1

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -245,6 +245,31 @@ static void applyZoomDelta(App& app, float delta) {
     }
 }
 
+// Maps a pressed key through the user keymap ([Keys] in settings.ini): a
+// remapped key becomes the built-in default the switches below expect, and
+// a default key the user moved elsewhere is swallowed. Non-action keys pass
+// through untouched. (#77)
+static WPARAM translateActionKey(App& app, WPARAM key, bool isChar) {
+    auto norm = [&](unsigned k) {
+        return isChar ? (unsigned)towupper((wint_t)k) : k;
+    };
+    unsigned pressed = norm((unsigned)key);
+    for (int i = 0; i < KEY_ACTION_COUNT; i++) {
+        if (KEY_ACTIONS[i].isChar != isChar) continue;
+        if (norm(app.keymap[i]) == pressed) {
+            return (WPARAM)KEY_ACTIONS[i].defaultKey;
+        }
+    }
+    for (int i = 0; i < KEY_ACTION_COUNT; i++) {
+        if (KEY_ACTIONS[i].isChar != isChar) continue;
+        if (norm(KEY_ACTIONS[i].defaultKey) == pressed &&
+            norm(app.keymap[i]) != pressed) {
+            return 0;  // default key rebound elsewhere: swallow
+        }
+    }
+    return key;
+}
+
 void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     // Print preview: the wheel flips pages
     if (app.showPrintPreview) {
@@ -1633,6 +1658,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 break;
         }
     } else {
+        wParam = translateActionKey(app, wParam, false);
         switch (wParam) {
             case VK_ESCAPE:
                 // Priority: ContextMenu > Help > Search > FolderBrowser > TOC > Theme chooser > Quit
@@ -1790,7 +1816,7 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
 
     // ':' to enter edit mode, '?' to toggle help — when no overlay is active
     if (!app.showSearch && !app.showFolderBrowser && !app.showToc && !app.showThemeChooser) {
-        wchar_t ch = (wchar_t)wParam;
+        wchar_t ch = (wchar_t)translateActionKey(app, wParam, true);
         if (ch == L':' && !app.showHelp) {
             enterEditMode(app);
             return;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -268,21 +268,23 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         return;
     }
 
-    // Edit mode: route scroll to editor or preview based on mouse X
+    // Edit mode: the wheel scrolls the editor from either pane — the preview
+    // follows through the scroll-anchor sync, so the panes cannot drift
+    // apart and both sides always respond (#77)
     if (app.editMode) {
         float sepX = app.editorShowPreview
             ? app.width * app.editorSplitRatio
             : static_cast<float>(app.width);
-        if (app.mouseX < sepX) {
-            if (ctrl) {
-                applyZoomDelta(app, delta);
-                InvalidateRect(hwnd, nullptr, FALSE);
-            } else {
-                handleEditorMouseWheel(app, hwnd, delta);
-            }
+        if (ctrl && app.mouseX < sepX) {
+            applyZoomDelta(app, delta);
+            InvalidateRect(hwnd, nullptr, FALSE);
             return;
         }
-        // Fall through to normal scroll for preview pane
+        if (!ctrl) {
+            handleEditorMouseWheel(app, hwnd, delta);
+            return;
+        }
+        // Ctrl over the preview pane: fall through to document zoom
     }
 
     // Handle folder browser scroll (not when Ctrl is held — that's zoom)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -34,6 +34,12 @@ static bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
     auto result = parseDocument(app.parser, buffer.str(), fullPath);
     if (!result.success) return false;
 
+    // Reading position memory (#77): keep the old document's position,
+    // resume the new one's
+    if (!app.currentFile.empty()) {
+        persistReadingPosition(app.currentFile, app.scrollY);
+    }
+
     app.root = result.root;
     app.parseTimeUs = result.parseTimeUs;
     int utf8Len = WideCharToMultiByte(CP_UTF8, 0, fullPath.c_str(), -1, nullptr, 0, nullptr, nullptr);
@@ -43,6 +49,7 @@ static bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
     app.scrollX = 0;
     app.targetScrollY = 0;
     app.targetScrollX = 0;
+    app.pendingScrollRestore = findReadingPosition(loadSettings(), app.currentFile);
     app.focusMermaidOnNextLayout = isMermaidDocumentPath(fullPath);
     app.contentHeight = 0;
     app.docText.clear();

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -191,6 +191,15 @@ void render(App& app) {
 
 render_document:
 
+    // Apply a saved reading position once the layout can reach it (#77)
+    if (app.pendingScrollRestore >= 0.0f &&
+        (app.layoutComplete ||
+         app.contentHeight >= app.pendingScrollRestore + app.height)) {
+        app.scrollY = app.pendingScrollRestore;
+        app.targetScrollY = app.pendingScrollRestore;
+        app.pendingScrollRestore = -1.0f;
+    }
+
     // Clamp scroll values
     float documentWidth = documentViewportWidth(app);
     float maxScrollX = std::max(0.0f, app.contentWidth - documentWidth);
@@ -1056,6 +1065,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.lightThemeIndex = app->lightThemeIndex;
                 settings.darkThemeIndex = app->darkThemeIndex;
                 settings.folderSearchEnabled = app->folderSearchEnabled;
+                if (!app->currentFile.empty()) {
+                    rememberReadingPosition(settings, app->currentFile, app->scrollY);
+                }
 
                 // Get window placement for position/size/maximized state
                 WINDOWPLACEMENT wp = {};
@@ -1357,6 +1369,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     }
 
     app.metrics.fileLoadUs = usElapsed(t0);
+
+    // Resume the saved reading position (#77); new-file windows start in the
+    // editor at the top instead
+    if (!startInEditMode && !app.currentFile.empty()) {
+        app.pendingScrollRestore = findReadingPosition(savedSettings, app.currentFile);
+    }
 
     // Set window title with filename
     updateWindowTitle(app);

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -97,8 +97,14 @@ void render(App& app) {
             // (the viewport is zero-width, so laying out now would be wasted
             // work against a nonsense max width)
         } else if (app.editMode) {
-            // Edit mode needs complete scroll anchors for preview sync
-            layoutDocument(app);
+            // The preview streams in like the viewer: visible region first,
+            // the rest in background chunks. The anchor sync clamps to
+            // whatever is laid out and self-corrects as chunks land, so
+            // entering edit mode no longer blocks on a full layout (#77)
+            layoutDocumentViewportFirst(app);
+            if (!app.layoutComplete) {
+                PostMessage(app.hwnd, WM_APP_LAYOUT_CHUNK, 0, 0);
+            }
         } else {
             // Lay out the visible region first so this frame presents
             // immediately; the rest continues in WM_APP_LAYOUT_CHUNK slices

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1185,6 +1185,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.zoomFactor = savedSettings.zoomFactor;
     app.editorShowPreview = savedSettings.editorShowPreview;
     app.editorWordWrap = savedSettings.editorWordWrap;
+    applyKeymap(app, savedSettings);
 
     // Parse command line
     std::string inputFile;

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -2,6 +2,7 @@
 #include "utils.h"
 #include "d2d_init.h"
 #include "print.h"
+#include "settings.h"
 
 #include <chrono>
 #include <algorithm>
@@ -893,9 +894,21 @@ void renderHelpOverlay(App& app) {
         const wchar_t* desc;
     };
 
+    // Remappable keys show their current binding ([Keys] in settings.ini)
+    std::wstring kDown = keyLabel(app.keymap[KA_SCROLLDOWN]) + L" / \x2193";
+    std::wstring kUp = keyLabel(app.keymap[KA_SCROLLUP]) + L" / \x2191";
+    std::wstring kSearch = keyLabel(app.keymap[KA_SEARCH]) + L" / Ctrl+F";
+    std::wstring kBrowse = keyLabel(app.keymap[KA_BROWSE]);
+    std::wstring kToc = keyLabel(app.keymap[KA_TOC]);
+    std::wstring kTheme = keyLabel(app.keymap[KA_THEME]);
+    std::wstring kStats = keyLabel(app.keymap[KA_STATS]);
+    std::wstring kHelp = keyLabel(app.keymap[KA_HELP]);
+    std::wstring kEdit = keyLabel(app.keymap[KA_EDIT]);
+    std::wstring kQuit = keyLabel(app.keymap[KA_QUIT]);
+
     const HelpEntry navEntries[] = {
-        {L"J / \x2193",   L"Scroll down"},
-        {L"K / \x2191",   L"Scroll up"},
+        {kDown.c_str(),   L"Scroll down"},
+        {kUp.c_str(),     L"Scroll up"},
         {L"Space / PgDn", L"Page down"},
         {L"PgUp",         L"Page up"},
         {L"Home / End",   L"Jump to start / end"},
@@ -903,17 +916,17 @@ void renderHelpOverlay(App& app) {
     };
 
     const HelpEntry overlayEntries[] = {
-        {L"F / Ctrl+F",   L"Search"},
+        {kSearch.c_str(), L"Search"},
         {L"Enter",        L"Next search match"},
-        {L"B",            L"Toggle folder browser"},
-        {L"Tab",          L"Toggle table of contents"},
-        {L"T",            L"Theme chooser"},
-        {L"S",            L"Toggle stats"},
-        {L"?",            L"This help"},
+        {kBrowse.c_str(), L"Toggle folder browser"},
+        {kToc.c_str(),    L"Toggle table of contents"},
+        {kTheme.c_str(),  L"Theme chooser"},
+        {kStats.c_str(),  L"Toggle stats"},
+        {kHelp.c_str(),   L"This help"},
     };
 
     const HelpEntry editEntries[] = {
-        {L":",             L"Enter edit mode"},
+        {kEdit.c_str(),   L"Enter edit mode"},
         {L"Ctrl+S",       L"Save (in edit mode)"},
         {L"Ctrl+E",       L"Show / hide preview pane"},
         {L"Ctrl+W",       L"Toggle word wrap"},
@@ -925,7 +938,7 @@ void renderHelpOverlay(App& app) {
         {L"Ctrl+C",       L"Copy selection"},
         {L"Ctrl+P",       L"Print / PDF"},
         {L"ESC",          L"Close overlay / Quit"},
-        {L"Q",            L"Quit"},
+        {kQuit.c_str(),   L"Quit"},
     };
 
     float padding = dpi(app, 20.0f);
@@ -1139,6 +1152,20 @@ void renderContextMenu(App& app) {
 
     app.hoveredContextMenuItem = contextMenuItemAt(app, app.mouseX, app.mouseY);
 
+    // Shortcut hints reflect the user keymap ([Keys] in settings.ini)
+    auto shortcutLabel = [&](int item) -> std::wstring {
+        switch (item) {
+            case CTX_NEW:    return keyLabel(app.keymap[KA_NEWFILE]);
+            case CTX_EDIT:   return keyLabel(app.keymap[KA_EDIT]);
+            case CTX_SEARCH: return keyLabel(app.keymap[KA_SEARCH]);
+            case CTX_TOC:    return keyLabel(app.keymap[KA_TOC]);
+            case CTX_BROWSE: return keyLabel(app.keymap[KA_BROWSE]);
+            case CTX_THEME:  return keyLabel(app.keymap[KA_THEME]);
+            case CTX_HELP:   return keyLabel(app.keymap[KA_HELP]);
+            default:         return CTX_ENTRIES[item].shortcut;
+        }
+    };
+
     float pad = ctxPadding(app);
     float itemH = ctxItemHeight(app);
     float inset = dpi(app, 12.0f);
@@ -1164,10 +1191,11 @@ void renderContextMenu(App& app) {
             CTX_ENTRIES[i].label, (UINT32)wcslen(CTX_ENTRIES[i].label), format,
             D2D1::RectF(x + inset, textY, x + w - inset, top + itemH), app.brush);
 
-        if (CTX_ENTRIES[i].shortcut[0]) {
+        std::wstring hintText = shortcutLabel(i);
+        if (!hintText.empty()) {
             IDWriteTextLayout* hint = nullptr;
             app.dwriteFactory->CreateTextLayout(
-                CTX_ENTRIES[i].shortcut, (UINT32)wcslen(CTX_ENTRIES[i].shortcut),
+                hintText.c_str(), (UINT32)hintText.size(),
                 format, 1000.0f, itemH, &hint);
             if (hint) {
                 DWRITE_TEXT_METRICS metrics{};

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -43,11 +43,65 @@ void saveSettings(const Settings& settings) {
     file << "darkThemeIndex=" << settings.darkThemeIndex << "\n";
     file << "folderSearchEnabled=" << (settings.folderSearchEnabled ? 1 : 0) << "\n";
 
+    // Remappable keys, written with every save so the section documents
+    // itself: change a value, restart Tinta
+    file << "[Keys]\n";
+    file << "; single letters/digits, Tab, Space, F1-F12, or one character\n";
+    for (int i = 0; i < KEY_ACTION_COUNT; i++) {
+        std::string value = keyIniName(KEY_ACTIONS[i].defaultKey);
+        for (const auto& kv : settings.keyOverrides) {
+            if (kv.first == KEY_ACTIONS[i].name) { value = kv.second; break; }
+        }
+        file << KEY_ACTIONS[i].name << "=" << value << "\n";
+    }
+
     if (!settings.readingPositions.empty()) {
         file << "[Positions]\n";
         for (const auto& pos : settings.readingPositions) {
             // Windows paths cannot contain '|'
             file << "pos=" << pos.scrollY << "|" << pos.path << "\n";
+        }
+    }
+}
+
+// "G" -> 'G', "Tab"/"Space"/"F1".."F12" -> VK code, ":" -> ':'; 0 = invalid
+static unsigned parseKeyName(const std::string& value) {
+    if (value.empty()) return 0;
+    if (value.size() == 1) return (unsigned)toupper((unsigned char)value[0]);
+    std::string lower;
+    for (char c : value) lower += (char)tolower((unsigned char)c);
+    if (lower == "tab") return VK_TAB;
+    if (lower == "space") return VK_SPACE;
+    if (lower.size() >= 2 && lower[0] == 'f') {
+        int n = atoi(lower.c_str() + 1);
+        if (n >= 1 && n <= 12) return VK_F1 + n - 1;
+    }
+    return 0;
+}
+
+std::string keyIniName(unsigned key) {
+    if (key == VK_TAB) return "Tab";
+    if (key == VK_SPACE) return "Space";
+    if (key >= VK_F1 && key <= VK_F12) return "F" + std::to_string(key - VK_F1 + 1);
+    return std::string(1, (char)key);
+}
+
+std::wstring keyLabel(unsigned key) {
+    std::string narrow = keyIniName(key);
+    return std::wstring(narrow.begin(), narrow.end());
+}
+
+void applyKeymap(App& app, const Settings& settings) {
+    for (int i = 0; i < KEY_ACTION_COUNT; i++) {
+        app.keymap[i] = KEY_ACTIONS[i].defaultKey;
+    }
+    for (const auto& kv : settings.keyOverrides) {
+        for (int i = 0; i < KEY_ACTION_COUNT; i++) {
+            if (kv.first == KEY_ACTIONS[i].name) {
+                unsigned key = parseKeyName(kv.second);
+                if (key) app.keymap[i] = key;
+                break;
+            }
         }
     }
 }
@@ -89,7 +143,7 @@ Settings loadSettings() {
 
     std::string line;
     while (std::getline(file, line)) {
-        if (line.empty() || line[0] == '[') continue;
+        if (line.empty() || line[0] == '[' || line[0] == ';') continue;
 
         size_t eq = line.find('=');
         if (eq == std::string::npos) continue;
@@ -140,6 +194,13 @@ Settings loadSettings() {
                         settings.readingPositions.push_back({value.substr(sep + 1), y});
                     }
                 } catch (...) {}
+            }
+        } else {
+            for (int i = 0; i < KEY_ACTION_COUNT; i++) {
+                if (key == KEY_ACTIONS[i].name) {
+                    settings.keyOverrides.push_back({key, value});
+                    break;
+                }
             }
         }
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -42,6 +42,41 @@ void saveSettings(const Settings& settings) {
     file << "lightThemeIndex=" << settings.lightThemeIndex << "\n";
     file << "darkThemeIndex=" << settings.darkThemeIndex << "\n";
     file << "folderSearchEnabled=" << (settings.folderSearchEnabled ? 1 : 0) << "\n";
+
+    if (!settings.readingPositions.empty()) {
+        file << "[Positions]\n";
+        for (const auto& pos : settings.readingPositions) {
+            // Windows paths cannot contain '|'
+            file << "pos=" << pos.scrollY << "|" << pos.path << "\n";
+        }
+    }
+}
+
+void rememberReadingPosition(Settings& settings, const std::string& path, float scrollY) {
+    if (path.empty()) return;
+    auto& list = settings.readingPositions;
+    for (size_t i = 0; i < list.size(); i++) {
+        if (_stricmp(list[i].path.c_str(), path.c_str()) == 0) {
+            list.erase(list.begin() + i);
+            break;
+        }
+    }
+    list.insert(list.begin(), {path, scrollY});
+    if (list.size() > 50) list.resize(50);
+}
+
+void persistReadingPosition(const std::string& path, float scrollY) {
+    if (path.empty()) return;
+    Settings settings = loadSettings();
+    rememberReadingPosition(settings, path, scrollY);
+    saveSettings(settings);
+}
+
+float findReadingPosition(const Settings& settings, const std::string& path) {
+    for (const auto& pos : settings.readingPositions) {
+        if (_stricmp(pos.path.c_str(), path.c_str()) == 0) return pos.scrollY;
+    }
+    return -1.0f;
 }
 
 Settings loadSettings() {
@@ -96,8 +131,19 @@ Settings loadSettings() {
             settings.editorShowPreview = (value == "1");
         } else if (key == "editorWordWrap") {
             settings.editorWordWrap = (value == "1");
+        } else if (key == "pos") {
+            size_t sep = value.find('|');
+            if (sep != std::string::npos && sep + 1 < value.size()) {
+                try {
+                    float y = std::stof(value.substr(0, sep));
+                    if (y >= 0.0f) {
+                        settings.readingPositions.push_back({value.substr(sep + 1), y});
+                    }
+                } catch (...) {}
+            }
         }
     }
+    if (settings.readingPositions.size() > 50) settings.readingPositions.resize(50);
     return settings;
 }
 


### PR DESCRIPTION
Implements all five points from #77 (thanks @goodenn for the detailed report).

## 1. Reading position memory
Documents reopen where you left off. Positions persist to `settings.ini` (most-recent-first, capped at 50), saved on close and on switching files in-app; the restore waits until chunked layout can reach the target. Entering edit mode also resumes at the reading position now — the viewer scroll maps through the layout anchors to a source line — instead of dropping you at line 1.

## 2. Preview scroll sync fixed
Two root causes: the wheel over the preview pane scrolled the document directly, which the per-frame editor→preview sync immediately overwrote (the "dead pane"); and the line→byte-offset table only existed after the first reparse, so sync was inert right after `:`. The wheel now drives the editor from either pane — the preview follows through the anchors, so the panes cannot drift — and the offset table is built at entry against the raw file bytes (CRLF included), matching the anchors exactly.

## 3. Edit mode enters instantly
`:` (and every preview reparse) forced a full synchronous document layout for complete scroll anchors. The preview now streams in viewport-first with background chunks exactly like the viewer; the sync clamps to what is laid out and self-corrects as chunks land.

## 4. Editor horizontal scroll
The editor had no horizontal scroll state at all — long unwrapped lines vanished under the pane separator and the caret could not reach them. `editorScrollX` now follows the caret (arrows, End, clicks), Shift+wheel pans, clicks and the IME window map through the offset, and the line-number gutter repaints over scrolled text. Word-wrap mode pins the offset at zero.

## 5. Remappable shortcuts
`%APPDATA%\Tinta\settings.ini` gains a self-documenting `[Keys]` section listing every single-key action with its current binding — change a value and restart. Letters, digits, `Tab`, `Space`, `F1`–`F12`, or any single character; Ctrl combos stay fixed. The help overlay and context menu show whatever is currently bound, and the README documents the settings file. Implemented as a translation layer in front of the existing key dispatch, so all overlay guard logic is untouched.

## Testing
Every point verified with the synthetic-input screenshot harness: position restore is pixel-identical across restarts, preview-pane wheel scrolls both panes in lockstep on entry, the stress doc enters edit mode without the freeze, End/Home traverse a 400-char line with the gutter intact, and `search=G` opens search on G, frees F, and relabels the help overlay. All ctest suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)