### PR TITLE
Editor pane uses the language-aware CJK font fallback

### DIFF
--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -60,6 +60,17 @@ static IDWriteTextLayout* createEditorLineLayout(const App& app, size_t lineStar
     if (layout && app.editorWordWrap) {
         layout->SetWordWrapping(DWRITE_WORD_WRAPPING_WRAP);
     }
+    // Language-aware CJK fallback (#48): without this the editor pane falls
+    // back through the system chain and shows Japanese-variant glyphs for
+    // Chinese text (#81 "门") while the preview beside it renders correctly
+    if (layout && app.fontFallback) {
+        IDWriteTextLayout2* layout2 = nullptr;
+        if (SUCCEEDED(layout->QueryInterface(__uuidof(IDWriteTextLayout2),
+                reinterpret_cast<void**>(&layout2)))) {
+            layout2->SetFontFallback(app.fontFallback);
+            layout2->Release();
+        }
+    }
     return layout;
 }
 


### PR DESCRIPTION
Closes the last open item in #81: Chinese text in the edit pane rendered with Japanese-variant glyphs (the reporter's example: 门), because the language-aware fallback chain from #48 (Microsoft YaHei-first for Han) was only attached to viewer layouts in render.cpp — the editor's line layouts fell back through the system chain.

One patch point: `createEditorLineLayout` now applies `app.fontFallback` via `IDWriteTextLayout2`, the same idiom render.cpp uses. Since every editor consumer (paint, hit-testing, caret, IME positioning) goes through this cached factory, the whole editor is covered.

Verified visually: editor and preview now render 门体验 with identical glyph forms (zoom-compared side by side). Latin stays Consolas — only CJK fallback changes. For anyone who wants a different editor font outright, `codefont=` in themes.ini already controls it.

Tests 4/4 green.