### PR TITLE
Fix batch: Cyrillic image paths, edit-mode printing, preview tail, full-width shortcuts, Store CLI alias

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -378,6 +378,10 @@ struct App {
         float contentScale = 1.0f, zoomFactor = 1.0f, appliedZoomFactor = 1.0f;
         float scrollX = 0, scrollY = 0, targetScrollX = 0, targetScrollY = 0;
         D2DTheme theme{};
+        // Edit mode is suspended during print layout: the layout width comes
+        // from documentViewportWidth, which in edit mode is the preview
+        // pane — printing from the editor wrapped at half the page (#81)
+        bool editMode = false;
     };
     bool showPrintPreview = false;
     PrintSavedView printSaved;

--- a/packaging/msix/AppxManifest.xml
+++ b/packaging/msix/AppxManifest.xml
@@ -2,8 +2,10 @@
 <Package
     xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
     xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+    xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+    xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
     xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-    IgnorableNamespaces="uap rescap">
+    IgnorableNamespaces="uap uap3 desktop rescap">
 
   <Identity
       Name="oipoi.TintaMarkdownViewer"
@@ -48,6 +50,14 @@
             </uap:SupportedFileTypes>
           </uap:FileTypeAssociation>
         </uap:Extension>
+        <!-- `tinta` works from any shell after a Store install (#86) -->
+        <uap3:Extension Category="windows.appExecutionAlias"
+                        Executable="tinta.exe"
+                        EntryPoint="Windows.FullTrustApplication">
+          <uap3:AppExecutionAlias>
+            <desktop:ExecutionAlias Alias="tinta.exe" />
+          </uap3:AppExecutionAlias>
+        </uap3:Extension>
         <uap:Extension Category="windows.fileTypeAssociation">
           <uap:FileTypeAssociation Name="mermaid">
             <uap:DisplayName>Mermaid Diagram</uap:DisplayName>

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -471,6 +471,16 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             return;
         }
         if (!ctrl) {
+            float editorMax = std::max(0.0f, app.editorContentHeight - (float)app.height);
+            if (delta < 0 && app.editorScrollY >= editorMax - 1.0f) {
+                // Editor is at its end: scroll the preview's remaining tail
+                // directly (#85); the sync allows this overshoot
+                float maxScroll = std::max(0.0f, app.contentHeight - (float)app.height);
+                app.scrollY = std::min(app.scrollY - delta * dpi(app, 60.0f), maxScroll);
+                app.targetScrollY = app.scrollY;
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
             handleEditorMouseWheel(app, hwnd, delta);
             return;
         }
@@ -2158,7 +2168,12 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
 
     // ':' to enter edit mode, '?' to toggle help — when no overlay is active
     if (!app.showSearch && !app.showFolderBrowser && !app.showToc && !app.showThemeChooser) {
-        wchar_t ch = (wchar_t)translateActionKey(app, wParam, true);
+        // Chinese IME full-width forms count as their ASCII keys, so the
+        // shortcuts work without switching input modes (#85)
+        WPARAM key = wParam;
+        if (key == 0xFF1A) key = L':';  // ：
+        if (key == 0xFF1F) key = L'?';  // ？
+        wchar_t ch = (wchar_t)translateActionKey(app, key, true);
         if (ch == L':' && !app.showHelp) {
             enterEditMode(app);
             return;

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -155,7 +155,16 @@ void render(App& app) {
         }
 
         float previewMaxScroll = std::max(0.0f, app.contentHeight - (float)app.height);
-        app.scrollY = std::max(0.0f, std::min(targetY, previewMaxScroll));
+        float synced = std::max(0.0f, std::min(targetY, previewMaxScroll));
+        float editorMax = std::max(0.0f, app.editorContentHeight - (float)app.height);
+        if (app.editorScrollY >= editorMax - 1.0f) {
+            // The editor has bottomed out, but rendered content is taller
+            // than its source (images, diagrams): let the preview overshoot
+            // to reach its tail (#85). Scrolling the editor up re-syncs.
+            app.scrollY = std::min(std::max(app.scrollY, synced), previewMaxScroll);
+        } else {
+            app.scrollY = synced;
+        }
         app.targetScrollY = app.scrollY;
     }
 

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -52,7 +52,9 @@ void enterPrintLayout(App& app, SavedView& saved) {
     saved.targetScrollX = app.targetScrollX;
     saved.targetScrollY = app.targetScrollY;
     saved.theme = app.theme;
+    saved.editMode = app.editMode;
 
+    app.editMode = false;  // layout width must be the page, not a pane (#81)
     app.contentScale = 1.0f;
     app.zoomFactor = 1.0f;
     app.theme = printTheme();
@@ -141,6 +143,7 @@ void layoutAtPrintWidth(App& app, float contentWidthDips) {
 }
 
 void leavePrintLayout(App& app, const SavedView& saved) {
+    app.editMode = saved.editMode;
     app.width = saved.width;
     app.height = saved.height;
     app.contentScale = saved.contentScale;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -1646,11 +1646,13 @@ static App::ImageEntry& getOrLoadImage(App& app, const std::string& src) {
         std::thread(asyncImageWorker, app.hwnd, src).detach();
         return app.imageCache[src];
     } else {
-        // Resolve relative to current file's directory
+        // Resolve relative to the current file's directory. Both strings are
+        // UTF-8 and must be widened explicitly: a narrow filesystem::path
+        // decodes through the ANSI codepage and mangles non-ASCII paths (#87)
         std::wstring wsrc = toWide(src);
         if (!app.currentFile.empty()) {
-            std::filesystem::path basePath(app.currentFile);
-            std::filesystem::path imgPath = basePath.parent_path() / src;
+            std::filesystem::path basePath(toWide(app.currentFile));
+            std::filesystem::path imgPath = basePath.parent_path() / wsrc;
             widePath = imgPath.wstring();
         } else {
             widePath = wsrc;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -339,7 +339,31 @@ void openDefaultAppsSettings() {
 }
 
 void askAndRegisterFileAssociation(Settings& settings) {
-    if (isRunningPackaged()) return;
+    if (isRunningPackaged()) {
+        // Store installs: the package manifest already registers the file
+        // types, so only the "make default" choice is missing. Ask once per
+        // install (settings.ini lives in the package's private AppData, so
+        // it resets on uninstall) and deep-link straight to Tinta's page in
+        // Settings > Default apps. Windows 10 ignores the query part and
+        // opens the general Default Apps page instead.
+        if (settings.hasAskedFileAssociation) return;
+        int result = MessageBoxW(
+            nullptr,
+            L"Would you like to make Tinta the default viewer for Markdown "
+            L"and Mermaid files?\n\n"
+            L"Windows will open Settings on Tinta's page — set .md, "
+            L".markdown, and .mmd to Tinta Markdown Viewer.",
+            L"Tinta - Default apps",
+            MB_YESNO | MB_ICONQUESTION);
+        if (result == IDYES) {
+            ShellExecuteW(nullptr, L"open",
+                L"ms-settings:defaultapps?registeredAppUser=Tinta%20Markdown%20Viewer",
+                nullptr, nullptr, SW_SHOWNORMAL);
+        }
+        settings.hasAskedFileAssociation = true;
+        saveSettings(settings);
+        return;
+    }
     if (settings.hasAskedFileAssociation) {
         if (hasRegisteredFileAssociation(L".md") &&
             !hasRegisteredFileAssociation(L".mmd") &&


### PR DESCRIPTION
Four community-reported fixes in one pass.

## #87 — Local images on non-ASCII paths (@mrkingmidas)
The relative-image path was assembled through a narrow `std::filesystem::path`, which decodes UTF-8 via the ANSI codepage — Cyrillic anywhere in the directory or filename produced a path WIC could not open. Both components now widen from UTF-8 before joining. Verified with `Проверка\attach\логотип.png` — Cyrillic in both the directory and the filename.

## #81 — Printing from edit mode wrapped at half the page (@a86022)
Layout width comes from `documentViewportWidth`, which in edit mode is the preview pane — so Ctrl+P from the editor laid out at ~half the page with the right side blank. Print layout now suspends edit mode (stashed in `PrintSavedView`), so preview and print always use the full page. Verified: `--edit --printpages` output is now identical to viewer-mode printing.

## #85 — Preview could not reach its end + full-width shortcuts (@a86022)
Rendered content is taller than its source (images, diagrams), so when the editor hit bottom the per-frame sync pinned the preview short of the end. With the editor at its end the synced position becomes a floor rather than an exact target, and the wheel scrolls the preview remainder directly; scrolling up re-engages the exact sync. Verified with a short source ending in three tall images — the tail is now reachable.

Also: the full-width `：` and `？` produced by Chinese IMEs now count as `:` and `?`, so edit mode and help open without switching input modes.

## #86 — Store installs get a `tinta` command (@aszili)
The MSIX manifest now declares a `windows.appExecutionAlias` for `tinta.exe` — the supported mechanism for exposing a stable CLI entry point from a packaged app (no `App Paths` registry writes needed). Takes effect with the next Store submission; `makeappx` validates and packs cleanly.

All ctest suites pass; every fix verified with the synthetic-input screenshot harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also: Store first-run make-default ask
Store installs previously skipped the file-association flow entirely (the manifest registers the types) — users were never offered the make-default step. First run now asks once and deep-links to Tinta's own page in **Settings > Default apps** on Windows 11 (Windows 10 opens the general page). The asked-once flag lives in the package's private AppData, so a reinstall asks again. Uses the same MessageBox + ms-settings primitives as the proven unpackaged flow; will get its first live exercise in the next Store certification.
