### PR TITLE
Add multilingual UI with language chooser (en/zh-CN/ja/ko)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCES
     src/editor.cpp
     src/mermaid.cpp
     src/document.cpp
+    src/i18n.cpp
 )
 
 set(HEADERS
@@ -67,6 +68,7 @@ set(HEADERS
     include/editor.h
     include/mermaid.h
     include/document.h
+    include/i18n.h
 )
 
 # Windows resource file (icon)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 
 - **Lightning-fast startup** - Direct2D rendering, no web engine overhead
 - **10 beautiful themes** - 5 light and 5 dark themes to choose from
+- **Multilingual UI** - English, Simplified Chinese, Japanese, and Korean; follows your system language or override with `L` (press `L` to switch)
 - **Hardware-accelerated** - Smooth text rendering via DirectWrite
 - **Word wrap** - Optional soft wrap in the editor (Ctrl+W)
 - **Focused editing** - Hide the preview pane while writing (Ctrl+P)
@@ -88,6 +89,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 | `Enter` | Next search match |
 | `ESC` | Close overlay / Quit |
 | `T` | Open theme chooser |
+| `L` | Open language chooser |
 | `S` | Toggle stats overlay |
 | `Ctrl+C` | Copy selected text (or all if none selected) |
 | `Ctrl+A` | Select all text |

--- a/include/app.h
+++ b/include/app.h
@@ -18,6 +18,7 @@
 #include <chrono>
 
 #include "markdown.h"
+#include "i18n.h"
 
 using namespace qmd;
 
@@ -111,6 +112,7 @@ struct Settings {
     bool hasAskedFileAssociation = false;
     bool editorShowPreview = true;
     bool editorWordWrap = false;
+    int languageIndex = LANG_INDEX_DEFAULT;  // -1 = follow system, 0..N-1 = explicit
 };
 
 // Application state
@@ -203,11 +205,21 @@ struct App {
     bool showStats = false;
     int currentThemeIndex = 5;  // Default to "Midnight" (first dark theme)
     D2DTheme theme = THEMES[5];
+    int currentLanguageIndex = LANG_INDEX_EN;  // Runtime effective language
 
     // Theme chooser overlay
     bool showThemeChooser = false;
     int hoveredThemeIndex = -1;
     float themeChooserAnimation = 0.0f;  // 0 to 1 for fade in
+
+    // Language chooser overlay
+    bool showLanguageChooser = false;
+    int hoveredLanguageIndex = -1;
+    float languageChooserAnimation = 0.0f;  // 0 to 1 for fade in
+    // Cached text formats (built lazily by ensureLanguageFormats)
+    IDWriteTextFormat* languageTitleFormat = nullptr;
+    IDWriteTextFormat* languageNativeFormat = nullptr;
+    IDWriteTextFormat* languageSubtitleFormat = nullptr;
 
     // Folder browser overlay
     bool showFolderBrowser = false;
@@ -531,6 +543,9 @@ struct App {
         if (tocFormatBold) { tocFormatBold->Release(); tocFormatBold = nullptr; }
         if (supSubFormat) { supSubFormat->Release(); supSubFormat = nullptr; }
         if (editorTextFormat) { editorTextFormat->Release(); editorTextFormat = nullptr; }
+        if (languageTitleFormat) { languageTitleFormat->Release(); languageTitleFormat = nullptr; }
+        if (languageNativeFormat) { languageNativeFormat->Release(); languageNativeFormat = nullptr; }
+        if (languageSubtitleFormat) { languageSubtitleFormat->Release(); languageSubtitleFormat = nullptr; }
         for (auto& fmt : themePreviewFormats) {
             if (fmt.name) { fmt.name->Release(); fmt.name = nullptr; }
             if (fmt.preview) { fmt.preview->Release(); fmt.preview = nullptr; }

--- a/include/d2d_init.h
+++ b/include/d2d_init.h
@@ -5,9 +5,11 @@
 
 bool initD2D(App& app);
 void applyTheme(App& app, int themeIndex);
+void applyLanguage(App& app, int langIndex);
 void updateTextFormats(App& app);
 void updateOverlayFormats(App& app);
 void ensureThemePreviewFormats(App& app);
+void ensureLanguageFormats(App& app);
 void createTypography(App& app);
 bool createRenderTarget(App& app);
 

--- a/include/i18n.h
+++ b/include/i18n.h
@@ -1,0 +1,46 @@
+#ifndef TINTA_I18N_H
+#define TINTA_I18N_H
+
+#include <string>
+
+// Language indices are stable identifiers persisted in settings.ini.
+// Order matters: indices are stored on disk, so never renumber existing
+// entries — only append new ones.
+//   0 = English (en)         — fallback when a translation is missing
+//   1 = Simplified Chinese (zh-CN)
+//   2 = Japanese (ja)
+//   3 = Korean (ko)
+constexpr int LANG_COUNT = 4;
+constexpr int LANG_INDEX_EN = 0;
+constexpr int LANG_INDEX_DEFAULT = -1;  // Follow the system UI language
+
+struct Language {
+    const wchar_t* nativeName;   // Shown in the chooser, e.g. "简体中文"
+    const wchar_t* englishName;  // Auxiliary subtitle, e.g. "Chinese (Simplified)"
+    // Preferred font family for this language's native name. Empty = theme
+    // default. CJK fonts are already in the fallback chain, but using the
+    // native font here makes the chooser itself feel localized.
+    const wchar_t* nativeFont;
+};
+
+extern const Language LANGUAGES[LANG_COUNT];
+
+struct App;
+
+// Resolve a translation key for the given language index.
+// Falls back to English when the requested language lacks an entry, then to
+// the key itself (never returns null).
+const wchar_t* tr(int langIndex, const char* key);
+
+// Convenience overload using app.currentLanguageIndex.
+const wchar_t* tr(const App& app, const char* key);
+
+// Detect the user's preferred UI language via GetUserPreferredUILanguages.
+// Returns one of the LANG_INDEX_* values (always English as the last resort).
+int detectSystemLanguage();
+
+// Validates / clamps an arbitrary index into the [0, LANG_COUNT) range.
+// Returns LANG_INDEX_EN for out-of-range values.
+int clampLanguageIndex(int index);
+
+#endif // TINTA_I18N_H

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -7,6 +7,7 @@ void renderSearchOverlay(App& app);
 void renderFolderBrowser(App& app);
 void renderToc(App& app);
 void renderThemeChooser(App& app);
+void renderLanguageChooser(App& app);
 void renderHelpOverlay(App& app);
 
 #endif // TINTA_OVERLAYS_H

--- a/include/settings.h
+++ b/include/settings.h
@@ -8,6 +8,6 @@ void saveSettings(const Settings& settings);
 Settings loadSettings();
 bool registerFileAssociation();
 void openDefaultAppsSettings();
-void askAndRegisterFileAssociation(Settings& settings);
+void askAndRegisterFileAssociation(Settings& settings, int langIndex);
 
 #endif // TINTA_SETTINGS_H

--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -60,6 +60,25 @@ void applyTheme(App& app, int themeIndex) {
     }
 }
 
+void applyLanguage(App& app, int langIndex) {
+    if (langIndex < 0 || langIndex >= LANG_COUNT) return;
+    if (langIndex == app.currentLanguageIndex) {
+        // Nothing to do, but still force a redraw in case the chooser is open
+        if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
+        return;
+    }
+    app.currentLanguageIndex = langIndex;
+
+    // Cached text layouts bake their strings in, so a relayout is required for
+    // document chrome that reads translations (alert titles, image alt-text).
+    // Body text comes from the user's file and is unaffected.
+    app.layoutDirty = true;
+
+    if (app.hwnd) {
+        InvalidateRect(app.hwnd, nullptr, FALSE);
+    }
+}
+
 void updateTextFormats(App& app) {
     // Release existing formats
     if (app.textFormat) { app.textFormat->Release(); app.textFormat = nullptr; }
@@ -199,6 +218,16 @@ void updateOverlayFormats(App& app) {
         DWRITE_FONT_WEIGHT_SEMI_BOLD, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
         11.0f * scale, L"en-us", &app.themeHeaderFormat);
 
+    // Language chooser formats (title + native name + English subtitle).
+    // The native-name format is built per-row in renderLanguageChooser so each
+    // language shows in its own font; these two are for the panel chrome.
+    app.dwriteFactory->CreateTextFormat(L"Segoe UI Light", nullptr,
+        DWRITE_FONT_WEIGHT_LIGHT, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+        28.0f * scale, L"en-us", &app.languageTitleFormat);
+    app.dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr,
+        DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+        11.0f * scale, L"en-us", &app.languageSubtitleFormat);
+
     // Theme preview formats (3 per theme, several distinct font families) are
     // created lazily by ensureThemePreviewFormats when the chooser first opens
     // — they were ~30 CreateTextFormat calls on the startup critical path.
@@ -268,6 +297,17 @@ void ensureThemePreviewFormats(App& app) {
             DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
             10.0f * scale, L"en-us", &app.themePreviewFormats[i].code);
     }
+}
+
+void ensureLanguageFormats(App& app) {
+    // The native-name format is shared across rows (CJK glyphs resolve via the
+    // font fallback chain regardless of the requested family), so one format
+    // suffices. Built lazily so the chooser doesn't pay for it at startup.
+    if (app.languageNativeFormat) return;
+    float scale = app.contentScale;
+    app.dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr,
+        DWRITE_FONT_WEIGHT_SEMI_BOLD, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+        16.0f * scale, L"en-us", &app.languageNativeFormat);
 }
 
 void createTypography(App& app) {

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -5,6 +5,7 @@
 #include "render.h"
 #include "d2d_init.h"
 #include "search.h"
+#include "i18n.h"
 
 #include <fstream>
 #include <sstream>
@@ -559,8 +560,10 @@ static void scheduleReparse(App& app) {
         std::wstring wpath = toWide(app.currentFile);
         size_t lastSep = wpath.find_last_of(L"\\/");
         std::wstring fname = (lastSep != std::wstring::npos) ? wpath.substr(lastSep + 1) : wpath;
-        std::wstring title = L"Tinta - * " + fname;
-        SetWindowTextW(app.hwnd, title.c_str());
+        // title.dirty is "Tinta - * %1$s" — routed through tr() for consistency.
+        wchar_t buf[MAX_PATH + 40];
+        swprintf_s(buf, tr(app, "title.dirty"), fname.c_str());
+        SetWindowTextW(app.hwnd, buf);
     }
     // No preview pane — nothing to keep in sync until it's shown again
     if (!app.editorShowPreview) return;
@@ -599,7 +602,7 @@ void editorReparse(App& app) {
 void enterEditMode(App& app) {
     if (app.currentFile.empty()) {
         // Show brief "No file loaded" notification
-        app.editorNotificationMsg = L"No file loaded";
+        app.editorNotificationMsg = tr(app, "toast.no_file");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -649,7 +652,7 @@ void enterEditMode(App& app) {
     KillTimer(app.hwnd, 1); // TIMER_FILE_WATCH = 1
 
     // Show notification
-    app.editorNotificationMsg = L"Press ESC twice to exit edit mode";
+    app.editorNotificationMsg = tr(app, "toast.exit_edit_hint");
     app.showEditModeNotification = true;
     app.editModeNotificationAlpha = 1.0f;
     app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -666,7 +669,7 @@ void exitEditMode(App& app) {
     if (app.editorDirty) {
         // Show in-app prompt instead of modal dialog (avoids ESC key conflict)
         app.confirmExitPending = true;
-        app.editorNotificationMsg = L"Unsaved changes! Y = save & exit, N = discard, ESC = cancel";
+        app.editorNotificationMsg = tr(app, "toast.unsaved_exit");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -765,7 +768,7 @@ void saveEditorFile(App& app, HWND hwnd) {
         editorReparse(app);
 
         // Show "Saved!" notification
-        app.editorNotificationMsg = L"Saved!";
+        app.editorNotificationMsg = tr(app, "toast.saved");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -778,7 +781,7 @@ void saveEditorFile(App& app, HWND hwnd) {
     } else {
         // Surface the failure — a silent no-op here leaves the document
         // permanently dirty and traps the user in the exit-confirm prompt
-        app.editorNotificationMsg = L"Save failed — file may be locked or read-only";
+        app.editorNotificationMsg = tr(app, "toast.save_failed");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -870,7 +873,7 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
         } else if (wParam == VK_ESCAPE) {
             app.confirmExitPending = false;
             app.escPressedOnce = false;
-            app.editorNotificationMsg = L"Exit cancelled";
+            app.editorNotificationMsg = tr(app, "toast.exit_cancelled");
             app.showEditModeNotification = true;
             app.editModeNotificationAlpha = 1.0f;
             app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -895,7 +898,7 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
         app.lastEscTime = now;
 
         // Show brief hint
-        app.editorNotificationMsg = L"Press ESC again to exit edit mode";
+        app.editorNotificationMsg = tr(app, "toast.exit_confirm");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = now;
@@ -967,8 +970,8 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 app.editorRowMetricsWidth = -1.0f;  // pane width changed
                 app.editorNotificationMsg = app.editorShowPreview
-                    ? L"Preview shown (Ctrl+P to hide)"
-                    : L"Preview hidden (Ctrl+P to show)";
+                    ? tr(app, "toast.preview_shown")
+                    : tr(app, "toast.preview_hidden");
                 app.showEditModeNotification = true;
                 app.editModeNotificationAlpha = 1.0f;
                 app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -984,8 +987,8 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 rebuildEditorRowMetrics(app);
                 editorEnsureCursorVisible(app);
                 app.editorNotificationMsg = app.editorWordWrap
-                    ? L"Word wrap on (Ctrl+W to turn off)"
-                    : L"Word wrap off (Ctrl+W to turn on)";
+                    ? tr(app, "toast.wrap_on")
+                    : tr(app, "toast.wrap_off");
                 app.showEditModeNotification = true;
                 app.editModeNotificationAlpha = 1.0f;
                 app.editModeNotificationStart = std::chrono::steady_clock::now();

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -1,0 +1,259 @@
+#include "i18n.h"
+#include "app.h"
+
+#include <windows.h>
+#include <string.h>
+#include <cstring>
+
+// Language metadata. nativeFont is a hint — the chooser uses it so each
+// language's name shows in its native typeface. Empty string falls back to
+// the theme font (the font fallback chain already handles CJK glyphs).
+const Language LANGUAGES[LANG_COUNT] = {
+    { L"English",                L"English",                     L"" },
+    { L"\u7B80\u4F53\u4E2D\u6587", L"Chinese (Simplified)",       L"Microsoft YaHei UI" },
+    { L"\u65E5\u672C\u8A9E",       L"Japanese",                   L"Yu Gothic UI" },
+    { L"\uD55C\uAD6D\uC5B4",       L"Korean",                     L"Malgun Gothic" },
+};
+
+// Translation table.
+//
+// Every key MUST have an English entry — English is the fallback when a
+// language lacks a translation. The zh/ja/ko columns may be nullptr to mean
+// "fall back to English". Once a translation is added it should never be
+// removed (only amended); keys are stable identifiers referenced across the
+// codebase.
+//
+// Conventions:
+//   - Keys use dotted lowercase namespaces: help.title, toast.saved, ...
+//   - Format strings use positional printf-style placeholders so locales can
+//     reorder arguments: "%1$d of %2$zu", not "%d of %zu".
+//   - Em dash (U+2014) is written as a literal L"\u2014" for readability.
+namespace {
+
+struct Entry {
+    const char* key;
+    const wchar_t* en;
+    const wchar_t* zh;  // Simplified Chinese
+    const wchar_t* ja;  // Japanese (may be null -> fallback to en)
+    const wchar_t* ko;  // Korean   (may be null -> fallback to en)
+};
+
+// Note: kept as a plain array (not unordered_map) on purpose. ~80 entries,
+// linear scan is cache-friendly and avoids a static-init ordering fiasco.
+const Entry kEntries[] = {
+    // ----- Help overlay -----
+    { "help.title",            L"Keyboard Shortcuts",                       L"\u952E\u76D8\u5FEB\u6377\u952E",                       nullptr, nullptr },
+    { "help.section.navigation", L"NAVIGATION",                             L"\u5BFC\u822A",                                          nullptr, nullptr },
+    { "help.section.view",     L"VIEW",                                     L"\u89C6\u56FE",                                          nullptr, nullptr },
+    { "help.section.editing",  L"EDITING",                                  L"\u7F16\u8F91",                                          nullptr, nullptr },
+    { "help.section.general",  L"GENERAL",                                  L"\u5E38\u89C4",                                          nullptr, nullptr },
+    { "help.footer",           L"Press ESC or ? to close",                  L"\u6309 ESC \u6216 ? \u5173\u95ED",                      nullptr, nullptr },
+
+    // Help entries: only the description column is translated; keys (Ctrl+S etc.) stay verbatim.
+    { "help.nav.scroll_down",      L"Scroll down",                  L"\u5411\u4E0B\u6EDA\u52A8",                          nullptr, nullptr },
+    { "help.nav.scroll_up",        L"Scroll up",                    L"\u5411\u4E0A\u6EDA\u52A8",                          nullptr, nullptr },
+    { "help.nav.page_down",        L"Page down",                    L"\u5411\u4E0B\u7FFB\u9875",                          nullptr, nullptr },
+    { "help.nav.page_up",          L"Page up",                      L"\u5411\u4E0A\u7FFB\u9875",                          nullptr, nullptr },
+    { "help.nav.jump_start_end",   L"Jump to start / end",          L"\u8DF3\u8F6C\u5230\u5F00\u5934 / \u7ED3\u5C3E",     nullptr, nullptr },
+    { "help.nav.zoom",             L"Zoom in / out",                L"\u653E\u5927 / \u7F29\u5C0F",                       nullptr, nullptr },
+
+    { "help.view.search",          L"Search",                       L"\u641C\u7D22",                                      nullptr, nullptr },
+    { "help.view.next_match",      L"Next search match",            L"\u4E0B\u4E00\u4E2A\u5339\u914D\u7ED3\u679C",        nullptr, nullptr },
+    { "help.view.folder_browser",  L"Toggle folder browser",        L"\u5207\u6362\u6587\u4EF6\u5939\u6D4F\u89C8",        nullptr, nullptr },
+    { "help.view.toc",             L"Toggle table of contents",     L"\u5207\u6362\u76EE\u5F55",                          nullptr, nullptr },
+    { "help.view.theme",           L"Theme chooser",                L"\u4E3B\u9898\u9009\u62E9\u5668",                    nullptr, nullptr },
+    { "help.view.stats",           L"Toggle stats",                 L"\u5207\u6362\u7EDF\u8BA1\u4FE1\u606F",              nullptr, nullptr },
+    { "help.view.help",            L"This help",                    L"\u672C\u5E2E\u52A9",                                nullptr, nullptr },
+
+    { "help.edit.enter_edit",      L"Enter edit mode",              L"\u8FDB\u5165\u7F16\u8F91\u6A21\u5F0F",              nullptr, nullptr },
+    { "help.edit.save",            L"Save (in edit mode)",          L"\u4FDD\u5B58\uFF08\u7F16\u8F91\u6A21\u5F0F\u4E0B\uFF09", nullptr, nullptr },
+    { "help.edit.preview",         L"Show / hide preview pane",     L"\u663E\u793A / \u9690\u85CF\u9884\u89C8\u7A97\u683C", nullptr, nullptr },
+    { "help.edit.word_wrap",       L"Toggle word wrap",             L"\u5207\u6362\u81EA\u52A8\u6362\u884C",              nullptr, nullptr },
+    { "help.edit.exit_edit",       L"Exit edit mode",               L"\u9000\u51FA\u7F16\u8F91\u6A21\u5F0F",              nullptr, nullptr },
+
+    { "help.general.select_all",   L"Select all text",              L"\u5168\u9009\u6587\u672C",                          nullptr, nullptr },
+    { "help.general.copy",         L"Copy selection",               L"\u590D\u5236\u9009\u4E2D\u5185\u5BB9",              nullptr, nullptr },
+    { "help.general.close",        L"Close overlay / Quit",         L"\u5173\u95ED\u6D6E\u5C42 / \u9000\u51FA",           nullptr, nullptr },
+    { "help.general.quit",         L"Quit",                         L"\u9000\u51FA",                                      nullptr, nullptr },
+
+    // ----- Search overlay -----
+    { "search.placeholder",    L"Search...",                                L"\u641C\u7D22...",                                      nullptr, nullptr },
+    { "search.no_matches",     L"No matches",                               L"\u65E0\u5339\u914D",                                   nullptr, nullptr },
+    // Positional format: %1$d = current (1-based), %2$zu = total. Locales may reorder.
+    { "search.match_count",    L"%1$d of %2$zu",                            L"\u7B2C %1$d / %2$zu \u4E2A",                           nullptr, nullptr },
+
+    // ----- Table of contents -----
+    { "toc.title",             L"Contents",                                 L"\u76EE\u5F55",                                         nullptr, nullptr },
+    { "toc.empty",             L"No headings",                              L"\u65E0\u6807\u9898",                                   nullptr, nullptr },
+
+    // ----- Theme chooser -----
+    { "theme.chooser.title",   L"Choose Theme",                             L"\u9009\u62E9\u4E3B\u9898",                             nullptr, nullptr },
+    { "theme.chooser.light",   L"LIGHT THEMES",                             L"\u6D45\u8272\u4E3B\u9898",                             nullptr, nullptr },
+    { "theme.chooser.dark",    L"DARK THEMES",                              L"\u6DF1\u8272\u4E3B\u9898",                             nullptr, nullptr },
+
+    // ----- Language chooser -----
+    { "lang.chooser.title",    L"Choose Language",                          L"\u9009\u62E9\u8BED\u8A00",                             nullptr, nullptr },
+    { "lang.chooser.footer",   L"Press ESC to close",                       L"\u6309 ESC \u5173\u95ED",                              nullptr, nullptr },
+
+    // ----- Toast / editor notifications -----
+    { "toast.no_file",         L"No file loaded",                           L"\u672A\u52A0\u8F7D\u6587\u4EF6",                       nullptr, nullptr },
+    { "toast.exit_edit_hint",  L"Press ESC twice to exit edit mode",        L"\u8FDE\u6309\u4E24\u6B21 ESC \u9000\u51FA\u7F16\u8F91\u6A21\u5F0F", nullptr, nullptr },
+    { "toast.unsaved_exit",    L"Unsaved changes! Y = save & exit, N = discard, ESC = cancel",
+                               L"\u6709\u672A\u4FDD\u5B58\u7684\u66F4\u6539\uFF01Y = \u4FDD\u5B58\u5E76\u9000\u51FA\uFF0CN = \u653E\u5F03\uFF0CESC = \u53D6\u6D88",
+                               nullptr, nullptr },
+    { "toast.saved",           L"Saved!",                                   L"\u5DF2\u4FDD\u5B58\uFF01",                             nullptr, nullptr },
+    { "toast.save_failed",     L"Save failed \u2014 file may be locked or read-only",
+                               L"\u4FDD\u5B58\u5931\u8D25 \u2014 \u6587\u4EF6\u53EF\u80FD\u88AB\u9501\u5B9A\u6216\u4E3A\u53EA\u8BFB",
+                               nullptr, nullptr },
+    { "toast.exit_cancelled",  L"Exit cancelled",                           L"\u5DF2\u53D6\u6D88\u9000\u51FA",                       nullptr, nullptr },
+    { "toast.exit_confirm",    L"Press ESC again to exit edit mode",        L"\u518D\u6309\u4E00\u6B21 ESC \u9000\u51FA\u7F16\u8F91\u6A21\u5F0F", nullptr, nullptr },
+    { "toast.preview_shown",   L"Preview shown (Ctrl+P to hide)",           L"\u5DF2\u663E\u793A\u9884\u89C8\uFF08Ctrl+P \u9690\u85CF\uFF09", nullptr, nullptr },
+    { "toast.preview_hidden",  L"Preview hidden (Ctrl+P to show)",          L"\u5DF2\u9690\u85CF\u9884\u89C8\uFF08Ctrl+P \u663E\u793A\uFF09", nullptr, nullptr },
+    { "toast.wrap_on",         L"Word wrap on (Ctrl+W to turn off)",        L"\u5DF2\u5F00\u542F\u81EA\u52A8\u6362\u884C\uFF08Ctrl+W \u5173\u95ED\uFF09", nullptr, nullptr },
+    { "toast.wrap_off",        L"Word wrap off (Ctrl+W to turn on)",        L"\u5DF2\u5173\u95ED\u81EA\u52A8\u6362\u884C\uFF08Ctrl+W \u5F00\u542F\uFF09", nullptr, nullptr },
+
+    // Code block hover button + confirmation pill
+    { "codeblock.copy",        L"Copy",                                     L"\u590D\u5236",                                         nullptr, nullptr },
+    { "codeblock.copied",      L"Copied!",                                  L"\u5DF2\u590D\u5236\uFF01",                             nullptr, nullptr },
+
+    // ----- Stats overlay -----
+    // Two-line format. Labels translatable; D2D/DWrite kept as technical abbreviations.
+    // Placeholders: %1$zu parse us, %2$zu layout us, %3$zu draw calls,
+    //               %4$.1f startup ms, %5$.1f window ms, %6$.1f d2d ms,
+    //               %7$.1f dwrite ms, %8$.1f file ms
+    { "stats.line1",           L"Parse: %1$zu us | Layout: %2$zu us | Draw calls: %3$zu",
+                               L"\u89E3\u6790: %1$zu us | \u5E03\u5C40: %2$zu us | \u7ED8\u5236\u8C03\u7528: %3$zu",
+                               nullptr, nullptr },
+    { "stats.line2",           L"Startup: %4$.1fms (Win: %5$.1f | D2D: %6$.1f | DWrite: %7$.1f | File: %8$.1f)",
+                               L"\u542F\u52A8: %4$.1fms (\u7A97\u53E3: %5$.1f | D2D: %6$.1f | DWrite: %7$.1f | \u6587\u4EF6: %8$.1f)",
+                               nullptr, nullptr },
+
+    // ----- File-association dialogs (shared by settings.cpp and main_d2d.cpp /register) -----
+    { "fileassoc.title",                L"Tinta - File Association",                 L"Tinta - \u6587\u4EF6\u5173\u8054",                              nullptr, nullptr },
+    { "fileassoc.add_mmd_failed_body",  L"Failed to add the .mmd file association. Run tinta.exe /register to try again.",
+                                         L"\u6DFB\u52A0 .mmd \u6587\u4EF6\u5173\u8054\u5931\u8D25\u3002\u8BF7\u8FD0\u884C tinta.exe /register \u91CD\u8BD5\u3002",
+                                         nullptr, nullptr },
+    { "fileassoc.ask_body",
+        L"Would you like to set Tinta as the default viewer for Markdown and Mermaid files?\n\nWindows will open Settings where you can select Tinta.",
+        L"\u662F\u5426\u5C06 Tinta \u8BBE\u4E3A Markdown \u548C Mermaid \u6587\u4EF6\u7684\u9ED8\u8BA4\u67E5\u770B\u5668\uFF1F\n\nWindows \u5C06\u6253\u5F00\u8BBE\u7F6E\uFF0C\u60A8\u53EF\u5728\u5176\u4E2D\u9009\u62E9 Tinta\u3002",
+        nullptr, nullptr },
+    { "fileassoc.done_title",   L"Almost done!",                              L"\u5C31\u5FEB\u5B8C\u6210\u4E86\uFF01",                          nullptr, nullptr },
+    { "fileassoc.done_body",
+        L"Tinta has been registered.\n\nIn the Settings window that opens:\n1. Search for '.md' or '.mmd'\n2. Click on the current default app\n3. Select 'Tinta' from the list",
+        L"Tinta \u5DF2\u6CE8\u518C\u3002\n\n\u5728\u6253\u5F00\u7684\u8BBE\u7F6E\u7A97\u53E3\u4E2D\uFF1A\n1. \u641C\u7D22 \u201C.md\u201D \u6216 \u201C.mmd\u201D\n2. \u70B9\u51FB\u5F53\u524D\u9ED8\u8BA4\u5E94\u7528\n3. \u4ECE\u5217\u8868\u4E2D\u9009\u62E9 \u201CTinta\u201D",
+        nullptr, nullptr },
+    { "fileassoc.register_failed_body", L"Failed to register file association. Try running as administrator.",
+                                         L"\u6CE8\u518C\u6587\u4EF6\u5173\u8054\u5931\u8D25\u3002\u8BF7\u5C1D\u8BD5\u4EE5\u7BA1\u7406\u5458\u8EAB\u4EFD\u8FD0\u884C\u3002",
+                                         nullptr, nullptr },
+
+    // ----- Init-failure dialogs -----
+    { "error.title",               L"Error",                                       L"\u9519\u8BEF",                                  nullptr, nullptr },
+    { "error.d2d_init_failed",     L"Failed to initialize Direct2D",              L"Direct2D \u521D\u59CB\u5316\u5931\u8D25",        nullptr, nullptr },
+    { "error.render_target_failed", L"Failed to create render target",             L"\u521B\u5EFA\u6E32\u67D3\u76EE\u6807\u5931\u8D25", nullptr, nullptr },
+
+    // ----- Window title -----
+    // Format with positional args: %1$s = filename (or full path), %2$s is unused
+    // for the non-dirty case. For the dirty case see title.dirty below.
+    { "title.plain",   L"Tinta - %1$s",            L"Tinta - %1$s",            nullptr, nullptr },
+    { "title.dirty",   L"Tinta - * %1$s",           L"Tinta - * %1$s",          nullptr, nullptr },
+    { "title.no_file", L"Tinta",                    L"Tinta",                   nullptr, nullptr },
+
+    // ----- GitHub-style alert titles (render.cpp) -----
+    // Emoji prefix + variation selector are added by the renderer; we only
+    // translate the trailing word. The keys below carry the bare word.
+    { "alert.note",      L"Note",      L"\u6CE8\u91CA",       nullptr, nullptr },
+    { "alert.tip",       L"Tip",       L"\u63D0\u793A",       nullptr, nullptr },
+    { "alert.important", L"Important", L"\u91CD\u8981",       nullptr, nullptr },
+    { "alert.warning",   L"Warning",   L"\u8B66\u544A",       nullptr, nullptr },
+    { "alert.caution",   L"Caution",   L"\u6CE8\u610F",       nullptr, nullptr },
+
+    // ----- Image alt-text placeholder (render.cpp) -----
+    // Renders as "[image: <alt>]". The brackets and separator are added by
+    // the renderer; only the word "image" is translated here.
+    { "image.placeholder", L"image", L"\u56FE\u7247", nullptr, nullptr },
+};
+
+constexpr size_t kEntryCount = sizeof(kEntries) / sizeof(kEntries[0]);
+
+const Entry* findEntry(const char* key) {
+    // Linear scan — ~80 entries, called a few hundred times per frame at most.
+    for (size_t i = 0; i < kEntryCount; i++) {
+        if (std::strcmp(kEntries[i].key, key) == 0) {
+            return &kEntries[i];
+        }
+    }
+    return nullptr;
+}
+
+const wchar_t* pick(const Entry* e, int langIndex) {
+    if (!e) return nullptr;
+    switch (langIndex) {
+        case 1: if (e->zh) return e->zh; break;
+        case 2: if (e->ja) return e->ja; break;
+        case 3: if (e->ko) return e->ko; break;
+        default: break;
+    }
+    return e->en;  // English is the fallback (also handles langIndex == 0)
+}
+
+} // namespace
+
+const wchar_t* tr(int langIndex, const char* key) {
+    if (!key) return L"";
+    const Entry* e = findEntry(key);
+    const wchar_t* v = pick(e, langIndex);
+    if (v) return v;
+    // Unknown key: return the key itself so breakage is visible in dev
+    // without crashing. Convert char* to a stable wide buffer.
+    static thread_local std::wstring fallback;
+    fallback.clear();
+    for (const char* p = key; *p; ++p) fallback.push_back((wchar_t)(unsigned char)*p);
+    return fallback.c_str();
+}
+
+const wchar_t* tr(const App& app, const char* key) {
+    return tr(app.currentLanguageIndex, key);
+}
+
+int clampLanguageIndex(int index) {
+    return (index >= 0 && index < LANG_COUNT) ? index : LANG_INDEX_EN;
+}
+
+int detectSystemLanguage() {
+    // GetUserPreferredUILanguages returns a double-NUL-terminated list of
+    // BCP 47 tags ("en-US\0zh-Hans-CN\0\0"). We pick the first one we recognize.
+    ULONG numLanguages = 0;
+    ULONG bufferSize = 0;
+    if (GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, &numLanguages, nullptr, &bufferSize)) {
+        std::wstring buffer(bufferSize, L'\0');
+        if (GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, &numLanguages, buffer.data(), &bufferSize) && numLanguages > 0) {
+            // Walk each NUL-terminated tag in the buffer.
+            const wchar_t* p = buffer.c_str();
+            for (ULONG i = 0; i < numLanguages; ++i) {
+                std::wstring tag(p);
+                // ci-compare prefix
+                auto startsWith = [&](const wchar_t* prefix) {
+                    size_t n = 0;
+                    while (prefix[n]) ++n;
+                    if (tag.size() < n) return false;
+                    for (size_t k = 0; k < n; ++k) {
+                        wchar_t a = tag[k], b = prefix[k];
+                        if (a >= L'A' && a <= L'Z') a += (L'a' - L'A');
+                        if (b >= L'A' && b <= L'Z') b += (L'a' - L'A');
+                        if (a != b) return false;
+                    }
+                    return true;
+                };
+                // zh-Hans* (Simplified) -> Simplified Chinese.
+                // zh-Hant* (Traditional) is not yet translated -> falls through to English.
+                if (startsWith(L"zh-hans") || startsWith(L"zh-cn") || startsWith(L"zh-sg")) {
+                    return 1;
+                }
+                if (startsWith(L"ja")) return 2;
+                if (startsWith(L"ko")) return 3;
+                p += tag.size() + 1;  // skip past the NUL
+            }
+        }
+    }
+    return LANG_INDEX_EN;
+}

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -7,6 +7,7 @@
 #include "d2d_init.h"
 #include "settings.h"
 #include "render.h"
+#include "i18n.h"
 
 #include <windowsx.h>
 #include <shellapi.h>
@@ -321,6 +322,14 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         // Only invalidate when mouse is over the panel (hover tracking needed)
         if (inPanel)
             InvalidateRect(hwnd, nullptr, FALSE);
+    } else if (app.showLanguageChooser) {
+        // Hand cursor over a language row, arrow otherwise
+        if (app.hoveredLanguageIndex >= 0) {
+            SetCursor(cursorHand);
+        } else {
+            SetCursor(cursorArrow);
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
     } else if (app.scrollbarHovered || app.scrollbarDragging ||
         app.hScrollbarHovered || app.hScrollbarDragging) {
         SetCursor(cursorArrow);
@@ -407,7 +416,7 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     }
 
     // If theme chooser, folder browser, or TOC is open, don't start selection - just record for click handling
-    if (app.showThemeChooser || app.showFolderBrowser || app.showToc) {
+    if (app.showThemeChooser || app.showFolderBrowser || app.showToc || app.showLanguageChooser) {
         return;
     }
 
@@ -723,6 +732,52 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         return;
     }
 
+    // Language chooser click handling
+    if (app.showLanguageChooser) {
+        int clickX = GET_X_LPARAM(lParam);
+        int clickY = GET_Y_LPARAM(lParam);
+
+        // Replicate the layout from renderLanguageChooser
+        float panelWidth = std::min(dpi(app, 420.0f), (float)app.width - dpi(app, 80.0f));
+        float panelHeight = std::min(dpi(app, 460.0f), (float)app.height - dpi(app, 80.0f));
+        float panelX = (app.width - panelWidth) / 2;
+        float panelY = (app.height - panelHeight) / 2;
+        float padding = dpi(app, 20.0f);
+        float listTopY = panelY + dpi(app, 80.0f);
+        float listBottomY = panelY + panelHeight - dpi(app, 50.0f);
+        float rowWidth = panelWidth - padding * 2;
+        float rowHeight = std::min(dpi(app, 70.0f), (listBottomY - listTopY) / LANG_COUNT);
+        float rowX = panelX + padding;
+        float innerPad = dpi(app, 6.0f);
+
+        int clickedLang = -1;
+        for (int i = 0; i < LANG_COUNT; i++) {
+            float rowY = listTopY + i * rowHeight;
+            float innerX = rowX + innerPad;
+            float innerY = rowY + innerPad;
+            float innerW = rowWidth - innerPad * 2;
+            float innerH = rowHeight - innerPad * 2;
+            if (clickX >= innerX && clickX <= innerX + innerW &&
+                clickY >= innerY && clickY <= innerY + innerH) {
+                clickedLang = i;
+                break;
+            }
+        }
+
+        if (clickedLang >= 0) {
+            applyLanguage(app, clickedLang);
+            // Persist immediately so the choice survives crashes / power loss.
+            Settings s = loadSettings();
+            s.languageIndex = clickedLang;
+            saveSettings(s);
+        }
+        // Always close after a click (inside selects, outside cancels)
+        app.showLanguageChooser = false;
+        app.languageChooserAnimation = 0;
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     if (app.scrollbarDragging) {
         app.scrollbarDragging = false;
         InvalidateRect(hwnd, nullptr, FALSE);
@@ -899,7 +954,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     } else {
         switch (wParam) {
             case VK_ESCAPE:
-                // Priority: Help > Search > FolderBrowser > TOC > Theme chooser > Quit
+                // Priority: Help > Search > FolderBrowser > TOC > Theme/Language chooser > Quit
                 if (app.showHelp) {
                     app.showHelp = false;
                     app.helpAnimation = 0;
@@ -919,18 +974,21 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 } else if (app.showThemeChooser) {
                     app.showThemeChooser = false;
                     app.themeChooserAnimation = 0;
+                } else if (app.showLanguageChooser) {
+                    app.showLanguageChooser = false;
+                    app.languageChooserAnimation = 0;
                 } else {
                     PostQuitMessage(0);
                 }
                 break;
             case 'Q':
-                if (!app.showThemeChooser && !app.showSearch && !app.showFolderBrowser && !app.showToc) {
+                if (!app.showThemeChooser && !app.showSearch && !app.showFolderBrowser && !app.showToc && !app.showLanguageChooser) {
                     PostQuitMessage(0);
                 }
                 break;
             case 'B':
                 // B to toggle folder browser
-                if (!app.showSearch && !app.showThemeChooser && !app.showToc) {
+                if (!app.showSearch && !app.showThemeChooser && !app.showToc && !app.showLanguageChooser) {
                     app.showFolderBrowser = !app.showFolderBrowser;
                     if (app.showFolderBrowser) {
                         app.folderBrowserAnimation = 0;
@@ -949,7 +1007,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 break;
             case VK_TAB:
-                if (!app.showSearch && !app.showThemeChooser && !app.showFolderBrowser) {
+                if (!app.showSearch && !app.showThemeChooser && !app.showFolderBrowser && !app.showLanguageChooser) {
                     app.showToc = !app.showToc;
                     if (app.showToc) {
                         ensureLayoutComplete(app);  // headings list is built during layout
@@ -961,7 +1019,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 break;
             case 'T':
-                if (!app.showSearch) {
+                if (!app.showSearch && !app.showLanguageChooser) {
                     app.showThemeChooser = !app.showThemeChooser;
                     if (app.showThemeChooser) {
                         app.themeChooserAnimation = 0;
@@ -969,9 +1027,19 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 InvalidateRect(hwnd, nullptr, FALSE);
                 break;
+            case 'L':
+                // L to toggle the language chooser
+                if (!app.showSearch && !app.showThemeChooser && !app.showFolderBrowser && !app.showToc) {
+                    app.showLanguageChooser = !app.showLanguageChooser;
+                    if (app.showLanguageChooser) {
+                        app.languageChooserAnimation = 0;
+                    }
+                }
+                InvalidateRect(hwnd, nullptr, FALSE);
+                break;
             case 'F':
                 // F to open search (when not in search mode)
-                if (!app.showSearch && !app.showThemeChooser) {
+                if (!app.showSearch && !app.showThemeChooser && !app.showLanguageChooser) {
                     app.showSearch = true;
                     app.searchActive = true;
                     app.searchAnimation = 0;
@@ -1034,7 +1102,7 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
     }
 
     // ':' to enter edit mode, '?' to toggle help — when no overlay is active
-    if (!app.showSearch && !app.showFolderBrowser && !app.showToc && !app.showThemeChooser) {
+    if (!app.showSearch && !app.showFolderBrowser && !app.showToc && !app.showThemeChooser && !app.showLanguageChooser) {
         wchar_t ch = (wchar_t)wParam;
         if (ch == L':' && !app.showHelp) {
             enterEditMode(app);

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -18,6 +18,7 @@
 #include "document.h"
 #include "d2d_init.h"
 #include "utils.h"
+#include "i18n.h"
 #include "syntax.h"
 #include "search.h"
 #include "render.h"
@@ -440,7 +441,8 @@ render_document:
                 app.theme.isDark ? 0.9f : 0.15f,
                 1.0f));
             IDWriteTextLayout* btnLayout = nullptr;
-            app.dwriteFactory->CreateTextLayout(L"Copy", 4, app.codeFormat,
+            const wchar_t* copyLabel = tr(app, "codeblock.copy");
+            app.dwriteFactory->CreateTextLayout(copyLabel, (UINT32)wcslen(copyLabel), app.codeFormat,
                 btnW, btnH, &btnLayout);
             if (btnLayout) {
                 btnLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
@@ -693,17 +695,22 @@ render_document:
                 D2D1::RoundedRect(D2D1::RectF(pillX, pillY, pillX + copyWidth, pillY + copyHeight), 13, 13),
                 app.brush);
 
-            // Cache the "Copied!" text layout and metrics across frames
+            // Cache the "Copied!" text layout and metrics across frames.
+            // The cache keys on language so switching languages rebuilds it.
             static IDWriteTextLayout* cachedCopyLayout = nullptr;
             static float cachedTextOffsetX = 0, cachedTextOffsetY = 0;
-            if (!cachedCopyLayout) {
-                app.dwriteFactory->CreateTextLayout(L"Copied!", 7,
+            static int cachedCopyLang = -1;
+            if (!cachedCopyLayout || cachedCopyLang != app.currentLanguageIndex) {
+                if (cachedCopyLayout) { cachedCopyLayout->Release(); cachedCopyLayout = nullptr; }
+                const wchar_t* copiedText = tr(app, "codeblock.copied");
+                app.dwriteFactory->CreateTextLayout(copiedText, (UINT32)wcslen(copiedText),
                     app.textFormat, copyWidth, copyHeight, &cachedCopyLayout);
                 if (cachedCopyLayout) {
                     DWRITE_TEXT_METRICS m;
                     cachedCopyLayout->GetMetrics(&m);
                     cachedTextOffsetX = (copyWidth - m.width) / 2;
                     cachedTextOffsetY = (copyHeight - m.height) / 2;
+                    cachedCopyLang = app.currentLanguageIndex;
                 }
             }
             if (cachedCopyLayout) {
@@ -721,17 +728,19 @@ render_document:
     // Draw stats
     if (app.showStats) {
         wchar_t stats[512];
-        swprintf(stats, 512,
-            L"Parse: %zu us | Layout: %zu us | Draw calls: %zu\n"
-            L"Startup: %.1fms (Win: %.1f | D2D: %.1f | DWrite: %.1f | File: %.1f)",
-            app.parseTimeUs,
-            app.layoutTimeUs,
-            app.drawCalls,
+        // Two positional-format lines (see i18n: stats.line1 / stats.line2).
+        // Compose them into one buffer so the overlay renders a single block.
+        wchar_t line1[256];
+        wchar_t line2[256];
+        swprintf_s(line1, 256, tr(app, "stats.line1"),
+            app.parseTimeUs, app.layoutTimeUs, app.drawCalls);
+        swprintf_s(line2, 256, tr(app, "stats.line2"),
             app.metrics.totalStartupUs / 1000.0,
             app.metrics.windowInitUs / 1000.0,
             app.metrics.d2dInitUs / 1000.0,
             app.metrics.dwriteInitUs / 1000.0,
             app.metrics.fileLoadUs / 1000.0);
+        swprintf_s(stats, 512, L"%ls\n%ls", line1, line2);
 
         float statsWidth = dpi(app, 600.0f);
         float statsHeight = dpi(app, 50.0f);
@@ -754,6 +763,7 @@ render_document:
     if (app.showFolderBrowser) renderFolderBrowser(app);
     if (app.showToc) renderToc(app);
     if (app.showThemeChooser) renderThemeChooser(app);
+    if (app.showLanguageChooser) renderLanguageChooser(app);
     if (app.showHelp) renderHelpOverlay(app);
 
     // Close edit mode split view clipping
@@ -921,6 +931,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.zoomFactor = app->zoomFactor;
                 settings.editorShowPreview = app->editorShowPreview;
                 settings.editorWordWrap = app->editorWordWrap;
+                settings.languageIndex = app->currentLanguageIndex;
 
                 // Get window placement for position/size/maximized state
                 WINDOWPLACEMENT wp = {};
@@ -1026,6 +1037,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.zoomFactor = savedSettings.zoomFactor;
     app.editorShowPreview = savedSettings.editorShowPreview;
     app.editorWordWrap = savedSettings.editorWordWrap;
+    // Language: explicit user choice wins; otherwise follow the system UI.
+    app.currentLanguageIndex = (savedSettings.languageIndex >= 0 && savedSettings.languageIndex < LANG_COUNT)
+        ? savedSettings.languageIndex
+        : detectSystemLanguage();
 
     // Parse command line
     std::string inputFile;
@@ -1055,22 +1070,18 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     if (forceRegister) {
         if (registerFileAssociation()) {
             MessageBoxW(nullptr,
-                       L"Tinta has been registered.\n\n"
-                       L"In the Settings window that opens:\n"
-                       L"1. Search for '.md' or '.mmd'\n"
-                       L"2. Click on the current default app\n"
-                       L"3. Select 'Tinta' from the list",
-                       L"Almost done!", MB_OK | MB_ICONINFORMATION);
+                       tr(app, "fileassoc.done_body"),
+                       tr(app, "fileassoc.done_title"), MB_OK | MB_ICONINFORMATION);
             openDefaultAppsSettings();
         } else {
-            MessageBoxW(nullptr, L"Failed to register file association. Try running as administrator.",
-                       L"Error", MB_OK | MB_ICONWARNING);
+            MessageBoxW(nullptr, tr(app, "fileassoc.register_failed_body"),
+                       tr(app, "error.title"), MB_OK | MB_ICONWARNING);
         }
         return 0;  // Exit after registering
     }
 
     // Ask about file association on first run
-    askAndRegisterFileAssociation(savedSettings);
+    askAndRegisterFileAssociation(savedSettings, app.currentLanguageIndex);
 
     if (lightMode) {
         app.currentThemeIndex = 0;  // Paper (first light theme)
@@ -1136,7 +1147,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
 
     // Initialize D2D
     if (!initD2D(app)) {
-        MessageBoxW(nullptr, L"Failed to initialize Direct2D", L"Error", MB_OK);
+        MessageBoxW(nullptr, tr(app, "error.d2d_init_failed"), tr(app, "error.title"), MB_OK);
         return 1;
     }
 
@@ -1153,7 +1164,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     // Create render target
     t0 = Clock::now();
     if (!createRenderTarget(app)) {
-        MessageBoxW(nullptr, L"Failed to create render target", L"Error", MB_OK);
+        MessageBoxW(nullptr, tr(app, "error.render_target_failed"), tr(app, "error.title"), MB_OK);
         return 1;
     }
     app.metrics.renderTargetUs = usElapsed(t0);

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1,6 +1,7 @@
 #include "overlays.h"
 #include "utils.h"
 #include "d2d_init.h"
+#include "i18n.h"
 
 #include <chrono>
 #include <algorithm>
@@ -78,7 +79,8 @@ void renderSearchOverlay(App& app) {
             D2D1_COLOR_F placeholderColor = app.theme.text;
             placeholderColor.a = 0.4f * anim;
             app.brush->SetColor(placeholderColor);
-            app.renderTarget->DrawText(L"Search...", 9, searchTextFormat,
+            const wchar_t* ph = tr(app, "search.placeholder");
+            app.renderTarget->DrawText(ph, (UINT32)wcslen(ph), searchTextFormat,
                 D2D1::RectF(textX, barY + dpi(app, 12.0f), textX + textWidth, barY + barHeight), app.brush);
         } else {
             // Actual search query
@@ -112,15 +114,16 @@ void renderSearchOverlay(App& app) {
 
         // Match count
         if (!app.searchQuery.empty()) {
-            wchar_t countText[32];
+            wchar_t countText[64];
             size_t matchCount = app.editMode ? app.editorSearchMatches.size() : app.searchMatches.size();
             int currentIdx = app.editMode ? app.editorSearchCurrentIndex : app.searchCurrentIndex;
             if (matchCount == 0) {
-                wcscpy_s(countText, L"No matches");
+                const wchar_t* nm = tr(app, "search.no_matches");
+                wcscpy_s(countText, nm);
                 // Red color for no matches
                 app.brush->SetColor(D2D1::ColorF(0.9f, 0.3f, 0.3f, anim));
             } else {
-                swprintf_s(countText, L"%d of %zu", currentIdx + 1, matchCount);
+                swprintf_s(countText, tr(app, "search.match_count"), currentIdx + 1, matchCount);
                 D2D1_COLOR_F countColor = app.theme.text;
                 countColor.a = 0.7f * anim;
                 app.brush->SetColor(countColor);
@@ -355,7 +358,7 @@ void renderToc(App& app) {
         D2D1_COLOR_F headerColor = app.theme.heading;
         headerColor.a = anim;
         app.brush->SetColor(headerColor);
-        app.renderTarget->DrawText(L"Contents", 8, tocBold,
+        app.renderTarget->DrawText(tr(app, "toc.title"), (UINT32)wcslen(tr(app, "toc.title")), tocBold,
             D2D1::RectF(panelX + padding, headerY, panelX + panelWidth - padding, headerY + headerHeight),
             app.brush);
 
@@ -376,7 +379,8 @@ void renderToc(App& app) {
             D2D1_COLOR_F dimColor = app.theme.text;
             dimColor.a = 0.5f * anim;
             app.brush->SetColor(dimColor);
-            app.renderTarget->DrawText(L"No headings", 11, tocNormal,
+            const wchar_t* nh = tr(app, "toc.empty");
+            app.renderTarget->DrawText(nh, (UINT32)wcslen(nh), tocNormal,
                 D2D1::RectF(panelX + padding, listStartY + dpi(app, 8.0f), panelX + panelWidth - padding, listStartY + dpi(app, 40.0f)),
                 app.brush);
         } else {
@@ -496,7 +500,8 @@ void renderThemeChooser(App& app) {
     if (titleFormat) {
         titleFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
         app.brush->SetColor(D2D1::ColorF(1, 1, 1, anim));
-        app.renderTarget->DrawText(L"Choose Theme", 12, titleFormat,
+        const wchar_t* themeTitle = tr(app, "theme.chooser.title");
+        app.renderTarget->DrawText(themeTitle, (UINT32)wcslen(themeTitle), titleFormat,
             D2D1::RectF(panelX, panelY + dpi(app, 15.0f), panelX + panelWidth, panelY + dpi(app, 55.0f)), app.brush);
     }
 
@@ -636,13 +641,164 @@ void renderThemeChooser(App& app) {
         app.brush->SetColor(D2D1::ColorF(0.5f, 0.5f, 0.5f, anim));
 
         // Light themes header
-        app.renderTarget->DrawText(L"LIGHT THEMES", 12, headerFormat,
+        const wchar_t* lightHdr = tr(app, "theme.chooser.light");
+        app.renderTarget->DrawText(lightHdr, (UINT32)wcslen(lightHdr), headerFormat,
             D2D1::RectF(panelX + dpi(app, 20.0f), gridStartY - dpi(app, 20.0f), panelX + dpi(app, 20.0f) + cardWidth, gridStartY - dpi(app, 5.0f)), app.brush);
 
         // Dark themes header
-        app.renderTarget->DrawText(L"DARK THEMES", 11, headerFormat,
+        const wchar_t* darkHdr = tr(app, "theme.chooser.dark");
+        app.renderTarget->DrawText(darkHdr, (UINT32)wcslen(darkHdr), headerFormat,
             D2D1::RectF(panelX + dpi(app, 40.0f) + cardWidth, gridStartY - dpi(app, 20.0f), panelX + dpi(app, 40.0f) + cardWidth * 2, gridStartY - dpi(app, 5.0f)), app.brush);
     }
+}
+
+void renderLanguageChooser(App& app) {
+    // Animate in
+    if (app.languageChooserAnimation < 1.0f) {
+        float prev = app.languageChooserAnimation;
+        app.languageChooserAnimation = std::min(1.0f, app.languageChooserAnimation + 0.15f);
+        if (app.languageChooserAnimation != prev)
+            InvalidateRect(app.hwnd, nullptr, FALSE);
+    }
+    float anim = app.languageChooserAnimation;
+
+    // Build the per-row native-name format lazily on first open.
+    ensureLanguageFormats(app);
+
+    // Semi-transparent backdrop
+    app.brush->SetColor(D2D1::ColorF(0, 0, 0, 0.85f * anim));
+    app.renderTarget->FillRectangle(
+        D2D1::RectF(0, 0, (float)app.width, (float)app.height), app.brush);
+
+    // Panel dimensions — narrow single-column list (4 items)
+    float panelWidth = std::min(dpi(app, 420.0f), app.width - dpi(app, 40.0f));
+    float panelHeight = std::min(dpi(app, 460.0f), app.height - dpi(app, 40.0f));
+    float panelX = (app.width - panelWidth) / 2;
+    float panelY = (app.height - panelHeight) / 2 + (1 - anim) * dpi(app, 50.0f);
+
+    // Panel background
+    D2D1_ROUNDED_RECT panelRect = D2D1::RoundedRect(
+        D2D1::RectF(panelX, panelY, panelX + panelWidth, panelY + panelHeight),
+        dpi(app, 16.0f), dpi(app, 16.0f));
+    app.brush->SetColor(hexColor(0x1A1A1E, 0.98f * anim));
+    app.renderTarget->FillRoundedRectangle(panelRect, app.brush);
+
+    // Border
+    app.brush->SetColor(hexColor(0x3A3A40, 0.6f * anim));
+    app.renderTarget->DrawRoundedRectangle(panelRect, app.brush, 1.0f);
+
+    // Title
+    IDWriteTextFormat* titleFormat = app.languageTitleFormat;
+    if (titleFormat) {
+        titleFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+        app.brush->SetColor(D2D1::ColorF(1, 1, 1, anim));
+        const wchar_t* title = tr(app, "lang.chooser.title");
+        app.renderTarget->DrawText(title, (UINT32)wcslen(title), titleFormat,
+            D2D1::RectF(panelX, panelY + dpi(app, 20.0f), panelX + panelWidth, panelY + dpi(app, 65.0f)), app.brush);
+    }
+
+    IDWriteTextFormat* nativeFmt = app.languageNativeFormat;
+    IDWriteTextFormat* subtitleFmt = app.languageSubtitleFormat;
+    if (!nativeFmt || !subtitleFmt) return;
+
+    // Single-column list of all languages
+    float padding = dpi(app, 20.0f);
+    float listTopY = panelY + dpi(app, 80.0f);
+    float listBottomY = panelY + panelHeight - dpi(app, 50.0f);
+    float rowWidth = panelWidth - padding * 2;
+    float rowHeight = std::min(dpi(app, 70.0f), (listBottomY - listTopY) / LANG_COUNT);
+    float rowX = panelX + padding;
+
+    app.hoveredLanguageIndex = -1;
+
+    for (int i = 0; i < LANG_COUNT; i++) {
+        float rowY = listTopY + i * rowHeight;
+        float innerPad = dpi(app, 6.0f);
+        float innerX = rowX + innerPad;
+        float innerY = rowY + innerPad;
+        float innerW = rowWidth - innerPad * 2;
+        float innerH = rowHeight - innerPad * 2;
+
+        bool isHovered = (app.mouseX >= innerX && app.mouseX <= innerX + innerW &&
+                          app.mouseY >= innerY && app.mouseY <= innerY + innerH);
+        bool isSelected = (i == app.currentLanguageIndex);
+
+        if (isHovered) {
+            app.hoveredLanguageIndex = i;
+        }
+
+        // Row background + selection/hover glow
+        D2D1_ROUNDED_RECT rowRect = D2D1::RoundedRect(
+            D2D1::RectF(innerX, innerY, innerX + innerW, innerY + innerH),
+            dpi(app, 8.0f), dpi(app, 8.0f));
+
+        if (isSelected || isHovered) {
+            float glowSize = isSelected ? 3.0f : 2.0f;
+            D2D1_ROUNDED_RECT glowRect = D2D1::RoundedRect(
+                D2D1::RectF(innerX - glowSize, innerY - glowSize,
+                            innerX + innerW + glowSize, innerY + innerH + glowSize),
+                dpi(app, 10.0f), dpi(app, 10.0f));
+            D2D1_COLOR_F glowColor = app.theme.accent;
+            glowColor.a = (isSelected ? 0.8f : 0.5f) * anim;
+            app.brush->SetColor(glowColor);
+            app.renderTarget->DrawRoundedRectangle(glowRect, app.brush, 2.0f);
+        }
+
+        D2D1_COLOR_F rowBg = hexColor(0x262630, 0.6f * anim);
+        app.brush->SetColor(rowBg);
+        app.renderTarget->FillRoundedRectangle(rowRect, app.brush);
+
+        // Native language name (left-aligned, large)
+        nativeFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+        D2D1_COLOR_F nameColor = D2D1::ColorF(1, 1, 1, anim);
+        app.brush->SetColor(nameColor);
+        const wchar_t* nativeName = LANGUAGES[i].nativeName;
+        app.renderTarget->DrawText(nativeName, (UINT32)wcslen(nativeName), nativeFmt,
+            D2D1::RectF(innerX + dpi(app, 16.0f), innerY + dpi(app, 10.0f),
+                        innerX + innerW - dpi(app, 40.0f), innerY + dpi(app, 38.0f)),
+            app.brush);
+
+        // English subtitle below
+        subtitleFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
+        D2D1_COLOR_F subColor = D2D1::ColorF(0.6f, 0.6f, 0.6f, anim);
+        app.brush->SetColor(subColor);
+        const wchar_t* engName = LANGUAGES[i].englishName;
+        app.renderTarget->DrawText(engName, (UINT32)wcslen(engName), subtitleFmt,
+            D2D1::RectF(innerX + dpi(app, 16.0f), innerY + dpi(app, 38.0f),
+                        innerX + innerW - dpi(app, 16.0f), innerY + dpi(app, 58.0f)),
+            app.brush);
+
+        // Checkmark for the selected language
+        if (isSelected) {
+            D2D1_COLOR_F checkColor = app.theme.accent;
+            checkColor.a = anim;
+            app.brush->SetColor(checkColor);
+            float cx = innerX + innerW - dpi(app, 20.0f);
+            float cy = innerY + innerH / 2.0f;
+            app.renderTarget->DrawLine(
+                D2D1::Point2F(cx - dpi(app, 6.0f), cy),
+                D2D1::Point2F(cx - dpi(app, 2.0f), cy + dpi(app, 4.0f)),
+                app.brush, dpi(app, 2.0f));
+            app.renderTarget->DrawLine(
+                D2D1::Point2F(cx - dpi(app, 2.0f), cy + dpi(app, 4.0f)),
+                D2D1::Point2F(cx + dpi(app, 6.0f), cy - dpi(app, 4.0f)),
+                app.brush, dpi(app, 2.0f));
+        }
+
+        // Row border
+        D2D1_COLOR_F borderColor = hexColor(0x404040, 0.5f * anim);
+        app.brush->SetColor(borderColor);
+        app.renderTarget->DrawRoundedRectangle(rowRect, app.brush, 1.0f);
+    }
+
+    // Footer hint
+    subtitleFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+    app.brush->SetColor(D2D1::ColorF(0.5f, 0.5f, 0.5f, anim));
+    const wchar_t* footer = tr(app, "lang.chooser.footer");
+    app.renderTarget->DrawText(footer, (UINT32)wcslen(footer), subtitleFmt,
+        D2D1::RectF(panelX, panelY + panelHeight - dpi(app, 38.0f),
+                    panelX + panelWidth, panelY + panelHeight - dpi(app, 12.0f)),
+        app.brush);
 }
 
 void renderHelpOverlay(App& app) {
@@ -683,7 +839,8 @@ void renderHelpOverlay(App& app) {
     if (titleFormat) {
         titleFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
         app.brush->SetColor(D2D1::ColorF(1, 1, 1, anim));
-        app.renderTarget->DrawText(L"Keyboard Shortcuts", 18, titleFormat,
+        const wchar_t* helpTitle = tr(app, "help.title");
+        app.renderTarget->DrawText(helpTitle, (UINT32)wcslen(helpTitle), titleFormat,
             D2D1::RectF(panelX, panelY + dpi(app, 15.0f), panelX + panelWidth, titleBottomY), app.brush);
     }
 
@@ -698,37 +855,37 @@ void renderHelpOverlay(App& app) {
     };
 
     const HelpEntry navEntries[] = {
-        {L"J / \x2193",   L"Scroll down"},
-        {L"K / \x2191",   L"Scroll up"},
-        {L"Space / PgDn", L"Page down"},
-        {L"PgUp",         L"Page up"},
-        {L"Home / End",   L"Jump to start / end"},
-        {L"Ctrl+Scroll",  L"Zoom in / out"},
+        {L"J / \x2193",   tr(app, "help.nav.scroll_down")},
+        {L"K / \x2191",   tr(app, "help.nav.scroll_up")},
+        {L"Space / PgDn", tr(app, "help.nav.page_down")},
+        {L"PgUp",         tr(app, "help.nav.page_up")},
+        {L"Home / End",   tr(app, "help.nav.jump_start_end")},
+        {L"Ctrl+Scroll",  tr(app, "help.nav.zoom")},
     };
 
     const HelpEntry overlayEntries[] = {
-        {L"F / Ctrl+F",   L"Search"},
-        {L"Enter",        L"Next search match"},
-        {L"B",            L"Toggle folder browser"},
-        {L"Tab",          L"Toggle table of contents"},
-        {L"T",            L"Theme chooser"},
-        {L"S",            L"Toggle stats"},
-        {L"?",            L"This help"},
+        {L"F / Ctrl+F",   tr(app, "help.view.search")},
+        {L"Enter",        tr(app, "help.view.next_match")},
+        {L"B",            tr(app, "help.view.folder_browser")},
+        {L"Tab",          tr(app, "help.view.toc")},
+        {L"T",            tr(app, "help.view.theme")},
+        {L"S",            tr(app, "help.view.stats")},
+        {L"?",            tr(app, "help.view.help")},
     };
 
     const HelpEntry editEntries[] = {
-        {L":",             L"Enter edit mode"},
-        {L"Ctrl+S",       L"Save (in edit mode)"},
-        {L"Ctrl+P",       L"Show / hide preview pane"},
-        {L"Ctrl+W",       L"Toggle word wrap"},
-        {L"ESC ESC",      L"Exit edit mode"},
+        {L":",             tr(app, "help.edit.enter_edit")},
+        {L"Ctrl+S",       tr(app, "help.edit.save")},
+        {L"Ctrl+P",       tr(app, "help.edit.preview")},
+        {L"Ctrl+W",       tr(app, "help.edit.word_wrap")},
+        {L"ESC ESC",      tr(app, "help.edit.exit_edit")},
     };
 
     const HelpEntry generalEntries[] = {
-        {L"Ctrl+A",       L"Select all text"},
-        {L"Ctrl+C",       L"Copy selection"},
-        {L"ESC",          L"Close overlay / Quit"},
-        {L"Q",            L"Quit"},
+        {L"Ctrl+A",       tr(app, "help.general.select_all")},
+        {L"Ctrl+C",       tr(app, "help.general.copy")},
+        {L"ESC",          tr(app, "help.general.close")},
+        {L"Q",            tr(app, "help.general.quit")},
     };
 
     float padding = dpi(app, 20.0f);
@@ -796,15 +953,16 @@ void renderHelpOverlay(App& app) {
         y += sectionGap;
     };
 
-    drawSection(L"NAVIGATION", navEntries, 6);
-    drawSection(L"VIEW", overlayEntries, 7);
-    drawSection(L"EDITING", editEntries, 3);
-    drawSection(L"GENERAL", generalEntries, 4);
+    drawSection(tr(app, "help.section.navigation"), navEntries, 6);
+    drawSection(tr(app, "help.section.view"), overlayEntries, 7);
+    drawSection(tr(app, "help.section.editing"), editEntries, 3);
+    drawSection(tr(app, "help.section.general"), generalEntries, 4);
 
     // Footer hint
     normalFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
     app.brush->SetColor(D2D1::ColorF(0.5f, 0.5f, 0.5f, anim));
-    app.renderTarget->DrawText(L"Press ESC or ? to close", 23, normalFmt,
+    const wchar_t* helpFooter = tr(app, "help.footer");
+    app.renderTarget->DrawText(helpFooter, (UINT32)wcslen(helpFooter), normalFmt,
         D2D1::RectF(panelX, y, panelX + panelWidth, y + lineH), app.brush);
 
     app.renderTarget->PopAxisAlignedClip();

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -3,6 +3,7 @@
 #include "syntax.h"
 #include "search.h"
 #include "mermaid.h"
+#include "i18n.h"
 
 #include <algorithm>
 #include <cctype>
@@ -1453,16 +1454,20 @@ static void layoutBlockquote(App& app, const ElementPtr& elem, float& y, float i
 
     // GitHub alert callouts: accent-colored bar plus a bold title line.
     // Colors are github.com's light/dark alert accents, picked by theme.
+    // The emoji prefix is fixed; the trailing word is translated at render
+    // time via the i18n key, so the array stores prefix + key instead of a
+    // pre-baked title string.
     static const struct {
-        const wchar_t* title;
+        const wchar_t* prefix;  // emoji glyph(s) + two spaces
+        const char* key;        // i18n key for the trailing word
         uint32_t light;
         uint32_t dark;
     } ALERT_STYLES[] = {
-        {L"\u24D8  Note",            0x0969DA, 0x4493F8},  // circled info
-        {L"\U0001F4A1\uFE0E  Tip",   0x1A7F37, 0x3FB950},  // bulb, text presentation
-        {L"\u2757\uFE0E  Important", 0x8250DF, 0xAB7DF8},  // exclamation
-        {L"\u26A0\uFE0E  Warning",   0x9A6700, 0xD29922},  // warning triangle
-        {L"\u26D4\uFE0E  Caution",   0xCF222E, 0xF85149},  // no-entry
+        {L"\u24D8  ",            "alert.note",      0x0969DA, 0x4493F8},  // circled info
+        {L"\U0001F4A1\uFE0E  ", "alert.tip",       0x1A7F37, 0x3FB950},  // bulb, text presentation
+        {L"\u2757\uFE0E  ",     "alert.important", 0x8250DF, 0xAB7DF8},  // exclamation
+        {L"\u26A0\uFE0E  ",     "alert.warning",   0x9A6700, 0xD29922},  // warning triangle
+        {L"\u26D4\uFE0E  ",     "alert.caution",   0xCF222E, 0xF85149},  // no-entry
     };
 
     D2D1_COLOR_F barColor = app.theme.blockquoteBorder;
@@ -1470,7 +1475,7 @@ static void layoutBlockquote(App& app, const ElementPtr& elem, float& y, float i
         const auto& style = ALERT_STYLES[elem->alertKind - 1];
         barColor = hexColor(app.theme.isDark ? style.dark : style.light);
 
-        std::wstring title = style.title;
+        std::wstring title = style.prefix + std::wstring(tr(app, style.key));
         LayoutInfo info = createLayout(app, title, app.textFormat, 24.0f, app.bodyTypography);
         if (info.layout) {
             DWRITE_TEXT_RANGE range = {0, (UINT32)title.length()};
@@ -1708,8 +1713,9 @@ static void layoutImage(App& app, const ElementPtr& elem, float& y, float indent
     auto& entry = getOrLoadImage(app, elem->url);
 
     if (entry.failed || !entry.bitmap) {
-        // Render alt text as placeholder
-        std::wstring altText = L"[image";
+        // Render alt text as placeholder. Only the word "image" is translated;
+        // the bracket/separator punctuation stays locale-neutral.
+        std::wstring altText = L"[" + std::wstring(tr(app, "image.placeholder"));
         std::wstring alt;
         std::function<void(const ElementPtr&)> extract = [&](const ElementPtr& e) {
             if (!e) return;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,5 +1,6 @@
 #include "settings.h"
 #include "document.h"
+#include "i18n.h"
 
 #include <windows.h>
 #include <shlobj.h>
@@ -38,6 +39,7 @@ void saveSettings(const Settings& settings) {
     file << "hasAskedFileAssociation=" << (settings.hasAskedFileAssociation ? 1 : 0) << "\n";
     file << "editorShowPreview=" << (settings.editorShowPreview ? 1 : 0) << "\n";
     file << "editorWordWrap=" << (settings.editorWordWrap ? 1 : 0) << "\n";
+    file << "languageIndex=" << settings.languageIndex << "\n";
 }
 
 Settings loadSettings() {
@@ -82,6 +84,10 @@ Settings loadSettings() {
             settings.editorShowPreview = (value == "1");
         } else if (key == "editorWordWrap") {
             settings.editorWordWrap = (value == "1");
+        } else if (key == "languageIndex") {
+            // Accept any integer; LANG_INDEX_DEFAULT (-1) means follow system.
+            // Out-of-range positive values are clamped elsewhere at load time.
+            settings.languageIndex = std::stoi(value);
         }
     }
     return settings;
@@ -206,16 +212,18 @@ void openDefaultAppsSettings() {
     ShellExecuteW(nullptr, L"open", L"ms-settings:defaultapps", nullptr, nullptr, SW_SHOWNORMAL);
 }
 
-void askAndRegisterFileAssociation(Settings& settings) {
+void askAndRegisterFileAssociation(Settings& settings, int langIndex) {
     if (isRunningPackaged()) return;
+    // Resolve the effective language: explicit choice wins, otherwise detect.
+    int lang = (langIndex >= 0 && langIndex < LANG_COUNT) ? langIndex : detectSystemLanguage();
     if (settings.hasAskedFileAssociation) {
         if (hasRegisteredFileAssociation(L".md") &&
             !hasRegisteredFileAssociation(L".mmd") &&
             !registerFileAssociation()) {
             MessageBoxW(
                 nullptr,
-                L"Failed to add the .mmd file association. Run tinta.exe /register to try again.",
-                L"Tinta - File Association",
+                tr(lang, "fileassoc.add_mmd_failed_body"),
+                tr(lang, "fileassoc.title"),
                 MB_OK | MB_ICONWARNING);
         }
         return;
@@ -223,25 +231,20 @@ void askAndRegisterFileAssociation(Settings& settings) {
 
     int result = MessageBoxW(
         nullptr,
-        L"Would you like to set Tinta as the default viewer for Markdown and Mermaid files?\n\n"
-        L"Windows will open Settings where you can select Tinta.",
-        L"Tinta - File Association",
+        tr(lang, "fileassoc.ask_body"),
+        tr(lang, "fileassoc.title"),
         MB_YESNO | MB_ICONQUESTION
     );
 
     if (result == IDYES) {
         if (registerFileAssociation()) {
             MessageBoxW(nullptr,
-                       L"Tinta has been registered.\n\n"
-                       L"In the Settings window that opens:\n"
-                       L"1. Search for '.md' or '.mmd'\n"
-                       L"2. Click on the current default app\n"
-                       L"3. Select 'Tinta' from the list",
-                       L"Almost done!", MB_OK | MB_ICONINFORMATION);
+                       tr(lang, "fileassoc.done_body"),
+                       tr(lang, "fileassoc.done_title"), MB_OK | MB_ICONINFORMATION);
             openDefaultAppsSettings();
         } else {
-            MessageBoxW(nullptr, L"Failed to register file association. Try running as administrator.",
-                       L"Error", MB_OK | MB_ICONWARNING);
+            MessageBoxW(nullptr, tr(lang, "fileassoc.register_failed_body"),
+                       tr(lang, "error.title"), MB_OK | MB_ICONWARNING);
         }
     }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,9 +1,11 @@
 #include "utils.h"
 #include "render.h"
+#include "i18n.h"
 
 #include <windows.h>
 #include <shellapi.h>
 #include <algorithm>
+#include <cstdio>
 
 std::wstring toWide(const std::string& str) {
     if (str.empty()) return L"";
@@ -132,14 +134,18 @@ void findLineRects(const App& app, float y, float& lineLeft, float& lineRight,
 }
 
 void updateWindowTitle(App& app) {
-    std::wstring title = L"Tinta";
-    if (!app.currentFile.empty()) {
+    std::wstring title;
+    if (app.currentFile.empty()) {
+        title = tr(app, "title.no_file");
+    } else {
         std::wstring wpath = toWide(app.currentFile);
         size_t lastSep = wpath.find_last_of(L"\\/");
-        if (lastSep != std::wstring::npos)
-            title = L"Tinta - " + wpath.substr(lastSep + 1);
-        else
-            title = L"Tinta - " + wpath;
+        std::wstring fname = (lastSep != std::wstring::npos) ? wpath.substr(lastSep + 1) : wpath;
+        // title.plain is "Tinta - %1$s" (and identical across current locales,
+        // but routed through tr() so the format can differ per language later).
+        wchar_t buf[MAX_PATH + 32];
+        swprintf_s(buf, tr(app, "title.plain"), fname.c_str());
+        title = buf;
     }
     SetWindowTextW(app.hwnd, title.c_str());
 }


### PR DESCRIPTION
## Summary

Adds a multilingual UI switcher. Press **`L`** to open a language chooser overlay (modeled on the existing `T` theme chooser) and pick between English, Simplified Chinese, Japanese, and Korean.

- **Follows the Windows UI language on first launch** via `GetUserPreferredUILanguages`; an explicit user choice is persisted to `settings.ini` (`languageIndex`) and overrides the system default thereafter.
- **Centralized lookup table** (`src/i18n.cpp`) keyed by stable dotted identifiers (`help.title`, `toast.saved`, ...), with English as the fallback when a locale lacks an entry.
- **English + Simplified Chinese are complete.** Japanese and Korean currently fall back to English until native translations are added — the framework is ready, no code changes needed to fill them in.
- **All user-visible strings route through `tr()`**: help/search/TOC overlays, theme & language choosers, editor toasts, stats, file-association dialogs, window titles, GitHub alert titles (emoji prefix preserved), and image alt-text placeholders.
- **No new dependencies.** The CJK font fallback chain (Yu Gothic UI / Meiryo / Microsoft YaHei UI / Malgun Gothic) was already wired up in `d2d_init.cpp`, so rendering CJK text needs no extra work. Binary stays < 1 MB.

## How it works

| Scenario | Behavior |
|---|---|
| First launch on a zh-CN Windows | UI shows in Simplified Chinese |
| First launch on an English Windows | UI shows in English |
| Press `L`, pick a language | Applied immediately, persisted, survives restart |
| `languageIndex=-1` in settings.ini | Follow system language (default) |

## What's translated

Help overlay (title, section headers, shortcut descriptions, footer) · search overlay (placeholder, "No matches", match counter with positional `%1$d / %2$zu`) · TOC ("Contents", "No headings") · theme chooser ("Choose Theme", "LIGHT/DARK THEMES") · language chooser · editor toasts (saved/failed/wrap/preview/exit) · stats overlay · file-association MessageBox dialogs · init-failure dialogs · window title · GitHub alert titles (Note/Tip/Important/Warning/Caution) · image alt-text placeholder.

Deliberately **not** translated: theme names (brand identity), the shortcut-key column in help (locale-neutral), font preview samples, syntax-highlighting keywords, and Mermaid node text (comes from user files).

## Files

- **New:** `include/i18n.h`, `src/i18n.cpp` (~80 translation keys × 4 locales, `tr()`, `detectSystemLanguage()`)
- **Modified:** `CMakeLists.txt`, `include/{app,d2d_init,overlays,settings}.h`, `src/{d2d_init,editor,input,main_d2d,overlays,render,settings,utils}.cpp`, `README.md`

## Build status

Clean rebuild (`cmake --build build --config Release --clean-first`) passes with exit code 0. `tinta.exe` is 881 KB. Only pre-existing warnings remain (C4244/C4456 in untouched code).

## Test plan

- [ ] Launch, press `L` — chooser shows all four languages with native names
- [ ] Pick Simplified Chinese — Help (`?`), search (`F`), TOC (`Tab`), toasts (`:` then `Ctrl+S`), title bar, stats (`S`) all render in Chinese
- [ ] Quit and relaunch — the Chinese choice persists
- [ ] Delete `%APPDATA%\Tinta\settings.ini`, run on a Japanese Windows (or set `languageIndex=-1`) — UI follows the system locale
- [ ] Switch back to English — all strings revert, no layout breakage