### PR TITLE
Multilingual UI (en/zh-CN, ja/ko scaffolded) — based on @wxh-777's PR #84, integrated with settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SOURCES
     src/document.cpp
     src/inline_style.cpp
     src/print.cpp
+    src/i18n.cpp
 )
 
 set(HEADERS
@@ -71,6 +72,7 @@ set(HEADERS
     include/document.h
     include/inline_style.h
     include/print.h
+    include/i18n.h
 )
 
 # Windows resource file (icon)

--- a/include/app.h
+++ b/include/app.h
@@ -157,9 +157,11 @@ struct Settings {
     int zenWidthPct = 60;
     // Table of contents panel side: false = right (default), true = left
     bool tocOnLeft = false;
-    // UI language index (see i18n.h); -1 = follow the Windows display
-    // language. Credit: multilingual groundwork by wxh-777 (PR #84).
-    int languageIndex = -1;
+    // UI language id ("auto" follows the Windows display language; else a
+    // registry id like "en"/"zh"/"de" — see i18n.h). Persisted as a string
+    // because languages.ini languages have no stable numeric index.
+    // Credit: multilingual groundwork by wxh-777 (PR #84).
+    std::string language = "auto";
 };
 
 // Application state
@@ -362,10 +364,12 @@ struct App {
     std::vector<std::pair<D2D1_RECT_F, int>> themeEditorHits;
     D2D1_RECT_F themeEditorFontListRect{};  // for wheel routing (set in render)
 
-    // UI language: languageSetting is what persists (-1 = follow system),
-    // currentLanguageIndex is the resolved index tr() reads every call
+    // UI language: languageSetting is the chosen registry index (-1 =
+    // follow system), currentLanguageIndex is what tr() reads every call
     int languageSetting = -1;
     int currentLanguageIndex = 0;
+    bool settingsLangOpen = false;      // language dropdown popup expanded
+    D2D1_RECT_F settingsLangBox{};      // dropdown value box (set in render)
 
     // Resolved single-key bindings, indexed like KEY_ACTIONS (#77).
     // Filled by applyKeymap from settings; slots beyond the action count

--- a/include/app.h
+++ b/include/app.h
@@ -157,6 +157,9 @@ struct Settings {
     int zenWidthPct = 60;
     // Table of contents panel side: false = right (default), true = left
     bool tocOnLeft = false;
+    // UI language index (see i18n.h); -1 = follow the Windows display
+    // language. Credit: multilingual groundwork by wxh-777 (PR #84).
+    int languageIndex = -1;
 };
 
 // Application state
@@ -358,6 +361,11 @@ struct App {
     std::vector<std::wstring> systemFontFamilies;  // enumerated on first open
     std::vector<std::pair<D2D1_RECT_F, int>> themeEditorHits;
     D2D1_RECT_F themeEditorFontListRect{};  // for wheel routing (set in render)
+
+    // UI language: languageSetting is what persists (-1 = follow system),
+    // currentLanguageIndex is the resolved index tr() reads every call
+    int languageSetting = -1;
+    int currentLanguageIndex = 0;
 
     // Resolved single-key bindings, indexed like KEY_ACTIONS (#77).
     // Filled by applyKeymap from settings; slots beyond the action count

--- a/include/i18n.h
+++ b/include/i18n.h
@@ -1,0 +1,46 @@
+#ifndef TINTA_I18N_H
+#define TINTA_I18N_H
+
+#include <string>
+
+// Language indices are stable identifiers persisted in settings.ini.
+// Order matters: indices are stored on disk, so never renumber existing
+// entries — only append new ones.
+//   0 = English (en)         — fallback when a translation is missing
+//   1 = Simplified Chinese (zh-CN)
+//   2 = Japanese (ja)
+//   3 = Korean (ko)
+constexpr int LANG_COUNT = 4;
+constexpr int LANG_INDEX_EN = 0;
+constexpr int LANG_INDEX_DEFAULT = -1;  // Follow the system UI language
+
+struct Language {
+    const wchar_t* nativeName;   // Shown in the chooser, e.g. "简体中文"
+    const wchar_t* englishName;  // Auxiliary subtitle, e.g. "Chinese (Simplified)"
+    // Preferred font family for this language's native name. Empty = theme
+    // default. CJK fonts are already in the fallback chain, but using the
+    // native font here makes the chooser itself feel localized.
+    const wchar_t* nativeFont;
+};
+
+extern const Language LANGUAGES[LANG_COUNT];
+
+struct App;
+
+// Resolve a translation key for the given language index.
+// Falls back to English when the requested language lacks an entry, then to
+// the key itself (never returns null).
+const wchar_t* tr(int langIndex, const char* key);
+
+// Convenience overload using app.currentLanguageIndex.
+const wchar_t* tr(const App& app, const char* key);
+
+// Detect the user's preferred UI language via GetUserPreferredUILanguages.
+// Returns one of the LANG_INDEX_* values (always English as the last resort).
+int detectSystemLanguage();
+
+// Validates / clamps an arbitrary index into the [0, LANG_COUNT) range.
+// Returns LANG_INDEX_EN for out-of-range values.
+int clampLanguageIndex(int index);
+
+#endif // TINTA_I18N_H

--- a/include/i18n.h
+++ b/include/i18n.h
@@ -43,4 +43,16 @@ int detectSystemLanguage();
 // Returns LANG_INDEX_EN for out-of-range values.
 int clampLanguageIndex(int index);
 
+// languages.ini override layer: community translations without a compiler.
+// Loaded once at startup; openLanguagesIniFile seeds a commented template
+// listing every key with its English text, then opens it.
+void loadLanguageOverrides();
+void openLanguagesIniFile();
+
+// languages.ini override layer: community translations without a compiler.
+// Loaded once at startup; openLanguagesIniFile seeds a commented template
+// listing every key with its English text, then opens it.
+void loadLanguageOverrides();
+void openLanguagesIniFile();
+
 #endif // TINTA_I18N_H

--- a/include/i18n.h
+++ b/include/i18n.h
@@ -39,20 +39,21 @@ const wchar_t* tr(const App& app, const char* key);
 // Returns one of the LANG_INDEX_* values (always English as the last resort).
 int detectSystemLanguage();
 
-// Validates / clamps an arbitrary index into the [0, LANG_COUNT) range.
+// Validates / clamps an arbitrary index into the [0, languageCount()) range.
 // Returns LANG_INDEX_EN for out-of-range values.
 int clampLanguageIndex(int index);
 
-// languages.ini override layer: community translations without a compiler.
-// Loaded once at startup; openLanguagesIniFile seeds a commented template
-// listing every key with its English text, then opens it.
+// Dynamic language registry: the compiled languages plus any [section] of
+// %APPDATA%\Tinta\languages.ini that carries translations (name= labels
+// it). Indices are runtime-only — persist the id string, not the index.
+int languageCount();
+const wchar_t* languageNameAt(int index);
+std::string languageIdAt(int index);
+int languageIndexById(const std::string& id);   // -1 when unknown
+int languageCompiledColumn(int index);          // -1 for ini-only languages
 void loadLanguageOverrides();
-void openLanguagesIniFile();
-
-// languages.ini override layer: community translations without a compiler.
-// Loaded once at startup; openLanguagesIniFile seeds a commented template
-// listing every key with its English text, then opens it.
-void loadLanguageOverrides();
+// Seeds a translator template (common-language roster, every key commented
+// with its English text) on first use, then opens the file
 void openLanguagesIniFile();
 
 #endif // TINTA_I18N_H

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -27,8 +27,10 @@ enum SettingsAction {
     SET_OPEN_THEMES, SET_NEW_THEME, SET_EDIT_THEME,
     SET_OPEN_INI, SET_OPEN_THEMES_INI,
     SET_TOC_LEFT, SET_TOC_RIGHT,
-    SET_LANG_AUTO, SET_LANG_EN, SET_LANG_ZH, SET_LANG_JA, SET_LANG_KO,
-    SET_OPEN_LANGS_INI,
+    SET_LANG_DROPDOWN, SET_OPEN_LANGS_INI,
+    // Language picks encode as SET_LANG_PICK_BASE + i: 0 = Auto, then the
+    // registry languages in order (the list is dynamic via languages.ini)
+    SET_LANG_PICK_BASE = 1000,
 };
 // TOC panel X for the configured side at the current animation state;
 // geometry shared between render and the input hit tests

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -28,6 +28,7 @@ enum SettingsAction {
     SET_OPEN_INI, SET_OPEN_THEMES_INI,
     SET_TOC_LEFT, SET_TOC_RIGHT,
     SET_LANG_AUTO, SET_LANG_EN, SET_LANG_ZH, SET_LANG_JA, SET_LANG_KO,
+    SET_OPEN_LANGS_INI,
 };
 // TOC panel X for the configured side at the current animation state;
 // geometry shared between render and the input hit tests

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -27,6 +27,7 @@ enum SettingsAction {
     SET_OPEN_THEMES, SET_NEW_THEME, SET_EDIT_THEME,
     SET_OPEN_INI, SET_OPEN_THEMES_INI,
     SET_TOC_LEFT, SET_TOC_RIGHT,
+    SET_LANG_AUTO, SET_LANG_EN, SET_LANG_ZH, SET_LANG_JA, SET_LANG_KO,
 };
 // TOC panel X for the configured side at the current animation state;
 // geometry shared between render and the input hit tests

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -6,6 +6,7 @@
 #include "d2d_init.h"
 #include "search.h"
 #include "print.h"
+#include "i18n.h"
 
 #include <fstream>
 #include <sstream>
@@ -634,7 +635,7 @@ void editorReparse(App& app) {
 void enterEditMode(App& app) {
     if (app.currentFile.empty()) {
         // Show brief "No file loaded" notification
-        app.editorNotificationMsg = L"No file loaded";
+        app.editorNotificationMsg = tr(app, "toast.no_file");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -729,7 +730,7 @@ void enterEditMode(App& app) {
     KillTimer(app.hwnd, 1); // TIMER_FILE_WATCH = 1
 
     // Show notification
-    app.editorNotificationMsg = L"Press ESC twice to exit edit mode";
+    app.editorNotificationMsg = tr(app, "toast.exit_edit_hint");
     app.showEditModeNotification = true;
     app.editModeNotificationAlpha = 1.0f;
     app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -746,7 +747,7 @@ void exitEditMode(App& app) {
     if (app.editorDirty) {
         // Show in-app prompt instead of modal dialog (avoids ESC key conflict)
         app.confirmExitPending = true;
-        app.editorNotificationMsg = L"Unsaved changes! Y = save & exit, N = discard, ESC = cancel";
+        app.editorNotificationMsg = tr(app, "toast.unsaved_exit");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -846,7 +847,7 @@ void saveEditorFile(App& app, HWND hwnd) {
         editorReparse(app);
 
         // Show "Saved!" notification
-        app.editorNotificationMsg = L"Saved!";
+        app.editorNotificationMsg = tr(app, "toast.saved");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -859,7 +860,7 @@ void saveEditorFile(App& app, HWND hwnd) {
     } else {
         // Surface the failure — a silent no-op here leaves the document
         // permanently dirty and traps the user in the exit-confirm prompt
-        app.editorNotificationMsg = L"Save failed — file may be locked or read-only";
+        app.editorNotificationMsg = tr(app, "toast.save_failed");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -951,7 +952,7 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
         } else if (wParam == VK_ESCAPE) {
             app.confirmExitPending = false;
             app.escPressedOnce = false;
-            app.editorNotificationMsg = L"Exit cancelled";
+            app.editorNotificationMsg = tr(app, "toast.exit_cancelled");
             app.showEditModeNotification = true;
             app.editModeNotificationAlpha = 1.0f;
             app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -976,7 +977,7 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
         app.lastEscTime = now;
 
         // Show brief hint
-        app.editorNotificationMsg = L"Press ESC again to exit edit mode";
+        app.editorNotificationMsg = tr(app, "toast.exit_confirm");
         app.showEditModeNotification = true;
         app.editModeNotificationAlpha = 1.0f;
         app.editModeNotificationStart = now;
@@ -1054,8 +1055,8 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 app.editorRowMetricsWidth = -1.0f;  // pane width changed
                 app.editorNotificationMsg = app.editorShowPreview
-                    ? L"Preview shown (Ctrl+E to hide)"
-                    : L"Preview hidden (Ctrl+E to show)";
+                    ? tr(app, "toast.preview_shown")
+                    : tr(app, "toast.preview_hidden");
                 app.showEditModeNotification = true;
                 app.editModeNotificationAlpha = 1.0f;
                 app.editModeNotificationStart = std::chrono::steady_clock::now();
@@ -1072,8 +1073,8 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 rebuildEditorRowMetrics(app);
                 editorEnsureCursorVisible(app);
                 app.editorNotificationMsg = app.editorWordWrap
-                    ? L"Word wrap on (Ctrl+W to turn off)"
-                    : L"Word wrap off (Ctrl+W to turn on)";
+                    ? tr(app, "toast.wrap_on")
+                    : tr(app, "toast.wrap_off");
                 app.showEditModeNotification = true;
                 app.editModeNotificationAlpha = 1.0f;
                 app.editModeNotificationStart = std::chrono::steady_clock::now();

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -1,0 +1,312 @@
+#include "i18n.h"
+#include "app.h"
+
+#include <windows.h>
+#include <string.h>
+#include <cstring>
+
+// Language metadata. nativeFont is a hint — the chooser uses it so each
+// language's name shows in its native typeface. Empty string falls back to
+// the theme font (the font fallback chain already handles CJK glyphs).
+const Language LANGUAGES[LANG_COUNT] = {
+    { L"English",                L"English",                     L"" },
+    { L"\u7B80\u4F53\u4E2D\u6587", L"Chinese (Simplified)",       L"Microsoft YaHei UI" },
+    { L"\u65E5\u672C\u8A9E",       L"Japanese",                   L"Yu Gothic UI" },
+    { L"\uD55C\uAD6D\uC5B4",       L"Korean",                     L"Malgun Gothic" },
+};
+
+// Translation table.
+//
+// Every key MUST have an English entry — English is the fallback when a
+// language lacks a translation. The zh/ja/ko columns may be nullptr to mean
+// "fall back to English". Once a translation is added it should never be
+// removed (only amended); keys are stable identifiers referenced across the
+// codebase.
+//
+// Conventions:
+//   - Keys use dotted lowercase namespaces: help.title, toast.saved, ...
+//   - Format strings use positional printf-style placeholders so locales can
+//     reorder arguments: "%1$d of %2$zu", not "%d of %zu".
+//   - Em dash (U+2014) is written as a literal L"\u2014" for readability.
+namespace {
+
+struct Entry {
+    const char* key;
+    const wchar_t* en;
+    const wchar_t* zh;  // Simplified Chinese
+    const wchar_t* ja;  // Japanese (may be null -> fallback to en)
+    const wchar_t* ko;  // Korean   (may be null -> fallback to en)
+};
+
+// Note: kept as a plain array (not unordered_map) on purpose. ~80 entries,
+// linear scan is cache-friendly and avoids a static-init ordering fiasco.
+const Entry kEntries[] = {
+    // ----- Help overlay -----
+    { "help.title",            L"Keyboard Shortcuts",                       L"\u952E\u76D8\u5FEB\u6377\u952E",                       nullptr, nullptr },
+    { "help.section.navigation", L"NAVIGATION",                             L"\u5BFC\u822A",                                          nullptr, nullptr },
+    { "help.section.view",     L"VIEW",                                     L"\u89C6\u56FE",                                          nullptr, nullptr },
+    { "help.section.editing",  L"EDITING",                                  L"\u7F16\u8F91",                                          nullptr, nullptr },
+    { "help.section.general",  L"GENERAL",                                  L"\u5E38\u89C4",                                          nullptr, nullptr },
+    { "help.footer",           L"Press ESC or ? to close",                  L"\u6309 ESC \u6216 ? \u5173\u95ED",                      nullptr, nullptr },
+
+    // Help entries: only the description column is translated; keys (Ctrl+S etc.) stay verbatim.
+    { "help.nav.scroll_down",      L"Scroll down",                  L"\u5411\u4E0B\u6EDA\u52A8",                          nullptr, nullptr },
+    { "help.nav.scroll_up",        L"Scroll up",                    L"\u5411\u4E0A\u6EDA\u52A8",                          nullptr, nullptr },
+    { "help.nav.page_down",        L"Page down",                    L"\u5411\u4E0B\u7FFB\u9875",                          nullptr, nullptr },
+    { "help.nav.page_up",          L"Page up",                      L"\u5411\u4E0A\u7FFB\u9875",                          nullptr, nullptr },
+    { "help.nav.jump_start_end",   L"Jump to start / end",          L"\u8DF3\u8F6C\u5230\u5F00\u5934 / \u7ED3\u5C3E",     nullptr, nullptr },
+    { "help.nav.zoom",             L"Zoom in / out",                L"\u653E\u5927 / \u7F29\u5C0F",                       nullptr, nullptr },
+
+    { "help.view.search",          L"Search",                       L"\u641C\u7D22",                                      nullptr, nullptr },
+    { "help.view.next_match",      L"Next search match",            L"\u4E0B\u4E00\u4E2A\u5339\u914D\u7ED3\u679C",        nullptr, nullptr },
+    { "help.view.folder_browser",  L"Toggle folder browser",        L"\u5207\u6362\u6587\u4EF6\u5939\u6D4F\u89C8",        nullptr, nullptr },
+    { "help.view.toc",             L"Toggle table of contents",     L"\u5207\u6362\u76EE\u5F55",                          nullptr, nullptr },
+    { "help.view.theme",           L"Theme chooser",                L"\u4E3B\u9898\u9009\u62E9\u5668",                    nullptr, nullptr },
+    { "help.view.stats",           L"Toggle stats",                 L"\u5207\u6362\u7EDF\u8BA1\u4FE1\u606F",              nullptr, nullptr },
+    { "help.view.help",            L"This help",                    L"\u672C\u5E2E\u52A9",                                nullptr, nullptr },
+
+    { "help.edit.enter_edit",      L"Enter edit mode",              L"\u8FDB\u5165\u7F16\u8F91\u6A21\u5F0F",              nullptr, nullptr },
+    { "help.edit.save",            L"Save (in edit mode)",          L"\u4FDD\u5B58\uFF08\u7F16\u8F91\u6A21\u5F0F\u4E0B\uFF09", nullptr, nullptr },
+    { "help.edit.preview",         L"Show / hide preview pane",     L"\u663E\u793A / \u9690\u85CF\u9884\u89C8\u7A97\u683C", nullptr, nullptr },
+    { "help.edit.word_wrap",       L"Toggle word wrap",             L"\u5207\u6362\u81EA\u52A8\u6362\u884C",              nullptr, nullptr },
+    { "help.edit.exit_edit",       L"Exit edit mode",               L"\u9000\u51FA\u7F16\u8F91\u6A21\u5F0F",              nullptr, nullptr },
+
+    { "help.general.select_all",   L"Select all text",              L"\u5168\u9009\u6587\u672C",                          nullptr, nullptr },
+    { "help.general.copy",         L"Copy selection",               L"\u590D\u5236\u9009\u4E2D\u5185\u5BB9",              nullptr, nullptr },
+    { "help.general.close",        L"Close overlay / Quit",         L"\u5173\u95ED\u6D6E\u5C42 / \u9000\u51FA",           nullptr, nullptr },
+    { "help.general.quit",         L"Quit",                         L"\u9000\u51FA",                                      nullptr, nullptr },
+
+    // ----- Search overlay -----
+    { "search.placeholder",    L"Search...",                                L"\u641C\u7D22...",                                      nullptr, nullptr },
+    { "search.no_matches",     L"No matches",                               L"\u65E0\u5339\u914D",                                   nullptr, nullptr },
+    // Fixed argument order (current, total): MSVC's printf family has no
+    // positional specifiers, so locales phrase around the same order
+    { "search.match_count",    L"%d of %zu",                                L"\u7B2C %d / %zu \u4E2A",                       nullptr, nullptr },
+
+    // ----- Table of contents -----
+    { "toc.title",             L"Contents",                                 L"\u76EE\u5F55",                                         nullptr, nullptr },
+    { "toc.empty",             L"No headings",                              L"\u65E0\u6807\u9898",                                   nullptr, nullptr },
+
+    // ----- Theme chooser -----
+    { "theme.chooser.title",   L"Choose Theme",                             L"\u9009\u62E9\u4E3B\u9898",                             nullptr, nullptr },
+    { "theme.chooser.light",   L"LIGHT THEMES",                             L"\u6D45\u8272\u4E3B\u9898",                             nullptr, nullptr },
+    { "theme.chooser.dark",    L"DARK THEMES",                              L"\u6DF1\u8272\u4E3B\u9898",                             nullptr, nullptr },
+
+    // ----- Language chooser -----
+    { "lang.chooser.title",    L"Choose Language",                          L"\u9009\u62E9\u8BED\u8A00",                             nullptr, nullptr },
+    { "lang.chooser.footer",   L"Press ESC to close",                       L"\u6309 ESC \u5173\u95ED",                              nullptr, nullptr },
+
+    // ----- Toast / editor notifications -----
+    { "toast.no_file",         L"No file loaded",                           L"\u672A\u52A0\u8F7D\u6587\u4EF6",                       nullptr, nullptr },
+    { "toast.exit_edit_hint",  L"Press ESC twice to exit edit mode",        L"\u8FDE\u6309\u4E24\u6B21 ESC \u9000\u51FA\u7F16\u8F91\u6A21\u5F0F", nullptr, nullptr },
+    { "toast.unsaved_exit",    L"Unsaved changes! Y = save & exit, N = discard, ESC = cancel",
+                               L"\u6709\u672A\u4FDD\u5B58\u7684\u66F4\u6539\uFF01Y = \u4FDD\u5B58\u5E76\u9000\u51FA\uFF0CN = \u653E\u5F03\uFF0CESC = \u53D6\u6D88",
+                               nullptr, nullptr },
+    { "toast.saved",           L"Saved!",                                   L"\u5DF2\u4FDD\u5B58\uFF01",                             nullptr, nullptr },
+    { "toast.save_failed",     L"Save failed \u2014 file may be locked or read-only",
+                               L"\u4FDD\u5B58\u5931\u8D25 \u2014 \u6587\u4EF6\u53EF\u80FD\u88AB\u9501\u5B9A\u6216\u4E3A\u53EA\u8BFB",
+                               nullptr, nullptr },
+    { "toast.exit_cancelled",  L"Exit cancelled",                           L"\u5DF2\u53D6\u6D88\u9000\u51FA",                       nullptr, nullptr },
+    { "toast.exit_confirm",    L"Press ESC again to exit edit mode",        L"\u518D\u6309\u4E00\u6B21 ESC \u9000\u51FA\u7F16\u8F91\u6A21\u5F0F", nullptr, nullptr },
+    { "toast.preview_shown",   L"Preview shown (Ctrl+E to hide)",           L"\u5DF2\u663E\u793A\u9884\u89C8\uFF08Ctrl+E \u9690\u85CF\uFF09", nullptr, nullptr },
+    { "toast.preview_hidden",  L"Preview hidden (Ctrl+E to show)",          L"\u5DF2\u9690\u85CF\u9884\u89C8\uFF08Ctrl+E \u663E\u793A\uFF09", nullptr, nullptr },
+    { "toast.wrap_on",         L"Word wrap on (Ctrl+W to turn off)",        L"\u5DF2\u5F00\u542F\u81EA\u52A8\u6362\u884C\uFF08Ctrl+W \u5173\u95ED\uFF09", nullptr, nullptr },
+    { "toast.wrap_off",        L"Word wrap off (Ctrl+W to turn on)",        L"\u5DF2\u5173\u95ED\u81EA\u52A8\u6362\u884C\uFF08Ctrl+W \u5F00\u542F\uFF09", nullptr, nullptr },
+
+    // Code block hover button + confirmation pill
+    { "codeblock.copy",        L"Copy",                                     L"\u590D\u5236",                                         nullptr, nullptr },
+    { "codeblock.copied",      L"Copied!",                                  L"\u5DF2\u590D\u5236\uFF01",                             nullptr, nullptr },
+
+    // ----- Stats overlay -----
+    // Two-line format. Labels translatable; D2D/DWrite kept as technical abbreviations.
+    // Placeholders: %1$zu parse us, %2$zu layout us, %3$zu draw calls,
+    //               %4$.1f startup ms, %5$.1f window ms, %6$.1f d2d ms,
+    //               %7$.1f dwrite ms, %8$.1f file ms
+    { "stats.line1",           L"Parse: %1$zu us | Layout: %2$zu us | Draw calls: %3$zu",
+                               L"\u89E3\u6790: %1$zu us | \u5E03\u5C40: %2$zu us | \u7ED8\u5236\u8C03\u7528: %3$zu",
+                               nullptr, nullptr },
+    { "stats.line2",           L"Startup: %4$.1fms (Win: %5$.1f | D2D: %6$.1f | DWrite: %7$.1f | File: %8$.1f)",
+                               L"\u542F\u52A8: %4$.1fms (\u7A97\u53E3: %5$.1f | D2D: %6$.1f | DWrite: %7$.1f | \u6587\u4EF6: %8$.1f)",
+                               nullptr, nullptr },
+
+    // ----- File-association dialogs (shared by settings.cpp and main_d2d.cpp /register) -----
+    { "fileassoc.title",                L"Tinta - File Association",                 L"Tinta - \u6587\u4EF6\u5173\u8054",                              nullptr, nullptr },
+    { "fileassoc.add_mmd_failed_body",  L"Failed to add the .mmd file association. Run tinta.exe /register to try again.",
+                                         L"\u6DFB\u52A0 .mmd \u6587\u4EF6\u5173\u8054\u5931\u8D25\u3002\u8BF7\u8FD0\u884C tinta.exe /register \u91CD\u8BD5\u3002",
+                                         nullptr, nullptr },
+    { "fileassoc.ask_body",
+        L"Would you like to set Tinta as the default viewer for Markdown and Mermaid files?\n\nWindows will open Settings where you can select Tinta.",
+        L"\u662F\u5426\u5C06 Tinta \u8BBE\u4E3A Markdown \u548C Mermaid \u6587\u4EF6\u7684\u9ED8\u8BA4\u67E5\u770B\u5668\uFF1F\n\nWindows \u5C06\u6253\u5F00\u8BBE\u7F6E\uFF0C\u60A8\u53EF\u5728\u5176\u4E2D\u9009\u62E9 Tinta\u3002",
+        nullptr, nullptr },
+    { "fileassoc.done_title",   L"Almost done!",                              L"\u5C31\u5FEB\u5B8C\u6210\u4E86\uFF01",                          nullptr, nullptr },
+    { "fileassoc.done_body",
+        L"Tinta has been registered.\n\nIn the Settings window that opens:\n1. Search for '.md' or '.mmd'\n2. Click on the current default app\n3. Select 'Tinta' from the list",
+        L"Tinta \u5DF2\u6CE8\u518C\u3002\n\n\u5728\u6253\u5F00\u7684\u8BBE\u7F6E\u7A97\u53E3\u4E2D\uFF1A\n1. \u641C\u7D22 \u201C.md\u201D \u6216 \u201C.mmd\u201D\n2. \u70B9\u51FB\u5F53\u524D\u9ED8\u8BA4\u5E94\u7528\n3. \u4ECE\u5217\u8868\u4E2D\u9009\u62E9 \u201CTinta\u201D",
+        nullptr, nullptr },
+    { "fileassoc.register_failed_body", L"Failed to register file association. Try running as administrator.",
+                                         L"\u6CE8\u518C\u6587\u4EF6\u5173\u8054\u5931\u8D25\u3002\u8BF7\u5C1D\u8BD5\u4EE5\u7BA1\u7406\u5458\u8EAB\u4EFD\u8FD0\u884C\u3002",
+                                         nullptr, nullptr },
+
+    // ----- Init-failure dialogs -----
+    { "error.title",               L"Error",                                       L"\u9519\u8BEF",                                  nullptr, nullptr },
+    { "error.d2d_init_failed",     L"Failed to initialize Direct2D",              L"Direct2D \u521D\u59CB\u5316\u5931\u8D25",        nullptr, nullptr },
+    { "error.render_target_failed", L"Failed to create render target",             L"\u521B\u5EFA\u6E32\u67D3\u76EE\u6807\u5931\u8D25", nullptr, nullptr },
+
+    // ----- Window title -----
+    // Format with positional args: %1$s = filename (or full path), %2$s is unused
+    // for the non-dirty case. For the dirty case see title.dirty below.
+    { "title.plain",   L"Tinta - %1$s",            L"Tinta - %1$s",            nullptr, nullptr },
+    { "title.dirty",   L"Tinta - * %1$s",           L"Tinta - * %1$s",          nullptr, nullptr },
+    { "title.no_file", L"Tinta",                    L"Tinta",                   nullptr, nullptr },
+
+    // ----- GitHub-style alert titles (render.cpp) -----
+    // Emoji prefix + variation selector are added by the renderer; we only
+    // translate the trailing word. The keys below carry the bare word.
+    { "alert.note",      L"Note",      L"\u6CE8\u91CA",       nullptr, nullptr },
+    { "alert.tip",       L"Tip",       L"\u63D0\u793A",       nullptr, nullptr },
+    { "alert.important", L"Important", L"\u91CD\u8981",       nullptr, nullptr },
+    { "alert.warning",   L"Warning",   L"\u8B66\u544A",       nullptr, nullptr },
+    { "alert.caution",   L"Caution",   L"\u6CE8\u610F",       nullptr, nullptr },
+
+    // ----- Image alt-text placeholder (render.cpp) -----
+    // Renders as "[image: <alt>]". The brackets and separator are added by
+    // the renderer; only the word "image" is translated here.
+    { "image.placeholder", L"image", L"\u56FE\u7247", nullptr, nullptr },
+
+    // ----- Context menu (post-#84 surface) -----
+    { "ctx.copy", L"Copy", L"\u590D\u5236", nullptr, nullptr },
+    { "ctx.select_all", L"Select All", L"\u5168\u9009", nullptr, nullptr },
+    { "ctx.new", L"New File", L"\u65B0\u5EFA\u6587\u4EF6", nullptr, nullptr },
+    { "ctx.print", L"Print / PDF", L"\u6253\u5370 / PDF", nullptr, nullptr },
+    { "ctx.edit", L"Edit", L"\u7F16\u8F91", nullptr, nullptr },
+    { "ctx.search", L"Search", L"\u641C\u7D22", nullptr, nullptr },
+    { "ctx.toc", L"Table of Contents", L"\u76EE\u5F55", nullptr, nullptr },
+    { "ctx.browse", L"Browse Files", L"\u6D4F\u89C8\u6587\u4EF6", nullptr, nullptr },
+    { "ctx.reveal", L"Reveal in Explorer", L"\u5728\u8D44\u6E90\u7BA1\u7406\u5668\u4E2D\u663E\u793A", nullptr, nullptr },
+    { "ctx.theme", L"Theme", L"\u4E3B\u9898", nullptr, nullptr },
+    { "ctx.settings", L"Settings", L"\u8BBE\u7F6E", nullptr, nullptr },
+    { "ctx.help", L"Help", L"\u5E2E\u52A9", nullptr, nullptr },
+
+    // ----- Settings dialog (post-#84 surface) -----
+    { "settings.title", L"Settings", L"\u8BBE\u7F6E", nullptr, nullptr },
+    { "settings.section.general", L"General", L"\u5E38\u89C4", nullptr, nullptr },
+    { "settings.section.appearance", L"Appearance", L"\u5916\u89C2", nullptr, nullptr },
+    { "settings.section.editor", L"Editor", L"\u7F16\u8F91\u5668", nullptr, nullptr },
+    { "settings.folder_search", L"Folder search results", L"\u6587\u4EF6\u5939\u641C\u7D22\u7ED3\u679C", nullptr, nullptr },
+    { "settings.folder_search.hint", L"Sibling files matched while searching", L"\u641C\u7D22\u65F6\u540C\u65F6\u5339\u914D\u540C\u76EE\u5F55\u7684\u5176\u4ED6\u6587\u4EF6", nullptr, nullptr },
+    { "settings.open_ini", L"Edit settings.ini", L"\u7F16\u8F91 settings.ini", nullptr, nullptr },
+    { "settings.open_ini.hint", L"Keys, positions, and everything else", L"\u5FEB\u6377\u952E\u3001\u9605\u8BFB\u4F4D\u7F6E\u7B49\u5168\u90E8\u914D\u7F6E", nullptr, nullptr },
+    { "settings.open_themes_ini", L"Edit themes.ini", L"\u7F16\u8F91 themes.ini", nullptr, nullptr },
+    { "settings.open_themes_ini.hint", L"Hand-tune custom themes, syntax colors included", L"\u624B\u52A8\u8C03\u6574\u81EA\u5B9A\u4E49\u4E3B\u9898\uFF08\u542B\u8BED\u6CD5\u914D\u8272\uFF09", nullptr, nullptr },
+    { "settings.open", L"Open", L"\u6253\u5F00", nullptr, nullptr },
+    { "settings.reading_width_window", L"Reading width \u2014 window", L"\u9605\u8BFB\u5BBD\u5EA6 \u2014 \u7A97\u53E3", nullptr, nullptr },
+    { "settings.reading_width_window.hint", L"Center the document in a column on wide screens", L"\u5BBD\u5C4F\u4E0B\u5C06\u6587\u6863\u5C45\u4E2D\u4E3A\u7A84\u680F", nullptr, nullptr },
+    { "settings.reading_width_full", L"Reading width \u2014 fullscreen", L"\u9605\u8BFB\u5BBD\u5EA6 \u2014 \u5168\u5C4F", nullptr, nullptr },
+    { "settings.reading_width_full.hint", L"Column used in zen mode (F11)", L"\u7985\u6A21\u5F0F\uFF08F11\uFF09\u4F7F\u7528\u7684\u680F\u5BBD", nullptr, nullptr },
+    { "settings.follow_windows", L"Follow Windows theme", L"\u8DDF\u968F Windows \u4E3B\u9898", nullptr, nullptr },
+    { "settings.follow_windows.hint", L"Switch light and dark with the system", L"\u968F\u7CFB\u7EDF\u5207\u6362\u6D45\u8272\u4E0E\u6DF1\u8272", nullptr, nullptr },
+    { "settings.toc_side", L"Table of contents", L"\u76EE\u5F55\u4F4D\u7F6E", nullptr, nullptr },
+    { "settings.toc_side.hint", L"Which side the Tab panel slides from", L"Tab \u76EE\u5F55\u9762\u677F\u4ECE\u54EA\u4E00\u4FA7\u6ED1\u51FA", nullptr, nullptr },
+    { "settings.toc.left", L"Left", L"\u5DE6\u4FA7", nullptr, nullptr },
+    { "settings.toc.right", L"Right", L"\u53F3\u4FA7", nullptr, nullptr },
+    { "settings.themes", L"Themes", L"\u4E3B\u9898", nullptr, nullptr },
+    { "settings.themes.hint", L"Browse, edit the current one, or start fresh", L"\u6D4F\u89C8\u3001\u7F16\u8F91\u5F53\u524D\u4E3B\u9898\u6216\u65B0\u5EFA", nullptr, nullptr },
+    { "settings.browse", L"Browse", L"\u6D4F\u89C8", nullptr, nullptr },
+    { "settings.edit", L"Edit", L"\u7F16\u8F91", nullptr, nullptr },
+    { "settings.new", L"+ New", L"+ \u65B0\u5EFA", nullptr, nullptr },
+    { "settings.word_wrap", L"Word wrap", L"\u81EA\u52A8\u6362\u884C", nullptr, nullptr },
+    { "settings.word_wrap.hint", L"Wrap long lines in the editor pane", L"\u7F16\u8F91\u5668\u5185\u957F\u884C\u81EA\u52A8\u6362\u884C", nullptr, nullptr },
+    { "settings.preview_pane", L"Preview pane", L"\u9884\u89C8\u7A97\u683C", nullptr, nullptr },
+    { "settings.preview_pane.hint", L"Show the rendered preview beside the editor", L"\u5728\u7F16\u8F91\u5668\u65C1\u663E\u793A\u6E32\u67D3\u9884\u89C8", nullptr, nullptr },
+    { "settings.language", L"Language", L"\u754C\u9762\u8BED\u8A00", nullptr, nullptr },
+    { "settings.language.hint", L"Auto follows the Windows display language", L"\u81EA\u52A8 = \u8DDF\u968F Windows \u663E\u793A\u8BED\u8A00", nullptr, nullptr },
+    { "settings.lang.auto", L"Auto", L"\u81EA\u52A8", nullptr, nullptr },
+    { "settings.footer", L"Esc to close \u2022 changes apply immediately", L"\u6309 Esc \u5173\u95ED \u2022 \u66F4\u6539\u7ACB\u5373\u751F\u6548", nullptr, nullptr },
+    { "settings.full", L"Full", L"\u5168\u5BBD", nullptr, nullptr },
+
+};
+
+constexpr size_t kEntryCount = sizeof(kEntries) / sizeof(kEntries[0]);
+
+const Entry* findEntry(const char* key) {
+    // Linear scan — ~80 entries, called a few hundred times per frame at most.
+    for (size_t i = 0; i < kEntryCount; i++) {
+        if (std::strcmp(kEntries[i].key, key) == 0) {
+            return &kEntries[i];
+        }
+    }
+    return nullptr;
+}
+
+const wchar_t* pick(const Entry* e, int langIndex) {
+    if (!e) return nullptr;
+    switch (langIndex) {
+        case 1: if (e->zh) return e->zh; break;
+        case 2: if (e->ja) return e->ja; break;
+        case 3: if (e->ko) return e->ko; break;
+        default: break;
+    }
+    return e->en;  // English is the fallback (also handles langIndex == 0)
+}
+
+} // namespace
+
+const wchar_t* tr(int langIndex, const char* key) {
+    if (!key) return L"";
+    const Entry* e = findEntry(key);
+    const wchar_t* v = pick(e, langIndex);
+    if (v) return v;
+    // Unknown key: return the key itself so breakage is visible in dev
+    // without crashing. Convert char* to a stable wide buffer.
+    static thread_local std::wstring fallback;
+    fallback.clear();
+    for (const char* p = key; *p; ++p) fallback.push_back((wchar_t)(unsigned char)*p);
+    return fallback.c_str();
+}
+
+const wchar_t* tr(const App& app, const char* key) {
+    return tr(app.currentLanguageIndex, key);
+}
+
+int clampLanguageIndex(int index) {
+    return (index >= 0 && index < LANG_COUNT) ? index : LANG_INDEX_EN;
+}
+
+int detectSystemLanguage() {
+    // GetUserPreferredUILanguages returns a double-NUL-terminated list of
+    // BCP 47 tags ("en-US\0zh-Hans-CN\0\0"). We pick the first one we recognize.
+    ULONG numLanguages = 0;
+    ULONG bufferSize = 0;
+    if (GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, &numLanguages, nullptr, &bufferSize)) {
+        std::wstring buffer(bufferSize, L'\0');
+        if (GetUserPreferredUILanguages(MUI_LANGUAGE_NAME, &numLanguages, buffer.data(), &bufferSize) && numLanguages > 0) {
+            // Walk each NUL-terminated tag in the buffer.
+            const wchar_t* p = buffer.c_str();
+            for (ULONG i = 0; i < numLanguages; ++i) {
+                std::wstring tag(p);
+                // ci-compare prefix
+                auto startsWith = [&](const wchar_t* prefix) {
+                    size_t n = 0;
+                    while (prefix[n]) ++n;
+                    if (tag.size() < n) return false;
+                    for (size_t k = 0; k < n; ++k) {
+                        wchar_t a = tag[k], b = prefix[k];
+                        if (a >= L'A' && a <= L'Z') a += (L'a' - L'A');
+                        if (b >= L'A' && b <= L'Z') b += (L'a' - L'A');
+                        if (a != b) return false;
+                    }
+                    return true;
+                };
+                // zh-Hans* (Simplified) -> Simplified Chinese.
+                // zh-Hant* (Traditional) is not yet translated -> falls through to English.
+                if (startsWith(L"zh-hans") || startsWith(L"zh-cn") || startsWith(L"zh-sg")) {
+                    return 1;
+                }
+                if (startsWith(L"ja")) return 2;
+                if (startsWith(L"ko")) return 3;
+                p += tag.size() + 1;  // skip past the NUL
+            }
+        }
+    }
+    return LANG_INDEX_EN;
+}

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -222,6 +222,8 @@ const Entry kEntries[] = {
     { "settings.language.hint", L"Auto follows the Windows display language", L"\u81EA\u52A8 = \u8DDF\u968F Windows \u663E\u793A\u8BED\u8A00", nullptr, nullptr },
     { "settings.lang.auto", L"Auto", L"\u81EA\u52A8", nullptr, nullptr },
     { "settings.footer", L"Esc to close \u2022 changes apply immediately", L"\u6309 Esc \u5173\u95ED \u2022 \u66F4\u6539\u7ACB\u5373\u751F\u6548", nullptr, nullptr },
+    { "settings.open_langs", L"Edit languages.ini", L"\u7F16\u8F91 languages.ini", nullptr, nullptr },
+    { "settings.open_langs.hint", L"Add or fix translations \u2014 ja and ko welcome", L"\u8865\u5145\u6216\u4FEE\u6B63\u7FFB\u8BD1\uFF08\u6B22\u8FCE\u65E5\u8BED\u3001\u97E9\u8BED\uFF09", nullptr, nullptr },
     { "settings.full", L"Full", L"\u5168\u5BBD", nullptr, nullptr },
 
 };
@@ -251,8 +253,15 @@ const wchar_t* pick(const Entry* e, int langIndex) {
 
 } // namespace
 
+namespace {
+const wchar_t* overrideFor(int langIndex, const char* key);
+}
+
 const wchar_t* tr(int langIndex, const char* key) {
     if (!key) return L"";
+    if (const wchar_t* o = overrideFor(clampLanguageIndex(langIndex), key)) {
+        return o;  // languages.ini overrides the compiled table
+    }
     const Entry* e = findEntry(key);
     const wchar_t* v = pick(e, langIndex);
     if (v) return v;
@@ -309,4 +318,112 @@ int detectSystemLanguage() {
         }
     }
     return LANG_INDEX_EN;
+}
+
+// ---- languages.ini override layer ----
+//
+// %APPDATA%\Tinta\languages.ini lets anyone fill the ja/ko columns or fix
+// a shipped string without a compiler. Sections name the locale ([ja]),
+// entries are key=value in UTF-8. Lookup order: override -> compiled
+// locale column -> compiled English -> the key itself.
+
+#include <shlobj.h>
+#include <shellapi.h>
+#include <fstream>
+#include <unordered_map>
+
+namespace {
+
+std::unordered_map<std::string, std::wstring> g_overrides[LANG_COUNT];
+
+std::wstring langUtf8ToWide(const std::string& s) {
+    if (s.empty()) return L"";
+    int len = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
+    std::wstring w(len > 0 ? len - 1 : 0, L'\0');
+    if (len > 1) MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, &w[0], len);
+    return w;
+}
+
+std::wstring languagesIniPath() {
+    wchar_t appData[MAX_PATH];
+    if (FAILED(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0, appData))) {
+        return L"";
+    }
+    std::wstring path = appData;
+    path += L"\\Tinta";
+    CreateDirectoryW(path.c_str(), nullptr);
+    return path + L"\\languages.ini";
+}
+
+int localeIndexFromSection(const std::string& name) {
+    if (name == "en") return 0;
+    if (name == "zh" || name == "zh-cn" || name == "zh-hans") return 1;
+    if (name == "ja" || name == "ja-jp") return 2;
+    if (name == "ko" || name == "ko-kr") return 3;
+    return -1;
+}
+
+const wchar_t* overrideFor(int langIndex, const char* key) {
+    if (langIndex < 0 || langIndex >= LANG_COUNT) return nullptr;
+    auto it = g_overrides[langIndex].find(key);
+    return it != g_overrides[langIndex].end() ? it->second.c_str() : nullptr;
+}
+
+} // namespace
+
+void loadLanguageOverrides() {
+    for (auto& map : g_overrides) map.clear();
+    std::wstring path = languagesIniPath();
+    if (path.empty()) return;
+    std::ifstream file(path);
+    if (!file) return;
+
+    int locale = -1;
+    std::string line;
+    while (std::getline(file, line)) {
+        while (!line.empty() && (line.back() == '\r' || line.back() == '\n')) line.pop_back();
+        if (line.empty() || line[0] == ';' || line[0] == '#') continue;
+        if (line.front() == '[' && line.back() == ']') {
+            std::string name = line.substr(1, line.size() - 2);
+            for (char& c : name) c = (char)tolower((unsigned char)c);
+            locale = localeIndexFromSection(name);
+            continue;
+        }
+        if (locale < 0) continue;
+        size_t eq = line.find('=');
+        if (eq == std::string::npos || eq == 0) continue;
+        std::wstring value = langUtf8ToWide(line.substr(eq + 1));
+        if (!value.empty()) {
+            g_overrides[locale][line.substr(0, eq)] = std::move(value);
+        }
+    }
+}
+
+// Seeds a translator-friendly template on first open: every key listed
+// under [ja] and [ko], commented out, with the English text as reference.
+void openLanguagesIniFile() {
+    std::wstring path = languagesIniPath();
+    if (path.empty()) return;
+    if (GetFileAttributesW(path.c_str()) == INVALID_FILE_ATTRIBUTES) {
+        std::ofstream f(path, std::ios::binary);
+        f << "; Tinta UI translations \xe2\x80\x94 UTF-8, key=value under a locale section.\n";
+        f << "; Values here override the built-in strings; missing keys fall back\n";
+        f << "; to the built-in translation, then English. Uncomment a line and\n";
+        f << "; translate the right-hand side, then restart Tinta.\n";
+        f << "; Sections: [en] [zh] [ja] [ko]\n";
+        for (const char* section : {"ja", "ko"}) {
+            f << "\n[" << section << "]\n";
+            for (const Entry& e : kEntries) {
+                int len = WideCharToMultiByte(CP_UTF8, 0, e.en, -1, nullptr, 0,
+                                              nullptr, nullptr);
+                std::string en(len > 0 ? len - 1 : 0, '\0');
+                if (len > 1) {
+                    WideCharToMultiByte(CP_UTF8, 0, e.en, -1, &en[0], len,
+                                        nullptr, nullptr);
+                }
+                f << ";" << e.key << "=" << en << "\n";
+            }
+        }
+    }
+    ShellExecuteW(nullptr, L"open", path.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 }

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -223,7 +223,7 @@ const Entry kEntries[] = {
     { "settings.lang.auto", L"Auto", L"\u81EA\u52A8", nullptr, nullptr },
     { "settings.footer", L"Esc to close \u2022 changes apply immediately", L"\u6309 Esc \u5173\u95ED \u2022 \u66F4\u6539\u7ACB\u5373\u751F\u6548", nullptr, nullptr },
     { "settings.open_langs", L"Edit languages.ini", L"\u7F16\u8F91 languages.ini", nullptr, nullptr },
-    { "settings.open_langs.hint", L"Add or fix translations \u2014 ja and ko welcome", L"\u8865\u5145\u6216\u4FEE\u6B63\u7FFB\u8BD1\uFF08\u6B22\u8FCE\u65E5\u8BED\u3001\u97E9\u8BED\uFF09", nullptr, nullptr },
+    { "settings.open_langs.hint", L"Add or fix translations \u2014 more languages welcome", L"\u8865\u5145\u6216\u4FEE\u6B63\u7FFB\u8BD1\uFF08\u6B22\u8FCE\u66F4\u591A\u8BED\u8A00\uFF09", nullptr, nullptr },
     { "settings.full", L"Full", L"\u5168\u5BBD", nullptr, nullptr },
 
 };
@@ -254,16 +254,20 @@ const wchar_t* pick(const Entry* e, int langIndex) {
 } // namespace
 
 namespace {
-const wchar_t* overrideFor(int langIndex, const char* key);
+struct RuntimeLanguage;
+const wchar_t* overrideFor(const std::string& id, const char* key);
 }
 
 const wchar_t* tr(int langIndex, const char* key) {
     if (!key) return L"";
-    if (const wchar_t* o = overrideFor(clampLanguageIndex(langIndex), key)) {
+    langIndex = clampLanguageIndex(langIndex);
+    if (const wchar_t* o = overrideFor(languageIdAt(langIndex), key)) {
         return o;  // languages.ini overrides the compiled table
     }
     const Entry* e = findEntry(key);
-    const wchar_t* v = pick(e, langIndex);
+    // ini-only languages have no compiled column: fall through to English
+    int column = languageCompiledColumn(langIndex);
+    const wchar_t* v = pick(e, column >= 0 ? column : 0);
     if (v) return v;
     // Unknown key: return the key itself so breakage is visible in dev
     // without crashing. Convert char* to a stable wide buffer.
@@ -278,7 +282,7 @@ const wchar_t* tr(const App& app, const char* key) {
 }
 
 int clampLanguageIndex(int index) {
-    return (index >= 0 && index < LANG_COUNT) ? index : LANG_INDEX_EN;
+    return (index >= 0 && index < languageCount()) ? index : LANG_INDEX_EN;
 }
 
 int detectSystemLanguage() {
@@ -311,8 +315,18 @@ int detectSystemLanguage() {
                 if (startsWith(L"zh-hans") || startsWith(L"zh-cn") || startsWith(L"zh-sg")) {
                     return 1;
                 }
+                if (startsWith(L"zh-hant") || startsWith(L"zh-tw") || startsWith(L"zh-hk")) {
+                    int idx = languageIndexById("zh-tw");
+                    if (idx >= 0) return idx;  // translated via languages.ini
+                }
                 if (startsWith(L"ja")) return 2;
                 if (startsWith(L"ko")) return 3;
+                // Languages registered from languages.ini match by prefix
+                for (int li = LANG_COUNT; li < languageCount(); li++) {
+                    std::string id = languageIdAt(li);
+                    std::wstring wid(id.begin(), id.end());
+                    if (startsWith(wid.c_str())) return li;
+                }
                 p += tag.size() + 1;  // skip past the NUL
             }
         }
@@ -320,21 +334,39 @@ int detectSystemLanguage() {
     return LANG_INDEX_EN;
 }
 
-// ---- languages.ini override layer ----
+// ---- Dynamic language registry + languages.ini ----
 //
-// %APPDATA%\Tinta\languages.ini lets anyone fill the ja/ko columns or fix
-// a shipped string without a compiler. Sections name the locale ([ja]),
-// entries are key=value in UTF-8. Lookup order: override -> compiled
-// locale column -> compiled English -> the key itself.
+// The compiled table ships en/zh complete with ja/ko columns; the registry
+// grows at runtime from %APPDATA%\Tinta\languages.ini, where any [section]
+// becomes a selectable language (name= sets its dropdown label) and
+// key=value lines override or fill strings. Lookup order per language:
+// override -> compiled column (if any) -> compiled English -> the key.
 
 #include <shlobj.h>
 #include <shellapi.h>
 #include <fstream>
 #include <unordered_map>
+#include <vector>
 
 namespace {
 
-std::unordered_map<std::string, std::wstring> g_overrides[LANG_COUNT];
+struct RuntimeLanguage {
+    std::string id;           // section name, lowercase ("en", "de", "zh-tw")
+    std::wstring nativeName;  // dropdown label
+    int compiledColumn;       // 0..3 into Entry, or -1 for ini-only languages
+};
+
+std::vector<RuntimeLanguage> g_langs;
+std::unordered_map<std::string,
+                   std::unordered_map<std::string, std::wstring>> g_overrides;
+
+void ensureBaseLanguages() {
+    if (!g_langs.empty()) return;
+    for (int i = 0; i < LANG_COUNT; i++) {
+        const char* ids[] = {"en", "zh", "ja", "ko"};
+        g_langs.push_back({ids[i], LANGUAGES[i].nativeName, i});
+    }
+}
 
 std::wstring langUtf8ToWide(const std::string& s) {
     if (s.empty()) return L"";
@@ -355,24 +387,80 @@ std::wstring languagesIniPath() {
     return path + L"\\languages.ini";
 }
 
-int localeIndexFromSection(const std::string& name) {
-    if (name == "en") return 0;
-    if (name == "zh" || name == "zh-cn" || name == "zh-hans") return 1;
-    if (name == "ja" || name == "ja-jp") return 2;
-    if (name == "ko" || name == "ko-kr") return 3;
-    return -1;
+// Section-name aliases onto the compiled languages
+std::string normalizeLanguageId(std::string id) {
+    for (char& c : id) c = (char)tolower((unsigned char)c);
+    if (id == "zh-cn" || id == "zh-hans" || id.rfind("en-", 0) == 0) {
+        return id[0] == 'e' ? "en" : "zh";
+    }
+    if (id == "ja-jp") return "ja";
+    if (id == "ko-kr") return "ko";
+    return id;
 }
 
-const wchar_t* overrideFor(int langIndex, const char* key) {
-    if (langIndex < 0 || langIndex >= LANG_COUNT) return nullptr;
-    auto it = g_overrides[langIndex].find(key);
-    return it != g_overrides[langIndex].end() ? it->second.c_str() : nullptr;
+const wchar_t* overrideFor(const std::string& id, const char* key) {
+    auto oit = g_overrides.find(id);
+    if (oit == g_overrides.end()) return nullptr;
+    auto kit = oit->second.find(key);
+    return kit != oit->second.end() ? kit->second.c_str() : nullptr;
 }
+
+// Common languages seeded into the template. Native names are UTF-8.
+struct SeedLanguage { const char* id; const char* nativeUtf8; };
+const SeedLanguage kSeedLanguages[] = {
+    {"de", "Deutsch"},
+    {"es", "Espa\xc3\xb1ol"},
+    {"fr", "Fran\xc3\xa7" "ais"},
+    {"it", "Italiano"},
+    {"ja", "\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e"},
+    {"ko", "\xed\x95\x9c\xea\xb5\xad\xec\x96\xb4"},
+    {"nl", "Nederlands"},
+    {"pl", "Polski"},
+    {"pt", "Portugu\xc3\xaas"},
+    {"ru", "\xd0\xa0\xd1\x83\xd1\x81\xd1\x81\xd0\xba\xd0\xb8\xd0\xb9"},
+    {"tr", "T\xc3\xbcrk\xc3\xa7" "e"},
+    {"zh-tw", "\xe7\xb9\x81\xe9\xab\x94\xe4\xb8\xad\xe6\x96\x87"},
+};
 
 } // namespace
 
+int languageCount() {
+    ensureBaseLanguages();
+    return (int)g_langs.size();
+}
+
+const wchar_t* languageNameAt(int index) {
+    ensureBaseLanguages();
+    if (index < 0 || index >= (int)g_langs.size()) index = 0;
+    return g_langs[index].nativeName.c_str();
+}
+
+std::string languageIdAt(int index) {
+    ensureBaseLanguages();
+    if (index < 0 || index >= (int)g_langs.size()) index = 0;
+    return g_langs[index].id;
+}
+
+int languageCompiledColumn(int index) {
+    ensureBaseLanguages();
+    if (index < 0 || index >= (int)g_langs.size()) return 0;
+    return g_langs[index].compiledColumn;
+}
+
+int languageIndexById(const std::string& rawId) {
+    ensureBaseLanguages();
+    std::string id = normalizeLanguageId(rawId);
+    for (size_t i = 0; i < g_langs.size(); i++) {
+        if (g_langs[i].id == id) return (int)i;
+    }
+    return -1;
+}
+
 void loadLanguageOverrides() {
-    for (auto& map : g_overrides) map.clear();
+    ensureBaseLanguages();
+    g_langs.resize(LANG_COUNT);  // drop ini-registered languages, re-read
+    g_overrides.clear();
+
     std::wstring path = languagesIniPath();
     if (path.empty()) return;
     std::ifstream file(path);
@@ -384,35 +472,46 @@ void loadLanguageOverrides() {
         while (!line.empty() && (line.back() == '\r' || line.back() == '\n')) line.pop_back();
         if (line.empty() || line[0] == ';' || line[0] == '#') continue;
         if (line.front() == '[' && line.back() == ']') {
-            std::string name = line.substr(1, line.size() - 2);
-            for (char& c : name) c = (char)tolower((unsigned char)c);
-            locale = localeIndexFromSection(name);
+            std::string id = normalizeLanguageId(line.substr(1, line.size() - 2));
+            locale = languageIndexById(id);
+            if (locale < 0 && !id.empty()) {
+                g_langs.push_back({id, langUtf8ToWide(id), -1});
+                locale = (int)g_langs.size() - 1;
+            }
             continue;
         }
         if (locale < 0) continue;
         size_t eq = line.find('=');
         if (eq == std::string::npos || eq == 0) continue;
+        std::string key = line.substr(0, eq);
         std::wstring value = langUtf8ToWide(line.substr(eq + 1));
-        if (!value.empty()) {
-            g_overrides[locale][line.substr(0, eq)] = std::move(value);
+        if (value.empty()) continue;
+        if (key == "name") {
+            g_langs[locale].nativeName = std::move(value);
+        } else {
+            g_overrides[g_langs[locale].id][key] = std::move(value);
         }
     }
 }
 
-// Seeds a translator-friendly template on first open: every key listed
-// under [ja] and [ko], commented out, with the English text as reference.
+// Seeds a translator-friendly template on first open: a roster of common
+// languages, each with its native name and every key commented out with
+// the English text as reference. Any section with translations becomes
+// selectable in Settings after a restart.
 void openLanguagesIniFile() {
     std::wstring path = languagesIniPath();
     if (path.empty()) return;
     if (GetFileAttributesW(path.c_str()) == INVALID_FILE_ATTRIBUTES) {
         std::ofstream f(path, std::ios::binary);
-        f << "; Tinta UI translations \xe2\x80\x94 UTF-8, key=value under a locale section.\n";
-        f << "; Values here override the built-in strings; missing keys fall back\n";
-        f << "; to the built-in translation, then English. Uncomment a line and\n";
-        f << "; translate the right-hand side, then restart Tinta.\n";
-        f << "; Sections: [en] [zh] [ja] [ko]\n";
-        for (const char* section : {"ja", "ko"}) {
-            f << "\n[" << section << "]\n";
+        f << "; Tinta UI translations \xe2\x80\x94 UTF-8, key=value under a language section.\n";
+        f << "; Uncomment a line, translate the right-hand side, restart Tinta \xe2\x80\x94\n";
+        f << "; the language appears in Settings once it has translations.\n";
+        f << "; name= sets the label shown in the language dropdown.\n";
+        f << "; Values override the built-in strings (sections [en] and [zh] work\n";
+        f << "; too); missing keys fall back to English.\n";
+        for (const SeedLanguage& lang : kSeedLanguages) {
+            f << "\n[" << lang.id << "]\n";
+            f << "name=" << lang.nativeUtf8 << "\n";
             for (const Entry& e : kEntries) {
                 int len = WideCharToMultiByte(CP_UTF8, 0, e.en, -1, nullptr, 0,
                                               nullptr, nullptr);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -399,6 +399,9 @@ static void settingsAction(App& app, HWND hwnd, int action) {
         case SET_OPEN_THEMES_INI:
             openThemesIniFile();
             break;
+        case SET_OPEN_LANGS_INI:
+            openLanguagesIniFile();
+            break;
     }
     InvalidateRect(hwnd, nullptr, FALSE);
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -9,6 +9,7 @@
 #include "render.h"
 #include "overlays.h"
 #include "print.h"
+#include "i18n.h"
 
 #include <windowsx.h>
 #include <shellapi.h>
@@ -382,6 +383,14 @@ static void settingsAction(App& app, HWND hwnd, int action) {
             openThemeEditor(app, true);
             break;
         case SET_TOC_LEFT: app.tocOnLeft = true; break;
+        case SET_LANG_AUTO:
+            app.languageSetting = -1;
+            app.currentLanguageIndex = detectSystemLanguage();
+            break;
+        case SET_LANG_EN: case SET_LANG_ZH: case SET_LANG_JA: case SET_LANG_KO:
+            app.languageSetting = action - SET_LANG_EN;
+            app.currentLanguageIndex = app.languageSetting;
+            break;
         case SET_TOC_RIGHT: app.tocOnLeft = false; break;
         case SET_OPEN_INI:
             ShellExecuteW(nullptr, L"open", getSettingsPath().c_str(),

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -347,6 +347,21 @@ static void settingsSliderApply(App& app, int which, float mx) {
 
 // Applies one settings-overlay action (id from app.settingsHits)
 static void settingsAction(App& app, HWND hwnd, int action) {
+    // Language dropdown picks: 0 = Auto, then the registry languages
+    if (action >= SET_LANG_PICK_BASE) {
+        int pick = action - SET_LANG_PICK_BASE;
+        if (pick == 0) {
+            app.languageSetting = -1;
+            app.currentLanguageIndex = detectSystemLanguage();
+        } else if (pick - 1 < languageCount()) {
+            app.languageSetting = pick - 1;
+            app.currentLanguageIndex = pick - 1;
+        }
+        app.settingsLangOpen = false;
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+    if (action != SET_LANG_DROPDOWN) app.settingsLangOpen = false;
     switch (action) {
         case SET_SECTION_GENERAL: app.settingsSection = 0; break;
         case SET_SECTION_APPEARANCE: app.settingsSection = 1; break;
@@ -383,13 +398,8 @@ static void settingsAction(App& app, HWND hwnd, int action) {
             openThemeEditor(app, true);
             break;
         case SET_TOC_LEFT: app.tocOnLeft = true; break;
-        case SET_LANG_AUTO:
-            app.languageSetting = -1;
-            app.currentLanguageIndex = detectSystemLanguage();
-            break;
-        case SET_LANG_EN: case SET_LANG_ZH: case SET_LANG_JA: case SET_LANG_KO:
-            app.languageSetting = action - SET_LANG_EN;
-            app.currentLanguageIndex = app.languageSetting;
+        case SET_LANG_DROPDOWN:
+            app.settingsLangOpen = !app.settingsLangOpen;
             break;
         case SET_TOC_RIGHT: app.tocOnLeft = false; break;
         case SET_OPEN_INI:
@@ -1424,12 +1434,17 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         }
         float mx = (float)GET_X_LPARAM(lParam);
         float my = (float)GET_Y_LPARAM(lParam);
-        for (const auto& hit : app.settingsHits) {
-            if (mx >= hit.first.left && mx <= hit.first.right &&
-                my >= hit.first.top && my <= hit.first.bottom) {
-                settingsAction(app, hwnd, hit.second);
+        // Reverse: later-drawn controls (the language popup) sit on top
+        for (auto it = app.settingsHits.rbegin(); it != app.settingsHits.rend(); ++it) {
+            if (mx >= it->first.left && mx <= it->first.right &&
+                my >= it->first.top && my <= it->first.bottom) {
+                settingsAction(app, hwnd, it->second);
                 return;
             }
+        }
+        if (app.settingsLangOpen) {
+            app.settingsLangOpen = false;  // click elsewhere collapses it
+            InvalidateRect(hwnd, nullptr, FALSE);
         }
         return;
     }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -29,6 +29,7 @@
 #include "input.h"
 #include "editor.h"
 #include "print.h"
+#include "i18n.h"
 
 static App* g_app = nullptr;
 
@@ -1085,6 +1086,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.readingWidthPct = app->readingWidthPct;
                 settings.zenWidthPct = app->zenWidthPct;
                 settings.tocOnLeft = app->tocOnLeft;
+                settings.languageIndex = app->languageSetting;
                 if (!app->currentFile.empty()) {
                     rememberReadingPosition(settings, app->currentFile, app->scrollY);
                 }
@@ -1207,6 +1209,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.readingWidthPct = savedSettings.readingWidthPct;
     app.zenWidthPct = savedSettings.zenWidthPct;
     app.tocOnLeft = savedSettings.tocOnLeft;
+    app.languageSetting = savedSettings.languageIndex;
+    app.currentLanguageIndex = savedSettings.languageIndex >= 0
+        ? clampLanguageIndex(savedSettings.languageIndex)
+        : detectSystemLanguage();
     applyKeymap(app, savedSettings);
 
     // Parse command line

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1189,6 +1189,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
 
     // Load user themes before settings: saved theme indices may point at them
     loadCustomThemes();
+    loadLanguageOverrides();
 
     // Load saved settings
     Settings savedSettings = loadSettings();

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1086,7 +1086,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.readingWidthPct = app->readingWidthPct;
                 settings.zenWidthPct = app->zenWidthPct;
                 settings.tocOnLeft = app->tocOnLeft;
-                settings.languageIndex = app->languageSetting;
+                settings.language = app->languageSetting >= 0
+                    ? languageIdAt(app->languageSetting) : "auto";
                 if (!app->currentFile.empty()) {
                     rememberReadingPosition(settings, app->currentFile, app->scrollY);
                 }
@@ -1210,10 +1211,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.readingWidthPct = savedSettings.readingWidthPct;
     app.zenWidthPct = savedSettings.zenWidthPct;
     app.tocOnLeft = savedSettings.tocOnLeft;
-    app.languageSetting = savedSettings.languageIndex;
-    app.currentLanguageIndex = savedSettings.languageIndex >= 0
-        ? clampLanguageIndex(savedSettings.languageIndex)
-        : detectSystemLanguage();
+    app.languageSetting = savedSettings.language == "auto"
+        ? -1 : languageIndexById(savedSettings.language);
+    app.currentLanguageIndex = app.languageSetting >= 0
+        ? app.languageSetting : detectSystemLanguage();
     applyKeymap(app, savedSettings);
 
     // Parse command line

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1792,17 +1792,40 @@ void renderSettingsOverlay(App& app) {
 
     if (app.settingsSection == 0) {  // General
         rowLabel(tr(app, "settings.language"), tr(app, "settings.language.hint"));
-        cy += rowH + dpi(app, 2.0f);
         {
-            float lx = cx;
-            settingsChip(app, lx, cy, tr(app, "settings.lang.auto"),
-                         app.languageSetting < 0, SET_LANG_AUTO, anim, fmt);
-            for (int i = 0; i < LANG_COUNT; i++) {
-                settingsChip(app, lx, cy, LANGUAGES[i].nativeName,
-                             app.languageSetting == i, SET_LANG_EN + i, anim, fmt);
-            }
+            // Dropdown value box with a pencil beside it (opens languages.ini)
+            float boxH = dpi(app, 26.0f);
+            float penW = dpi(app, 26.0f);
+            float boxW = dpi(app, 150.0f);
+            float boxX = cx + cw - penW - dpi(app, 8.0f) - boxW;
+            float boxY = cy + dpi(app, 2.0f);
+            D2D1_RECT_F box = D2D1::RectF(boxX, boxY, boxX + boxW, boxY + boxH);
+            app.settingsLangBox = box;
+            D2D1_COLOR_F c = app.theme.text; c.a = (app.settingsLangOpen ? 0.6f : 0.3f) * anim;
+            app.brush->SetColor(c);
+            app.renderTarget->DrawRoundedRectangle(
+                D2D1::RoundedRect(box, dpi(app, 4.0f), dpi(app, 4.0f)), app.brush, 1.0f);
+            std::wstring current = app.languageSetting < 0
+                ? std::wstring(tr(app, "settings.lang.auto"))
+                : std::wstring(languageNameAt(app.languageSetting));
+            current += L"  \x25BE";
+            c = app.theme.text; c.a = 0.95f * anim;
+            app.brush->SetColor(c);
+            app.renderTarget->DrawText(current.c_str(), (UINT32)current.size(), fmt,
+                D2D1::RectF(box.left + dpi(app, 10.0f), box.top + dpi(app, 4.0f),
+                            box.right - dpi(app, 6.0f), box.bottom), app.brush);
+            app.settingsHits.push_back({box, SET_LANG_DROPDOWN});
+
+            D2D1_RECT_F pen = D2D1::RectF(box.right + dpi(app, 8.0f), boxY,
+                                          box.right + dpi(app, 8.0f) + penW, boxY + boxH);
+            c = app.theme.text; c.a = 0.7f * anim;
+            app.brush->SetColor(c);
+            app.renderTarget->DrawText(L"\x270E", 1, fmt,
+                D2D1::RectF(pen.left + dpi(app, 6.0f), pen.top + dpi(app, 4.0f),
+                            pen.right, pen.bottom), app.brush);
+            app.settingsHits.push_back({pen, SET_OPEN_LANGS_INI});
         }
-        cy += rowH - dpi(app, 8.0f);
+        hairline(); cy += rowH;
         rowLabel(tr(app, "settings.folder_search"), tr(app, "settings.folder_search.hint"));
         settingsToggle(app, cx + cw - dpi(app, 40.0f), cy + dpi(app, 6.0f),
                        app.folderSearchEnabled, SET_TOGGLE_FOLDERSEARCH, anim);
@@ -1856,6 +1879,44 @@ void renderSettingsOverlay(App& app) {
     }
 
     // Footer hint
+    // Language dropdown popup, drawn last so it sits above the rows.
+    // Hit-testing iterates settingsHits in reverse, so these win overlaps.
+    if (app.settingsLangOpen && app.settingsSection == 0) {
+        float itemH = dpi(app, 26.0f);
+        int count = languageCount() + 1;  // Auto + languages
+        D2D1_RECT_F box = app.settingsLangBox;
+        D2D1_RECT_F pop = D2D1::RectF(box.left, box.bottom + dpi(app, 4.0f),
+                                      box.right,
+                                      box.bottom + dpi(app, 4.0f) + itemH * count);
+        D2D1_COLOR_F pc = app.theme.background; pc.a = anim;
+        app.brush->SetColor(pc);
+        app.renderTarget->FillRoundedRectangle(
+            D2D1::RoundedRect(pop, dpi(app, 6.0f), dpi(app, 6.0f)), app.brush);
+        pc = app.theme.text; pc.a = 0.35f * anim;
+        app.brush->SetColor(pc);
+        app.renderTarget->DrawRoundedRectangle(
+            D2D1::RoundedRect(pop, dpi(app, 6.0f), dpi(app, 6.0f)), app.brush, 1.0f);
+        for (int i = 0; i < count; i++) {
+            float ry = pop.top + i * itemH;
+            D2D1_RECT_F row = D2D1::RectF(pop.left, ry, pop.right, ry + itemH);
+            bool active = (i == 0 && app.languageSetting < 0) ||
+                          (i > 0 && app.languageSetting == i - 1);
+            if (active) {
+                D2D1_COLOR_F hl = app.theme.accent; hl.a = 0.18f * anim;
+                app.brush->SetColor(hl);
+                app.renderTarget->FillRectangle(row, app.brush);
+            }
+            const wchar_t* rowLabel2 = i == 0 ? tr(app, "settings.lang.auto")
+                                              : languageNameAt(i - 1);
+            pc = app.theme.text; pc.a = 0.95f * anim;
+            app.brush->SetColor(pc);
+            app.renderTarget->DrawText(rowLabel2, (UINT32)wcslen(rowLabel2), fmt,
+                D2D1::RectF(row.left + dpi(app, 10.0f), row.top + dpi(app, 4.0f),
+                            row.right - dpi(app, 6.0f), row.bottom), app.brush);
+            app.settingsHits.push_back({row, SET_LANG_PICK_BASE + i});
+        }
+    }
+
     D2D1_COLOR_F fc = app.theme.text; fc.a = 0.4f * anim;
     app.brush->SetColor(fc);
     const wchar_t* footer = tr(app, "settings.footer");

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1814,6 +1814,10 @@ void renderSettingsOverlay(App& app) {
         rowLabel(tr(app, "settings.open_themes_ini"), tr(app, "settings.open_themes_ini.hint"));
         bx = cx + cw - dpi(app, 60.0f);
         settingsChip(app, bx, cy + dpi(app, 2.0f), tr(app, "settings.open"), false, SET_OPEN_THEMES_INI, anim, fmt);
+        hairline(); cy += rowH;
+        rowLabel(tr(app, "settings.open_langs"), tr(app, "settings.open_langs.hint"));
+        bx = cx + cw - dpi(app, 60.0f);
+        settingsChip(app, bx, cy + dpi(app, 2.0f), tr(app, "settings.open"), false, SET_OPEN_LANGS_INI, anim, fmt);
     } else if (app.settingsSection == 1) {  // Appearance
         rowLabel(tr(app, "settings.reading_width_window"), tr(app, "settings.reading_width_window.hint"));
         cy += rowH + dpi(app, 6.0f);

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -3,6 +3,7 @@
 #include "d2d_init.h"
 #include "print.h"
 #include "settings.h"
+#include "i18n.h"
 
 #include <chrono>
 #include <algorithm>
@@ -80,7 +81,8 @@ void renderSearchOverlay(App& app) {
             D2D1_COLOR_F placeholderColor = app.theme.text;
             placeholderColor.a = 0.4f * anim;
             app.brush->SetColor(placeholderColor);
-            app.renderTarget->DrawText(L"Search...", 9, searchTextFormat,
+            const wchar_t* ph = tr(app, "search.placeholder");
+            app.renderTarget->DrawText(ph, (UINT32)wcslen(ph), searchTextFormat,
                 D2D1::RectF(textX, barY + dpi(app, 12.0f), textX + textWidth, barY + barHeight), app.brush);
         } else {
             // Actual search query
@@ -118,11 +120,11 @@ void renderSearchOverlay(App& app) {
             size_t matchCount = app.editMode ? app.editorSearchMatches.size() : app.searchMatches.size();
             int currentIdx = app.editMode ? app.editorSearchCurrentIndex : app.searchCurrentIndex;
             if (matchCount == 0) {
-                wcscpy_s(countText, L"No matches");
+                wcscpy_s(countText, tr(app, "search.no_matches"));
                 // Red color for no matches
                 app.brush->SetColor(D2D1::ColorF(0.9f, 0.3f, 0.3f, anim));
             } else {
-                swprintf_s(countText, L"%d of %zu", currentIdx + 1, matchCount);
+                swprintf_s(countText, tr(app, "search.match_count"), currentIdx + 1, matchCount);
                 D2D1_COLOR_F countColor = app.theme.text;
                 countColor.a = 0.7f * anim;
                 app.brush->SetColor(countColor);
@@ -523,7 +525,8 @@ void renderToc(App& app) {
         D2D1_COLOR_F headerColor = app.theme.heading;
         headerColor.a = anim;
         app.brush->SetColor(headerColor);
-        app.renderTarget->DrawText(L"Contents", 8, tocBold,
+        const wchar_t* tocTitle = tr(app, "toc.title");
+        app.renderTarget->DrawText(tocTitle, (UINT32)wcslen(tocTitle), tocBold,
             D2D1::RectF(panelX + padding, headerY, panelX + panelWidth - padding, headerY + headerHeight),
             app.brush);
 
@@ -544,7 +547,8 @@ void renderToc(App& app) {
             D2D1_COLOR_F dimColor = app.theme.text;
             dimColor.a = 0.5f * anim;
             app.brush->SetColor(dimColor);
-            app.renderTarget->DrawText(L"No headings", 11, tocNormal,
+            const wchar_t* tocEmpty = tr(app, "toc.empty");
+            app.renderTarget->DrawText(tocEmpty, (UINT32)wcslen(tocEmpty), tocNormal,
                 D2D1::RectF(panelX + padding, listStartY + dpi(app, 8.0f), panelX + panelWidth - padding, listStartY + dpi(app, 40.0f)),
                 app.brush);
         } else {
@@ -691,7 +695,8 @@ void renderThemeChooser(App& app) {
     if (titleFormat) {
         titleFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
         app.brush->SetColor(D2D1::ColorF(1, 1, 1, anim));
-        app.renderTarget->DrawText(L"Choose Theme", 12, titleFormat,
+        const wchar_t* chooseTheme = tr(app, "theme.chooser.title");
+        app.renderTarget->DrawText(chooseTheme, (UINT32)wcslen(chooseTheme), titleFormat,
             D2D1::RectF(panelX, panelY + dpi(app, 15.0f), panelX + panelWidth, panelY + dpi(app, 55.0f)), app.brush);
     }
 
@@ -860,11 +865,13 @@ void renderThemeChooser(App& app) {
         app.brush->SetColor(D2D1::ColorF(0.5f, 0.5f, 0.5f, anim));
 
         // Light themes header
-        app.renderTarget->DrawText(L"LIGHT THEMES", 12, headerFormat,
+        const wchar_t* lightHdr = tr(app, "theme.chooser.light");
+        app.renderTarget->DrawText(lightHdr, (UINT32)wcslen(lightHdr), headerFormat,
             D2D1::RectF(panelX + dpi(app, 20.0f), gridStartY - dpi(app, 20.0f), panelX + dpi(app, 20.0f) + cardWidth, gridStartY - dpi(app, 5.0f)), app.brush);
 
         // Dark themes header
-        app.renderTarget->DrawText(L"DARK THEMES", 11, headerFormat,
+        const wchar_t* darkHdr = tr(app, "theme.chooser.dark");
+        app.renderTarget->DrawText(darkHdr, (UINT32)wcslen(darkHdr), headerFormat,
             D2D1::RectF(panelX + dpi(app, 40.0f) + cardWidth, gridStartY - dpi(app, 20.0f), panelX + dpi(app, 40.0f) + cardWidth * 2, gridStartY - dpi(app, 5.0f)), app.brush);
     }
 }
@@ -907,7 +914,8 @@ void renderHelpOverlay(App& app) {
     if (titleFormat) {
         titleFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
         app.brush->SetColor(D2D1::ColorF(1, 1, 1, anim));
-        app.renderTarget->DrawText(L"Keyboard Shortcuts", 18, titleFormat,
+        const wchar_t* helpTitle = tr(app, "help.title");
+        app.renderTarget->DrawText(helpTitle, (UINT32)wcslen(helpTitle), titleFormat,
             D2D1::RectF(panelX, panelY + dpi(app, 15.0f), panelX + panelWidth, titleBottomY), app.brush);
     }
 
@@ -934,38 +942,38 @@ void renderHelpOverlay(App& app) {
     std::wstring kQuit = keyLabel(app.keymap[KA_QUIT]);
 
     const HelpEntry navEntries[] = {
-        {kDown.c_str(),   L"Scroll down"},
-        {kUp.c_str(),     L"Scroll up"},
-        {L"Space / PgDn", L"Page down"},
-        {L"PgUp",         L"Page up"},
-        {L"Home / End",   L"Jump to start / end"},
-        {L"Ctrl+Scroll",  L"Zoom in / out"},
+        {kDown.c_str(),   tr(app, "help.nav.scroll_down")},
+        {kUp.c_str(),     tr(app, "help.nav.scroll_up")},
+        {L"Space / PgDn", tr(app, "help.nav.page_down")},
+        {L"PgUp",         tr(app, "help.nav.page_up")},
+        {L"Home / End",   tr(app, "help.nav.jump_start_end")},
+        {L"Ctrl+Scroll",  tr(app, "help.nav.zoom")},
     };
 
     const HelpEntry overlayEntries[] = {
-        {kSearch.c_str(), L"Search"},
-        {L"Enter",        L"Next search match"},
-        {kBrowse.c_str(), L"Toggle folder browser"},
-        {kToc.c_str(),    L"Toggle table of contents"},
-        {kTheme.c_str(),  L"Theme chooser"},
-        {kStats.c_str(),  L"Toggle stats"},
-        {kHelp.c_str(),   L"This help"},
+        {kSearch.c_str(), tr(app, "help.view.search")},
+        {L"Enter",        tr(app, "help.view.next_match")},
+        {kBrowse.c_str(), tr(app, "help.view.folder_browser")},
+        {kToc.c_str(),    tr(app, "help.view.toc")},
+        {kTheme.c_str(),  tr(app, "help.view.theme")},
+        {kStats.c_str(),  tr(app, "help.view.stats")},
+        {kHelp.c_str(),   tr(app, "help.view.help")},
     };
 
     const HelpEntry editEntries[] = {
-        {kEdit.c_str(),   L"Enter edit mode"},
-        {L"Ctrl+S",       L"Save (in edit mode)"},
-        {L"Ctrl+E",       L"Show / hide preview pane"},
-        {L"Ctrl+W",       L"Toggle word wrap"},
-        {L"ESC ESC",      L"Exit edit mode"},
+        {kEdit.c_str(),   tr(app, "help.edit.enter_edit")},
+        {L"Ctrl+S",       tr(app, "help.edit.save")},
+        {L"Ctrl+E",       tr(app, "help.edit.preview")},
+        {L"Ctrl+W",       tr(app, "help.edit.word_wrap")},
+        {L"ESC ESC",      tr(app, "help.edit.exit_edit")},
     };
 
     const HelpEntry generalEntries[] = {
-        {L"Ctrl+A",       L"Select all text"},
-        {L"Ctrl+C",       L"Copy selection"},
-        {L"Ctrl+P",       L"Print / PDF"},
-        {L"ESC",          L"Close overlay / Quit"},
-        {kQuit.c_str(),   L"Quit"},
+        {L"Ctrl+A",       tr(app, "help.general.select_all")},
+        {L"Ctrl+C",       tr(app, "help.general.copy")},
+        {L"Ctrl+P",       tr(app, "ctx.print")},
+        {L"ESC",          tr(app, "help.general.close")},
+        {kQuit.c_str(),   tr(app, "help.general.quit")},
     };
 
     float padding = dpi(app, 20.0f);
@@ -1036,15 +1044,16 @@ void renderHelpOverlay(App& app) {
         y += sectionGap;
     };
 
-    drawSection(L"NAVIGATION", navEntries, (int)_countof(navEntries));
-    drawSection(L"VIEW", overlayEntries, (int)_countof(overlayEntries));
-    drawSection(L"EDITING", editEntries, (int)_countof(editEntries));
-    drawSection(L"GENERAL", generalEntries, (int)_countof(generalEntries));
+    drawSection(tr(app, "help.section.navigation"), navEntries, (int)_countof(navEntries));
+    drawSection(tr(app, "help.section.view"), overlayEntries, (int)_countof(overlayEntries));
+    drawSection(tr(app, "help.section.editing"), editEntries, (int)_countof(editEntries));
+    drawSection(tr(app, "help.section.general"), generalEntries, (int)_countof(generalEntries));
 
     // Footer hint
     normalFmt->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
     app.brush->SetColor(D2D1::ColorF(0.5f, 0.5f, 0.5f, anim));
-    app.renderTarget->DrawText(L"Press ESC or ? to close", 23, normalFmt,
+    const wchar_t* helpFooter = tr(app, "help.footer");
+    app.renderTarget->DrawText(helpFooter, (UINT32)wcslen(helpFooter), normalFmt,
         D2D1::RectF(panelX, y, panelX + panelWidth, y + lineH), app.brush);
 
     app.renderTarget->PopAxisAlignedClip();
@@ -1180,6 +1189,13 @@ void renderContextMenu(App& app) {
 
     app.hoveredContextMenuItem = contextMenuItemAt(app, app.mouseX, app.mouseY);
 
+    // Labels come from the translation table (order matches ContextMenuItem)
+    static const char* kCtxKeys[CTX_ITEM_COUNT] = {
+        "ctx.copy", "ctx.select_all", "ctx.new", "ctx.print", "ctx.edit",
+        "ctx.search", "ctx.toc", "ctx.browse", "ctx.reveal", "ctx.theme",
+        "ctx.settings", "ctx.help",
+    };
+
     // Shortcut hints reflect the user keymap ([Keys] in settings.ini)
     auto shortcutLabel = [&](int item) -> std::wstring {
         switch (item) {
@@ -1215,8 +1231,9 @@ void renderContextMenu(App& app) {
         textColor.a = (enabled ? 1.0f : 0.35f) * anim;
         app.brush->SetColor(textColor);
         float textY = top + (itemH - dpi(app, 18.0f)) / 2;
+        const wchar_t* itemLabel = tr(app, kCtxKeys[i]);
         app.renderTarget->DrawText(
-            CTX_ENTRIES[i].label, (UINT32)wcslen(CTX_ENTRIES[i].label), format,
+            itemLabel, (UINT32)wcslen(itemLabel), format,
             D2D1::RectF(x + inset, textY, x + w - inset, top + itemH), app.brush);
 
         std::wstring hintText = shortcutLabel(i);
@@ -1680,13 +1697,16 @@ void renderSettingsOverlay(App& app) {
         app.themeTitleFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_LEADING);
         D2D1_COLOR_F tc = app.theme.heading; tc.a = anim;
         app.brush->SetColor(tc);
-        app.renderTarget->DrawText(L"Settings", 8, app.themeTitleFormat,
+        const wchar_t* title = tr(app, "settings.title");
+        app.renderTarget->DrawText(title, (UINT32)wcslen(title), app.themeTitleFormat,
             D2D1::RectF(px + dpi(app, 24.0f), py + dpi(app, 16.0f),
                         px + panelW, py + dpi(app, 56.0f)), app.brush);
     }
 
     // Section rail
-    const wchar_t* sections[] = {L"General", L"Appearance", L"Editor"};
+    const wchar_t* sections[] = {tr(app, "settings.section.general"),
+                                 tr(app, "settings.section.appearance"),
+                                 tr(app, "settings.section.editor")};
     const int sectionActions[] = {SET_SECTION_GENERAL, SET_SECTION_APPEARANCE, SET_SECTION_EDITOR};
     float railX = px + dpi(app, 24.0f);
     float railY = py + dpi(app, 68.0f);
@@ -1757,8 +1777,8 @@ void renderSettingsOverlay(App& app) {
                               trackH / 2, trackH / 2), app.brush);
         app.renderTarget->FillEllipse(
             D2D1::Ellipse(D2D1::Point2F(fillX, y), knobR, knobR), app.brush);
-        wchar_t label[8];
-        if (pct >= 100) wcscpy_s(label, L"Full");
+        wchar_t label[16];
+        if (pct >= 100) wcscpy_s(label, tr(app, "settings.full"));
         else swprintf_s(label, L"%d%%", pct);
         c = app.theme.text; c.a = 0.7f * anim;
         app.brush->SetColor(c);
@@ -1771,50 +1791,62 @@ void renderSettingsOverlay(App& app) {
     };
 
     if (app.settingsSection == 0) {  // General
-        rowLabel(L"Folder search results", L"Sibling files matched while searching");
+        rowLabel(tr(app, "settings.language"), tr(app, "settings.language.hint"));
+        cy += rowH + dpi(app, 2.0f);
+        {
+            float lx = cx;
+            settingsChip(app, lx, cy, tr(app, "settings.lang.auto"),
+                         app.languageSetting < 0, SET_LANG_AUTO, anim, fmt);
+            for (int i = 0; i < LANG_COUNT; i++) {
+                settingsChip(app, lx, cy, LANGUAGES[i].nativeName,
+                             app.languageSetting == i, SET_LANG_EN + i, anim, fmt);
+            }
+        }
+        cy += rowH - dpi(app, 8.0f);
+        rowLabel(tr(app, "settings.folder_search"), tr(app, "settings.folder_search.hint"));
         settingsToggle(app, cx + cw - dpi(app, 40.0f), cy + dpi(app, 6.0f),
                        app.folderSearchEnabled, SET_TOGGLE_FOLDERSEARCH, anim);
         hairline(); cy += rowH;
-        rowLabel(L"Edit settings.ini", L"Keys, positions, and everything else");
+        rowLabel(tr(app, "settings.open_ini"), tr(app, "settings.open_ini.hint"));
         float bx = cx + cw - dpi(app, 60.0f);
-        settingsChip(app, bx, cy + dpi(app, 2.0f), L"Open", false, SET_OPEN_INI, anim, fmt);
+        settingsChip(app, bx, cy + dpi(app, 2.0f), tr(app, "settings.open"), false, SET_OPEN_INI, anim, fmt);
         hairline(); cy += rowH;
-        rowLabel(L"Edit themes.ini", L"Hand-tune custom themes, syntax colors included");
+        rowLabel(tr(app, "settings.open_themes_ini"), tr(app, "settings.open_themes_ini.hint"));
         bx = cx + cw - dpi(app, 60.0f);
-        settingsChip(app, bx, cy + dpi(app, 2.0f), L"Open", false, SET_OPEN_THEMES_INI, anim, fmt);
+        settingsChip(app, bx, cy + dpi(app, 2.0f), tr(app, "settings.open"), false, SET_OPEN_THEMES_INI, anim, fmt);
     } else if (app.settingsSection == 1) {  // Appearance
-        rowLabel(L"Reading width \x2014 window", L"Center the document in a column on wide screens");
+        rowLabel(tr(app, "settings.reading_width_window"), tr(app, "settings.reading_width_window.hint"));
         cy += rowH + dpi(app, 6.0f);
         slider(cx, cy, cw, app.readingWidthPct, SET_SLIDER_READING, 0);
         cy += dpi(app, 30.0f);
-        rowLabel(L"Reading width \x2014 fullscreen", L"Column used in zen mode (F11)");
+        rowLabel(tr(app, "settings.reading_width_full"), tr(app, "settings.reading_width_full.hint"));
         cy += rowH + dpi(app, 6.0f);
         slider(cx, cy, cw, app.zenWidthPct, SET_SLIDER_ZEN, 1);
         cy += dpi(app, 30.0f);
-        rowLabel(L"Follow Windows theme", L"Switch light and dark with the system");
+        rowLabel(tr(app, "settings.follow_windows"), tr(app, "settings.follow_windows.hint"));
         settingsToggle(app, cx + cw - dpi(app, 40.0f), cy + dpi(app, 6.0f),
                        app.followSystemTheme, SET_TOGGLE_FOLLOW, anim);
         hairline(); cy += rowH;
-        rowLabel(L"Table of contents", L"Which side the Tab panel slides from");
+        rowLabel(tr(app, "settings.toc_side"), tr(app, "settings.toc_side.hint"));
         {
             float tx = cx + cw - dpi(app, 118.0f);
-            settingsChip(app, tx, cy + dpi(app, 2.0f), L"Left", app.tocOnLeft,
+            settingsChip(app, tx, cy + dpi(app, 2.0f), tr(app, "settings.toc.left"), app.tocOnLeft,
                          SET_TOC_LEFT, anim, fmt);
-            settingsChip(app, tx, cy + dpi(app, 2.0f), L"Right", !app.tocOnLeft,
+            settingsChip(app, tx, cy + dpi(app, 2.0f), tr(app, "settings.toc.right"), !app.tocOnLeft,
                          SET_TOC_RIGHT, anim, fmt);
         }
         hairline(); cy += rowH;
-        rowLabel(L"Themes", L"Browse, edit the current one, or start fresh");
+        rowLabel(tr(app, "settings.themes"), tr(app, "settings.themes.hint"));
         float bx2 = cx + cw - dpi(app, 208.0f);
-        settingsChip(app, bx2, cy + dpi(app, 2.0f), L"Browse", false, SET_OPEN_THEMES, anim, fmt);
-        settingsChip(app, bx2, cy + dpi(app, 2.0f), L"Edit", false, SET_EDIT_THEME, anim, fmt);
-        settingsChip(app, bx2, cy + dpi(app, 2.0f), L"+ New", false, SET_NEW_THEME, anim, fmt);
+        settingsChip(app, bx2, cy + dpi(app, 2.0f), tr(app, "settings.browse"), false, SET_OPEN_THEMES, anim, fmt);
+        settingsChip(app, bx2, cy + dpi(app, 2.0f), tr(app, "settings.edit"), false, SET_EDIT_THEME, anim, fmt);
+        settingsChip(app, bx2, cy + dpi(app, 2.0f), tr(app, "settings.new"), false, SET_NEW_THEME, anim, fmt);
     } else {  // Editor
-        rowLabel(L"Word wrap", L"Wrap long lines in the editor pane");
+        rowLabel(tr(app, "settings.word_wrap"), tr(app, "settings.word_wrap.hint"));
         settingsToggle(app, cx + cw - dpi(app, 40.0f), cy + dpi(app, 6.0f),
                        app.editorWordWrap, SET_TOGGLE_WRAP, anim);
         hairline(); cy += rowH;
-        rowLabel(L"Preview pane", L"Show the rendered preview beside the editor");
+        rowLabel(tr(app, "settings.preview_pane"), tr(app, "settings.preview_pane.hint"));
         settingsToggle(app, cx + cw - dpi(app, 40.0f), cy + dpi(app, 6.0f),
                        app.editorShowPreview, SET_TOGGLE_PREVIEW, anim);
     }
@@ -1822,7 +1854,7 @@ void renderSettingsOverlay(App& app) {
     // Footer hint
     D2D1_COLOR_F fc = app.theme.text; fc.a = 0.4f * anim;
     app.brush->SetColor(fc);
-    const wchar_t* footer = L"Esc to close \x2022 changes apply immediately";
+    const wchar_t* footer = tr(app, "settings.footer");
     app.renderTarget->DrawText(footer, (UINT32)wcslen(footer), fmt,
         D2D1::RectF(px + dpi(app, 24.0f), py + panelH - dpi(app, 32.0f),
                     px + panelW, py + panelH), app.brush);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -45,6 +45,7 @@ void saveSettings(const Settings& settings) {
     file << "readingWidthPct=" << settings.readingWidthPct << "\n";
     file << "zenWidthPct=" << settings.zenWidthPct << "\n";
     file << "tocOnLeft=" << (settings.tocOnLeft ? 1 : 0) << "\n";
+    file << "languageIndex=" << settings.languageIndex << "\n";
 
     // Remappable keys, written with every save so the section documents
     // itself: change a value, restart Tinta
@@ -178,6 +179,8 @@ Settings loadSettings() {
             if (w >= 30 && w <= 100) settings.zenWidthPct = w;
         } else if (key == "tocOnLeft") {
             settings.tocOnLeft = (value == "1");
+        } else if (key == "languageIndex") {
+            settings.languageIndex = std::stoi(value);  // -1 = follow system
         } else if (key == "folderSearchEnabled") {
             settings.folderSearchEnabled = (value == "1");
         } else if (key == "followSystemTheme") {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -45,7 +45,7 @@ void saveSettings(const Settings& settings) {
     file << "readingWidthPct=" << settings.readingWidthPct << "\n";
     file << "zenWidthPct=" << settings.zenWidthPct << "\n";
     file << "tocOnLeft=" << (settings.tocOnLeft ? 1 : 0) << "\n";
-    file << "languageIndex=" << settings.languageIndex << "\n";
+    file << "language=" << settings.language << "\n";
 
     // Remappable keys, written with every save so the section documents
     // itself: change a value, restart Tinta
@@ -179,8 +179,13 @@ Settings loadSettings() {
             if (w >= 30 && w <= 100) settings.zenWidthPct = w;
         } else if (key == "tocOnLeft") {
             settings.tocOnLeft = (value == "1");
+        } else if (key == "language") {
+            if (!value.empty()) settings.language = value;  // "auto" or an id
         } else if (key == "languageIndex") {
-            settings.languageIndex = std::stoi(value);  // -1 = follow system
+            // Legacy numeric form from the first i18n build
+            int idx = std::stoi(value);
+            const char* ids[] = {"en", "zh", "ja", "ko"};
+            settings.language = (idx >= 0 && idx < 4) ? ids[idx] : "auto";
         } else if (key == "folderSearchEnabled") {
             settings.folderSearchEnabled = (value == "1");
         } else if (key == "followSystemTheme") {


### PR DESCRIPTION
Brings Tinta's UI to English + Simplified Chinese, built on the excellent groundwork from @wxh-777 in #84 — the stable-key translation table with English fallback, system-language detection, and all original en/zh strings are theirs.

## What changed from #84

- **Language selection lives in Settings → General** (the new dialog postdates the PR): chips for Auto / English / 简体中文 / 日本語 / 한국어, each rendered in its own script. Auto follows the Windows display language; an explicit choice persists.
- **Fixed a real bug**: the `%1$d` positional printf specifiers are not supported by MSVC's CRT and broke the search match counter in every locale, English included. The format now keeps a fixed argument order.
- **Refreshed drifted strings** (the preview-pane toggle became Ctrl+E while the PR aged).
- **Extended coverage to surfaces newer than the PR**: the right-click context menu and the settings dialog itself, alongside the original scope — help overlay (translated descriptions composed with the keymap-dynamic key labels), search, TOC, theme chooser, and editor toasts.

Japanese and Korean columns are scaffolded — filling them is a single table edit, no code changes. Verified with screenshots in zh-CN: settings dialog, context menu, and help overlay all render translated with correct CJK fonts via the existing fallback chain. All ctest suites pass; binary stays under 1 MB.

Credit and thanks to **@wxh-777** for the architecture and translations. Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## languages.ini — translations without a compiler
The compiled en/zh table is the always-working baseline; `%APPDATA%\Tinta\languages.ini` layers on top with `[locale]` sections of `key=value` pairs (UTF-8) that override any string or fill the ja/ko columns. Lookup: override → compiled locale → compiled English → key. Settings → General has an **Edit languages.ini** button that seeds a translator template on first use (every key under `[ja]`/`[ko]`, commented, with English reference text). Verified: a two-line `[ja]` file renders キーボードショートカット in the help overlay with clean English fallback for everything untranslated.


## Dynamic registry + dropdown
The language list grows at runtime: any `[section]` in `languages.ini` with translations becomes selectable (`name=` labels it), so community languages need zero code — verified end-to-end with a seven-line German section rendering *Einstellungen/Sprache/Allgemein* picked from the new Settings dropdown (value box + popup + pencil button that opens the file). The seeded template rosters twelve common languages with native names and every key commented with English reference. Persistence moved to the language id string; legacy numeric values still load; system detection prefix-matches registered ids.
