### PR TITLE
Offset-based text selection: glyph-precise, Typora-style (#83)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ set(SOURCES
     src/inline_style.cpp
     src/print.cpp
     src/i18n.cpp
+    src/selection.cpp
 )
 
 set(HEADERS
@@ -73,6 +74,7 @@ set(HEADERS
     include/inline_style.h
     include/print.h
     include/i18n.h
+    include/selection.h
 )
 
 # Windows resource file (icon)

--- a/include/app.h
+++ b/include/app.h
@@ -472,6 +472,10 @@ struct App {
         D2D1_RECT_F rect;
         size_t docStart = 0;   // Start position in docText
         size_t docLength = 0;  // Length in docText
+        // Index into layoutTextRuns of the run whose layout covers this
+        // rect's doc range (SIZE_MAX = none; hit-testing interpolates).
+        // Both vectors rebuild together on relayout, so the index is stable.
+        size_t runIndex = (size_t)-1;
     };
     std::vector<TextRect> textRects;
 
@@ -519,10 +523,12 @@ struct App {
     };
     std::vector<FolderResultHit> folderResultHits;  // rebuilt each paint
 
-    // Text selection
+    // Text selection (#83): a pair of character offsets into docText.
+    // Highlights and copies derive from the same range, and offsets survive
+    // relayout (zoom, resize) where pixel rects would not.
     bool selecting = false;
-    int selStartX = 0, selStartY = 0;
-    int selEndX = 0, selEndY = 0;
+    size_t selAnchor = 0;  // where the drag started
+    size_t selFocus = 0;   // where the mouse is now
     bool hasSelection = false;
     std::wstring selectedText;
 
@@ -531,8 +537,9 @@ struct App {
     int clickCount = 0;
     int lastClickX = 0, lastClickY = 0;
     enum class SelectionMode { Normal, Word, Line } selectionMode = SelectionMode::Normal;
-    // Anchor bounds for word/line selection (the original word/line that was clicked)
-    float anchorLeft = 0, anchorRight = 0, anchorTop = 0, anchorBottom = 0;
+    // The word/line originally clicked; drag extension unions the current
+    // word/line with this range
+    size_t selAnchorRangeStart = 0, selAnchorRangeEnd = 0;
 
     // Document text built during render (used for search/mapping)
     std::wstring docText;

--- a/include/app.h
+++ b/include/app.h
@@ -33,6 +33,7 @@ inline int64_t usElapsed(Clock::time_point start) {
 #define TIMER_ZOOM_APPLY 5
 #define TIMER_IMAGE_REFLOW 6
 #define TIMER_FOLDER_SEARCH 7
+#define TIMER_SELECT_SCROLL 8
 
 // Posted to continue an incomplete document layout in time-budgeted chunks
 #define WM_APP_LAYOUT_CHUNK (WM_APP + 1)
@@ -531,6 +532,11 @@ struct App {
     size_t selFocus = 0;   // where the mouse is now
     bool hasSelection = false;
     std::wstring selectedText;
+    // Dragging past the viewport edge scrolls (px per TIMER_SELECT_SCROLL
+    // tick, sign = direction)
+    float selAutoScrollVel = 0.0f;
+    // Shift+click extends: finalize as a selection even without a drag
+    bool selShiftExtend = false;
 
     // Multi-click selection (double/triple click)
     std::chrono::steady_clock::time_point lastClickTime;

--- a/include/input.h
+++ b/include/input.h
@@ -14,5 +14,6 @@ void handleContextMenu(App& app, HWND hwnd, LPARAM lParam);
 void handleCharInput(App& app, HWND hwnd, WPARAM wParam);
 void handleDropFiles(App& app, HWND hwnd, WPARAM wParam);
 void handleFileWatchTimer(App& app, HWND hwnd);
+void handleSelectScrollTimer(App& app, HWND hwnd);
 
 #endif // TINTA_INPUT_H

--- a/include/selection.h
+++ b/include/selection.h
@@ -1,0 +1,39 @@
+#ifndef TINTA_SELECTION_H
+#define TINTA_SELECTION_H
+
+#include "app.h"
+
+#include <vector>
+
+// Offset-based text selection (#83). The selection is a pair of character
+// positions into app.docText (selAnchor / selFocus); highlight rectangles
+// and the copied text both derive from that range, so what is highlighted,
+// what was aimed at, and what lands on the clipboard always agree. Caret
+// positions snap to glyph clusters via each run's IDWriteTextLayout
+// (App::LayoutTextRun, reachable from a TextRect through runIndex).
+
+// Document-space point -> caret offset. Points that miss text vertically
+// resolve against the nearest line; horizontally they snap to the nearest
+// run's edge, so a drag can start on padding or margins.
+size_t selectionOffsetAtPoint(const App& app, float docX, float docY);
+
+// Word around an offset (double-click). Boundaries follow isWordBoundary
+// over docText; a boundary character selects just itself.
+void selectionWordRange(const App& app, size_t offset, size_t& start, size_t& end);
+
+// Visual line (layout line bucket) containing an offset (triple-click).
+bool selectionLineRange(const App& app, size_t offset, size_t& start, size_t& end);
+
+// Continuous per-line highlight bars for [start, end), document coordinates.
+// Interior lines fill to their text extents; the two boundary lines get
+// precise caret-x edges from the run layouts.
+void selectionHighlightRects(const App& app, size_t start, size_t end,
+                             std::vector<D2D1_RECT_F>& out);
+
+// Exactly docText[start, end) — docText carries newlines between layout
+// lines and blocks, so this pastes as sensible plain text.
+std::wstring selectionTextForRange(const App& app, size_t start, size_t end);
+
+void clearSelection(App& app);
+
+#endif // TINTA_SELECTION_H

--- a/include/selection.h
+++ b/include/selection.h
@@ -30,6 +30,13 @@ bool selectionLineRange(const App& app, size_t offset, size_t& start, size_t& en
 void selectionHighlightRects(const App& app, size_t start, size_t end,
                              std::vector<D2D1_RECT_F>& out);
 
+// Precise rect for the docText range [start, end) clipped to one text rect
+// (search match highlighting shares the selection machinery). Vertical
+// extent comes from the rect, horizontal from the run layout; interpolates
+// when no layout covers the rect.
+bool selectionRangeRect(const App& app, const App::TextRect& tr,
+                        size_t start, size_t end, D2D1_RECT_F& out);
+
 // Exactly docText[start, end) — docText carries newlines between layout
 // lines and blocks, so this pastes as sensible plain text.
 std::wstring selectionTextForRange(const App& app, size_t start, size_t end);

--- a/include/utils.h
+++ b/include/utils.h
@@ -19,13 +19,10 @@ float measureText(App& app, const std::wstring& text, IDWriteTextFormat* format)
 std::wstring toLower(const std::wstring& str);
 std::wstring_view textViewForRect(const App& app, const App::TextRect& tr);
 
-// Word/line boundary helpers
+// Word/line boundary helpers (offset-based word/line selection lives in
+// selection.h)
 bool isWordBoundary(wchar_t c);
 const App::TextRect* findTextRectAt(const App& app, int x, int y);
-bool findWordBoundsAt(const App& app, const App::TextRect& tr, int x,
-                      float& wordLeft, float& wordRight);
-void findLineRects(const App& app, float y, float& lineLeft, float& lineRight,
-                   float& lineTop, float& lineBottom);
 
 void updateWindowTitle(App& app);
 // Ctrl+N: spawns a second Tinta window on an untitled quick note

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -26,6 +26,45 @@ static HCURSOR cursorArrow = LoadCursor(nullptr, IDC_ARROW);
 static HCURSOR cursorHand  = LoadCursor(nullptr, IDC_HAND);
 static HCURSOR cursorIBeam = LoadCursor(nullptr, IDC_IBEAM);
 
+// Drag auto-scroll (#83): while a selection drag sits in the edge band,
+// TIMER_SELECT_SCROLL scrolls the document and drags the focus offset along
+void handleSelectScrollTimer(App& app, HWND hwnd) {
+    if (!app.selecting || app.selAutoScrollVel == 0.0f || app.editMode) {
+        KillTimer(hwnd, TIMER_SELECT_SCROLL);
+        app.selAutoScrollVel = 0.0f;
+        return;
+    }
+    float maxScroll = std::max(0.0f, app.contentHeight - app.height);
+    float next = std::clamp(app.scrollY + app.selAutoScrollVel, 0.0f, maxScroll);
+    if (next == app.scrollY) return;  // pinned at an end; keep the timer for reversals
+    app.scrollY = next;
+    app.targetScrollY = next;
+
+    POINT pt;
+    if (GetCursorPos(&pt) && ScreenToClient(hwnd, &pt)) {
+        app.mouseX = pt.x;
+        app.mouseY = pt.y;
+    }
+    float docX = ((float)app.mouseX - documentViewportX(app)) + app.scrollX;
+    float docY = (float)app.mouseY + app.scrollY;
+    size_t off = selectionOffsetAtPoint(app, docX, docY);
+    if (app.selectionMode == App::SelectionMode::Word) {
+        size_t ws, we;
+        selectionWordRange(app, off, ws, we);
+        app.selAnchor = std::min(app.selAnchorRangeStart, ws);
+        app.selFocus = std::max(app.selAnchorRangeEnd, we);
+    } else if (app.selectionMode == App::SelectionMode::Line) {
+        size_t ls, le;
+        if (selectionLineRange(app, off, ls, le)) {
+            app.selAnchor = std::min(app.selAnchorRangeStart, ls);
+            app.selFocus = std::max(app.selAnchorRangeEnd, le);
+        }
+    } else {
+        app.selFocus = off;
+    }
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
 // Loads a document into the viewer and resets per-document state.
 // Shared by the folder browser's item clicks, path input, and new-file flow.
 static bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
@@ -683,6 +722,23 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     // the mouse; word/line modes union the current word/line with the
     // originally clicked one (#83)
     if (app.selecting) {
+        // Dragging near/past the top or bottom edge scrolls the document
+        // (viewer only — the edit-mode preview is slaved to the editor)
+        if (!app.editMode) {
+            float band = 40.0f;
+            float vel = 0.0f;
+            if (app.mouseY < band) {
+                vel = -(band - (float)app.mouseY) * 0.35f;
+            } else if ((float)app.mouseY > app.height - band) {
+                vel = ((float)app.mouseY - (app.height - band)) * 0.35f;
+            }
+            if (vel != 0.0f && app.selAutoScrollVel == 0.0f) {
+                SetTimer(hwnd, TIMER_SELECT_SCROLL, 16, nullptr);
+            } else if (vel == 0.0f && app.selAutoScrollVel != 0.0f) {
+                KillTimer(hwnd, TIMER_SELECT_SCROLL);
+            }
+            app.selAutoScrollVel = vel;
+        }
         size_t off = selectionOffsetAtPoint(app, docX, docY);
         if (app.selectionMode == App::SelectionMode::Word) {
             size_t ws, we;
@@ -1230,6 +1286,13 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 app.hasSelection = true;
                 app.selectedText = selectionTextForRange(app, ls, le);
             }
+        } else if ((GetKeyState(VK_SHIFT) & 0x8000) && app.hasSelection) {
+            // Shift+click: keep the anchor, move the focus (Typora-style
+            // extension; the drag can keep adjusting it)
+            app.selectionMode = App::SelectionMode::Normal;
+            app.selecting = true;
+            app.selShiftExtend = true;
+            app.selFocus = selectionOffsetAtPoint(app, docX, docY);
         } else {
             // Single click: anchor a fresh selection at the caret offset
             app.selectionMode = App::SelectionMode::Normal;
@@ -1700,6 +1763,11 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         app.selecting = false;
         InvalidateRect(hwnd, nullptr, FALSE);
     } else if (app.selecting) {
+        // Edge auto-scroll ends with the drag
+        if (app.selAutoScrollVel != 0.0f) {
+            KillTimer(hwnd, TIMER_SELECT_SCROLL);
+            app.selAutoScrollVel = 0.0f;
+        }
         // Finalize selection based on mode
         if (app.selectionMode == App::SelectionMode::Word ||
             app.selectionMode == App::SelectionMode::Line) {
@@ -1714,11 +1782,12 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             float docY = app.mouseY + app.scrollY;
             app.selFocus = selectionOffsetAtPoint(app, docX, docY);
 
-            // Check if this was a meaningful drag (not just a click)
-            // Use screen coordinates stored from mouse down
+            // Check if this was a meaningful drag (not just a click).
+            // Shift+click extension counts without one.
             int dx = abs(app.mouseX - app.lastClickX);
             int dy = abs(app.mouseY - app.lastClickY);
-            if ((dx > 5 || dy > 5) && app.selFocus != app.selAnchor) {
+            if ((dx > 5 || dy > 5 || app.selShiftExtend) &&
+                app.selFocus != app.selAnchor) {
                 app.hasSelection = true;
                 app.selectedText = selectionTextForRange(
                     app, std::min(app.selAnchor, app.selFocus),
@@ -1747,6 +1816,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
     app.mouseDown = false;
     app.selecting = false;
+    app.selShiftExtend = false;
 }
 
 // Zen mode: borderless fullscreen + centered reading column (F11)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -40,11 +40,8 @@ void handleSelectScrollTimer(App& app, HWND hwnd) {
     app.scrollY = next;
     app.targetScrollY = next;
 
-    POINT pt;
-    if (GetCursorPos(&pt) && ScreenToClient(hwnd, &pt)) {
-        app.mouseX = pt.x;
-        app.mouseY = pt.y;
-    }
+    // app.mouseX/Y hold the drag position — with mouse capture they update
+    // even outside the window, and holding still keeps the last position
     float docX = ((float)app.mouseX - documentViewportX(app)) + app.scrollX;
     float docY = (float)app.mouseY + app.scrollY;
     size_t off = selectionOffsetAtPoint(app, docX, docY);
@@ -1236,6 +1233,10 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         }
         InvalidateRect(hwnd, nullptr, FALSE);
     } else {
+        // Capture the mouse for the duration of a selection drag: without
+        // it, mouse events stop at the window edge and the drag can neither
+        // auto-scroll past the viewport nor finalize outside the window
+        SetCapture(hwnd);
         // Detect double/triple clicks
         auto now = std::chrono::steady_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1817,6 +1818,9 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     app.mouseDown = false;
     app.selecting = false;
     app.selShiftExtend = false;
+    // Selection drags capture the mouse; the settings slider releases its
+    // own capture earlier, so this is a no-op for everything else
+    if (GetCapture() == hwnd) ReleaseCapture();
 }
 
 // Zen mode: borderless fullscreen + centered reading column (F11)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -10,6 +10,7 @@
 #include "overlays.h"
 #include "print.h"
 #include "i18n.h"
+#include "selection.h"
 
 #include <windowsx.h>
 #include <shellapi.h>
@@ -56,6 +57,7 @@ static bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
     app.docText.clear();
     app.docTextLower.clear();
     app.searchMatches.clear();
+    clearSelection(app);  // offsets belong to the old docText
     app.layoutDirty = true;
     updateFileWriteTime(app);
     updateWindowTitle(app);
@@ -677,38 +679,26 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     float docX = (app.mouseX - previewOffsetX) + app.scrollX;
     float docY = app.mouseY + app.scrollY;
 
-    // Text selection dragging
+    // Text selection dragging: the focus follows the caret offset under
+    // the mouse; word/line modes union the current word/line with the
+    // originally clicked one (#83)
     if (app.selecting) {
+        size_t off = selectionOffsetAtPoint(app, docX, docY);
         if (app.selectionMode == App::SelectionMode::Word) {
-            // Extend selection by words - merge anchor with current word
-            const App::TextRect* tr = findTextRectAt(app, (int)docX, (int)docY);
-            if (tr) {
-                float wordLeft, wordRight;
-                if (findWordBoundsAt(app, *tr, (int)docX, wordLeft, wordRight)) {
-                    // Selection spans from min(anchor, current) to max(anchor, current)
-                    app.selStartX = (int)std::min(app.anchorLeft, wordLeft);
-                    app.selEndX = (int)std::max(app.anchorRight, wordRight);
-                    app.selStartY = (int)(std::min(app.anchorTop, tr->rect.top));
-                    app.selEndY = (int)(std::max(app.anchorBottom, tr->rect.bottom));
-                    app.hasSelection = true;
-                }
-            }
+            size_t ws, we;
+            selectionWordRange(app, off, ws, we);
+            app.selAnchor = std::min(app.selAnchorRangeStart, ws);
+            app.selFocus = std::max(app.selAnchorRangeEnd, we);
+            app.hasSelection = true;
         } else if (app.selectionMode == App::SelectionMode::Line) {
-            // Extend selection by lines - merge anchor with current line
-            float lineLeft, lineRight, lineTop, lineBottom;
-            findLineRects(app, docY, lineLeft, lineRight, lineTop, lineBottom);
-            if (lineRight > lineLeft) {
-                // Selection spans from min(anchor, current) to max(anchor, current)
-                app.selStartX = (int)std::min(app.anchorLeft, lineLeft);
-                app.selEndX = (int)std::max(app.anchorRight, lineRight);
-                app.selStartY = (int)(std::min(app.anchorTop, lineTop));
-                app.selEndY = (int)(std::max(app.anchorBottom, lineBottom));
+            size_t ls, le;
+            if (selectionLineRange(app, off, ls, le)) {
+                app.selAnchor = std::min(app.selAnchorRangeStart, ls);
+                app.selFocus = std::max(app.selAnchorRangeEnd, le);
                 app.hasSelection = true;
             }
         } else {
-            // Normal selection - store in document coordinates
-            app.selEndX = (int)docX;
-            app.selEndY = (int)docY;
+            app.selFocus = off;
         }
         InvalidateRect(hwnd, nullptr, FALSE);
         return;
@@ -897,13 +887,12 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
             break;
         case CTX_SELECT_ALL:
             if (app.root) {
-                app.selectedText.clear();
-                extractText(app.root, app.selectedText);
+                // docText only exists for laid-out content — finish first
+                ensureLayoutComplete(app);
+                app.selAnchor = 0;
+                app.selFocus = app.docText.size();
                 app.hasSelection = true;
-                // Equal coords are the renderer's select-all signal; a stale
-                // drag range would re-extract the old selection every frame
-                app.selStartX = app.selEndX = 0;
-                app.selStartY = app.selEndY = 0;
+                app.selectedText = selectionTextForRange(app, 0, app.docText.size());
             }
             break;
         case CTX_NEW:
@@ -1213,53 +1202,39 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
         // Handle based on click count
         if (app.clickCount == 2) {
-            // Double-click: select word
-            const App::TextRect* tr = findTextRectAt(app, (int)docX, (int)docY);
-            if (tr) {
-                float wordLeft, wordRight;
-                if (findWordBoundsAt(app, *tr, (int)docX, wordLeft, wordRight)) {
-                    app.selectionMode = App::SelectionMode::Word;
-                    // Store anchor (the original word bounds) in document coords for drag extension
-                    app.anchorLeft = wordLeft;
-                    app.anchorRight = wordRight;
-                    app.anchorTop = tr->rect.top;
-                    app.anchorBottom = tr->rect.bottom;
-                    // Set selection to the word (document coordinates)
-                    app.selStartX = (int)wordLeft;
-                    app.selEndX = (int)wordRight;
-                    app.selStartY = (int)tr->rect.top;
-                    app.selEndY = (int)tr->rect.bottom;
-                    app.selecting = true;
-                    app.hasSelection = true;
-                }
-            }
-        } else if (app.clickCount == 3) {
-            // Triple-click: select line
-            float lineLeft, lineRight, lineTop, lineBottom;
-            findLineRects(app, docY, lineLeft, lineRight, lineTop, lineBottom);
-            if (lineRight > lineLeft) {
-                app.selectionMode = App::SelectionMode::Line;
-                // Store anchor (the original line bounds) in document coords for drag extension
-                app.anchorLeft = lineLeft;
-                app.anchorRight = lineRight;
-                app.anchorTop = lineTop;
-                app.anchorBottom = lineBottom;
-                // Set selection to the line (document coordinates)
-                app.selStartX = (int)lineLeft;
-                app.selEndX = (int)lineRight;
-                app.selStartY = (int)lineTop;
-                app.selEndY = (int)lineBottom;
+            // Double-click: select the word at the caret offset
+            size_t off = selectionOffsetAtPoint(app, docX, docY);
+            size_t ws, we;
+            selectionWordRange(app, off, ws, we);
+            if (we > ws) {
+                app.selectionMode = App::SelectionMode::Word;
+                app.selAnchorRangeStart = ws;
+                app.selAnchorRangeEnd = we;
+                app.selAnchor = ws;
+                app.selFocus = we;
                 app.selecting = true;
                 app.hasSelection = true;
+                app.selectedText = selectionTextForRange(app, ws, we);
+            }
+        } else if (app.clickCount == 3) {
+            // Triple-click: select the visual line
+            size_t off = selectionOffsetAtPoint(app, docX, docY);
+            size_t ls, le;
+            if (selectionLineRange(app, off, ls, le) && le > ls) {
+                app.selectionMode = App::SelectionMode::Line;
+                app.selAnchorRangeStart = ls;
+                app.selAnchorRangeEnd = le;
+                app.selAnchor = ls;
+                app.selFocus = le;
+                app.selecting = true;
+                app.hasSelection = true;
+                app.selectedText = selectionTextForRange(app, ls, le);
             }
         } else {
-            // Single click: start normal selection (document coordinates)
+            // Single click: anchor a fresh selection at the caret offset
             app.selectionMode = App::SelectionMode::Normal;
             app.selecting = true;
-            app.selStartX = (int)docX;
-            app.selStartY = (int)docY;
-            app.selEndX = (int)docX;
-            app.selEndY = (int)docY;
+            app.selAnchor = app.selFocus = selectionOffsetAtPoint(app, docX, docY);
             app.hasSelection = false;
             app.selectedText.clear();
         }
@@ -1728,22 +1703,26 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         // Finalize selection based on mode
         if (app.selectionMode == App::SelectionMode::Word ||
             app.selectionMode == App::SelectionMode::Line) {
-            // Word/Line selection: keep the bounds set during mouse down/move
-            // hasSelection was already set to true in WM_LBUTTONDOWN
+            // Word/Line selection: ranges were set during mouse down/move
+            app.selectedText = selectionTextForRange(
+                app, std::min(app.selAnchor, app.selFocus),
+                std::max(app.selAnchor, app.selFocus));
         } else {
-            // Normal selection: finalize with current mouse position (document coordinates)
+            // Normal selection: finalize the focus at the release point
             float previewOffsetX = documentViewportX(app);
             float docX = (app.mouseX - previewOffsetX) + app.scrollX;
             float docY = app.mouseY + app.scrollY;
-            app.selEndX = (int)docX;
-            app.selEndY = (int)docY;
+            app.selFocus = selectionOffsetAtPoint(app, docX, docY);
 
             // Check if this was a meaningful drag (not just a click)
             // Use screen coordinates stored from mouse down
             int dx = abs(app.mouseX - app.lastClickX);
             int dy = abs(app.mouseY - app.lastClickY);
-            if (dx > 5 || dy > 5) {
+            if ((dx > 5 || dy > 5) && app.selFocus != app.selAnchor) {
                 app.hasSelection = true;
+                app.selectedText = selectionTextForRange(
+                    app, std::min(app.selAnchor, app.selFocus),
+                    std::max(app.selAnchor, app.selFocus));
             } else if (const App::TaskRect* task = taskRectAt(app)) {
                 // Click on a task checkbox: flip the mark in the file
                 toggleTaskOnDisk(app, hwnd, task->markOffset, task->checked);
@@ -1943,15 +1922,14 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 launchQuickNoteWindow();
                 break;
             case 'A': {
-                // Select All - extract all text from document
+                // Select All - the whole docText range
                 if (app.root) {
-                    app.selectedText.clear();
-                    extractText(app.root, app.selectedText);
+                    // docText only exists for laid-out content — finish first
+                    ensureLayoutComplete(app);
+                    app.selAnchor = 0;
+                    app.selFocus = app.docText.size();
                     app.hasSelection = true;
-                    // Equal coords signal select-all to the renderer; clear
-                    // any drag range so it doesn't overwrite the selection
-                    app.selStartX = app.selEndX = 0;
-                    app.selStartY = app.selEndY = 0;
+                    app.selectedText = selectionTextForRange(app, 0, app.docText.size());
                 }
                 break;
             }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <thread>
 #include "settings.h"
+#include "selection.h"
 #include "document.h"
 #include "d2d_init.h"
 #include "utils.h"
@@ -590,93 +591,28 @@ render_document:
         app.drawCalls++;
     }
 
-    // Draw selection highlights
-    if ((app.selecting || app.hasSelection) && !app.textRects.empty()) {
-        // Calculate selection bounds (normalized so start is always before end)
-        // Selection is stored in document coordinates
-        float selStartX = (float)app.selStartX;
-        float selStartY = (float)app.selStartY;
-        float selEndX = (float)app.selEndX;
-        float selEndY = (float)app.selEndY;
+    // Draw selection highlights: continuous per-line bars derived from the
+    // [selAnchor, selFocus) offset range, with glyph-precise edges on the
+    // boundary lines (#83). The copied text comes from the same range, so
+    // highlight and clipboard always agree.
+    if ((app.selecting || app.hasSelection) && !app.textRects.empty() &&
+        app.selAnchor != app.selFocus) {
+        size_t selA = std::min(app.selAnchor, app.selFocus);
+        size_t selB = std::max(app.selAnchor, app.selFocus);
 
-        // Swap if selection was made bottom-to-top
-        if (selStartY > selEndY || (selStartY == selEndY && selStartX > selEndX)) {
-            std::swap(selStartX, selEndX);
-            std::swap(selStartY, selEndY);
-        }
-
-        // Check if this is a "select all" (selectedText is set but selection coords are same)
-        bool isSelectAll = app.hasSelection && !app.selectedText.empty() &&
-                          app.selStartX == app.selEndX && app.selStartY == app.selEndY;
+        std::vector<D2D1_RECT_F> bars;
+        selectionHighlightRects(app, selA, selB, bars);
 
         app.brush->SetColor(D2D1::ColorF(0.2f, 0.4f, 0.9f, 0.35f));
-
-        const auto& lines = app.lineBuckets;
-
-        std::wstring collectedText;
-        size_t selectedCount = 0;
-
-        for (size_t i = 0; i < lines.size(); i++) {
-            const auto& line = lines[i];
-            float lineCenterY = (line.top + line.bottom) / 2;
-
-            bool lineInSelection = false;
-            float drawLeft = line.minX;
-            float drawRight = line.maxX;
-
-            if (isSelectAll) {
-                lineInSelection = true;
-            } else if (lineCenterY >= selStartY - 3 && lineCenterY <= selEndY + 3) {
-                float lineHeight = line.bottom - line.top;
-                bool isSingleLine = (selEndY - selStartY) <= lineHeight;
-
-                if (isSingleLine) {
-                    // Single line selection
-                    drawLeft = std::max(line.minX, selStartX);
-                    drawRight = std::min(line.maxX, selEndX);
-                    if (drawLeft < drawRight) lineInSelection = true;
-                } else if (lineCenterY < selStartY + lineHeight) {
-                    // First line - from selection start to end of line
-                    drawLeft = std::max(line.minX, selStartX);
-                    lineInSelection = true;
-                } else if (lineCenterY > selEndY - lineHeight) {
-                    // Last line - from start of line to selection end
-                    drawRight = std::min(line.maxX, selEndX);
-                    lineInSelection = true;
-                } else {
-                    // Middle line - full width
-                    lineInSelection = true;
-                }
-            }
-
-            if (lineInSelection) {
-                // Draw continuous selection bar for this line
-                app.renderTarget->FillRectangle(
-                    D2D1::RectF(drawLeft - app.scrollX, line.top - app.scrollY,
-                                drawRight - app.scrollX, line.bottom - app.scrollY),
-                    app.brush);
-                selectedCount++;
-
-                // Collect text from rects in this line that fall within selection
-                if (!collectedText.empty()) collectedText += L"\n";
-                for (size_t idx : line.textRectIndices) {
-                    const auto& tr = app.textRects[idx];
-                    const D2D1_RECT_F& rect = tr.rect;
-                    if (rect.left < drawRight && rect.right > drawLeft) {
-                        if (!collectedText.empty() && collectedText.back() != L'\n') {
-                            collectedText += L" ";
-                        }
-                        std::wstring_view slice = textViewForRect(app, tr);
-                        collectedText.append(slice.data(), slice.size());
-                    }
-                }
-            }
-        }
-        app.drawCalls += selectedCount;
-
-        // Update selectedText for mouse selections (not select-all)
-        if (!isSelectAll && app.hasSelection && selectedCount > 0) {
-            app.selectedText = collectedText;
+        float viewTop = app.scrollY - 50.0f;
+        float viewBottom = app.scrollY + app.height + 50.0f;
+        for (const auto& bar : bars) {
+            if (bar.bottom < viewTop || bar.top > viewBottom) continue;
+            app.renderTarget->FillRectangle(
+                D2D1::RectF(bar.left - app.scrollX, bar.top - app.scrollY,
+                            bar.right - app.scrollX, bar.bottom - app.scrollY),
+                app.brush);
+            app.drawCalls++;
         }
     }
 

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -655,18 +655,16 @@ render_document:
                 size_t overlapEnd = std::min(rectEnd, mEnd);
 
                 if (overlapStart < overlapEnd) {
-                    float totalWidth = tr.rect.right - tr.rect.left;
-                    float charWidth = totalWidth / (float)textLen;
-                    float startX = tr.rect.left + (overlapStart - rectStart) * charWidth;
-                    float matchWidth = (overlapEnd - overlapStart) * charWidth;
-
-                    // Extend highlight slightly for better visibility
-                    D2D1_RECT_F highlightRect = D2D1::RectF(
-                        startX - 1, tr.rect.top,
-                        startX + matchWidth + 1, tr.rect.bottom
-                    );
-
-                    visibleMatches.push_back({highlightRect, mi});
+                    // Glyph-precise via the run layout (shared with text
+                    // selection); falls back to interpolation for code
+                    D2D1_RECT_F highlightRect;
+                    if (selectionRangeRect(app, tr, overlapStart, overlapEnd,
+                                           highlightRect)) {
+                        // Extend slightly for better visibility
+                        highlightRect.left -= 1;
+                        highlightRect.right += 1;
+                        visibleMatches.push_back({highlightRect, mi});
+                    }
                 }
 
                 if (mEnd <= rectEnd) {
@@ -942,6 +940,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (wParam == TIMER_FOLDER_SEARCH && app) {
                 KillTimer(hwnd, TIMER_FOLDER_SEARCH);
                 startFolderSearchScan(*app);
+            }
+            if (wParam == TIMER_SELECT_SCROLL && app) {
+                handleSelectScrollTimer(*app, hwnd);
             }
             if (wParam == TIMER_IMAGE_REFLOW && app) {
                 // One relayout for however many images arrived since armed

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -56,9 +56,10 @@ static LayoutInfo createLayout(App& app, std::wstring_view text, IDWriteTextForm
     return info;
 }
 
-static void addTextRect(App& app, const D2D1_RECT_F& rect, size_t docStart, size_t docLength) {
+static void addTextRect(App& app, const D2D1_RECT_F& rect, size_t docStart, size_t docLength,
+                        size_t runIndex = (size_t)-1) {
     size_t idx = app.textRects.size();
-    app.textRects.push_back({rect, docStart, docLength});
+    app.textRects.push_back({rect, docStart, docLength, runIndex});
 
     if (app.lineBuckets.empty() ||
         std::abs(rect.top - app.lineBuckets.back().top) > kLineBucketTolerance) {
@@ -95,7 +96,7 @@ static void addTextRun(App& app, LayoutInfo&& info, const D2D1_POINT_2F& pos,
     app.layoutTextRuns.push_back(run);
 
     if (selectable) {
-        addTextRect(app, bounds, docStart, docLength);
+        addTextRect(app, bounds, docStart, docLength, app.layoutTextRuns.size() - 1);
     }
 }
 
@@ -614,13 +615,17 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
             }
             D2D1_POINT_2F segPos = D2D1::Point2F(segX, y + drawYOffset);
             D2D1_RECT_F segBounds = D2D1::RectF(segX, y, segX + segWidth, y + lineHeight);
+            size_t runsBefore = app.layoutTextRuns.size();
             addTextRun(app, std::move(info), segPos, segBounds, color,
                        textDocStart + segStart, segEnd - segStart, false);
+            // Word rects hit-test against the covering segment layout
+            size_t segRun = app.layoutTextRuns.size() > runsBefore
+                ? app.layoutTextRuns.size() - 1 : (size_t)-1;
             for (const auto& w : segWords) {
                 float wx = segX + widthOf(segStart, w.start);
                 D2D1_RECT_F wb = D2D1::RectF(wx, y, wx + widthOf(w.start, w.start + w.len),
                                              y + lineHeight);
-                addTextRect(app, wb, textDocStart + w.start, w.len);
+                addTextRect(app, wb, textDocStart + w.start, w.len, segRun);
             }
             segWords.clear();
         };
@@ -1342,6 +1347,7 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
 
         size_t lineDocStart = codeDocStart + lineStart;
         float lineWidth = 0.0f;
+        size_t lineRun = (size_t)-1;
 
         if (language > 0) {
             std::vector<SyntaxToken> tokens = tokenizeLine(wline, language, inBlockComment);
@@ -1389,14 +1395,20 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
             D2D1_POINT_2F pos = D2D1::Point2F(indent + padding, textY);
             D2D1_RECT_F bounds = D2D1::RectF(indent + padding, textY,
                                              indent + padding + lineWidth, textY + lineHeight);
+            size_t runsBefore = app.layoutTextRuns.size();
             addTextRun(app, std::move(info), pos, bounds, app.theme.code,
                        lineDocStart, wline.length(), false);
+            if (app.layoutTextRuns.size() > runsBefore) {
+                lineRun = app.layoutTextRuns.size() - 1;
+            }
         }
 
         if (!wline.empty()) {
             D2D1_RECT_F lineBounds = D2D1::RectF(indent + padding, textY,
                 indent + padding + lineWidth, textY + lineHeight);
-            addTextRect(app, lineBounds, lineDocStart, wline.length());
+            // Syntax-highlighted lines have no single covering layout;
+            // monospace interpolation stays accurate there
+            addTextRect(app, lineBounds, lineDocStart, wline.length(), lineRun);
         }
 
         maxLineWidth = std::max(maxLineWidth, lineWidth);

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -171,6 +171,30 @@ void selectionHighlightRects(const App& app, size_t start, size_t end,
     }
 }
 
+bool selectionRangeRect(const App& app, const App::TextRect& tr,
+                        size_t start, size_t end, D2D1_RECT_F& out) {
+    size_t lo = std::max(start, tr.docStart);
+    size_t hi = std::min(end, tr.docStart + tr.docLength);
+    if (lo >= hi) return false;
+    if (const App::LayoutTextRun* run = runFor(app, tr)) {
+        DWRITE_HIT_TEST_METRICS m{};
+        UINT32 count = 0;
+        if (SUCCEEDED(run->layout->HitTestTextRange(
+                (UINT32)(lo - run->docStart), (UINT32)(hi - lo),
+                run->pos.x, run->pos.y, &m, 1, &count)) && count == 1) {
+            out = D2D1::RectF(m.left, tr.rect.top, m.left + m.width, tr.rect.bottom);
+            return true;
+        }
+    }
+    // Uniform interpolation without a covering layout (monospace code)
+    float w = tr.rect.right - tr.rect.left;
+    float cw = tr.docLength ? w / (float)tr.docLength : 0.0f;
+    float x0 = tr.rect.left + (float)(lo - tr.docStart) * cw;
+    float x1 = x0 + (float)(hi - lo) * cw;
+    out = D2D1::RectF(x0, tr.rect.top, x1, tr.rect.bottom);
+    return true;
+}
+
 std::wstring selectionTextForRange(const App& app, size_t start, size_t end) {
     start = std::min(start, app.docText.size());
     end = std::min(end, app.docText.size());
@@ -183,5 +207,7 @@ void clearSelection(App& app) {
     app.hasSelection = false;
     app.selAnchor = 0;
     app.selFocus = 0;
+    app.selAutoScrollVel = 0.0f;
+    app.selShiftExtend = false;
     app.selectedText.clear();
 }

--- a/src/selection.cpp
+++ b/src/selection.cpp
@@ -1,0 +1,187 @@
+#include "selection.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+// The layout run backing a text rect, when one exists. Word-level rects
+// (wrapped text) point at their covering segment run; syntax-highlighted
+// code lines have no single run and fall back to monospace approximation.
+const App::LayoutTextRun* runFor(const App& app, const App::TextRect& tr) {
+    if (tr.runIndex >= app.layoutTextRuns.size()) return nullptr;
+    const App::LayoutTextRun& run = app.layoutTextRuns[tr.runIndex];
+    if (!run.layout || run.docLength == 0) return nullptr;
+    return &run;
+}
+
+// Caret offset for a document-space point inside (or near) one rect.
+size_t offsetInRect(const App& app, const App::TextRect& tr, float docX, float docY) {
+    if (const App::LayoutTextRun* run = runFor(app, tr)) {
+        BOOL trailing = FALSE, inside = FALSE;
+        DWRITE_HIT_TEST_METRICS m{};
+        if (SUCCEEDED(run->layout->HitTestPoint(docX - run->pos.x, docY - run->pos.y,
+                                                &trailing, &inside, &m))) {
+            // Caret goes after the cluster on a trailing hit — this is the
+            // glyph-boundary snapping the geometric model lacked (#83)
+            size_t off = run->docStart + m.textPosition + (trailing ? m.length : 0);
+            size_t lo = run->docStart;
+            size_t hi = run->docStart + run->docLength;
+            return std::clamp(off, lo, hi);
+        }
+    }
+    // No layout: interpolate. Code lines are monospace, so this stays exact
+    // for ASCII and close for CJK.
+    if (tr.docLength == 0) return tr.docStart;
+    float w = tr.rect.right - tr.rect.left;
+    if (w <= 0.0f) return tr.docStart;
+    float frac = std::clamp((docX - tr.rect.left) / w, 0.0f, 1.0f);
+    return tr.docStart + (size_t)std::lround(frac * (float)tr.docLength);
+}
+
+// Doc-offset range covered by a line bucket
+void bucketRange(const App& app, const App::LineBucket& b, size_t& lo, size_t& hi) {
+    lo = SIZE_MAX;
+    hi = 0;
+    for (size_t idx : b.textRectIndices) {
+        const App::TextRect& tr = app.textRects[idx];
+        lo = std::min(lo, tr.docStart);
+        hi = std::max(hi, tr.docStart + tr.docLength);
+    }
+}
+
+// Precise caret x for an offset that lies on this bucket's line
+float caretXInBucket(const App& app, const App::LineBucket& b, size_t offset,
+                     float fallback) {
+    for (size_t idx : b.textRectIndices) {
+        const App::TextRect& tr = app.textRects[idx];
+        const App::LayoutTextRun* run = runFor(app, tr);
+        if (run && run->docStart <= offset &&
+            offset <= run->docStart + run->docLength) {
+            FLOAT x = 0, y = 0;
+            DWRITE_HIT_TEST_METRICS m{};
+            if (SUCCEEDED(run->layout->HitTestTextPosition(
+                    (UINT32)(offset - run->docStart), FALSE, &x, &y, &m))) {
+                return run->pos.x + x;
+            }
+        }
+    }
+    // Monospace / layout-less rects: interpolate
+    for (size_t idx : b.textRectIndices) {
+        const App::TextRect& tr = app.textRects[idx];
+        if (tr.docStart <= offset && offset <= tr.docStart + tr.docLength &&
+            tr.docLength > 0) {
+            float frac = (float)(offset - tr.docStart) / (float)tr.docLength;
+            return tr.rect.left + frac * (tr.rect.right - tr.rect.left);
+        }
+    }
+    return fallback;
+}
+
+} // namespace
+
+size_t selectionOffsetAtPoint(const App& app, float docX, float docY) {
+    if (app.lineBuckets.empty() || app.docText.empty()) return 0;
+
+    // Nearest line by vertical distance. Buckets follow layout order; a
+    // linear scan at mouse rate is cheap and copes with table rows.
+    const App::LineBucket* best = nullptr;
+    float bestDist = 1e9f;
+    for (const App::LineBucket& b : app.lineBuckets) {
+        float dist = docY < b.top ? b.top - docY
+                                  : (docY > b.bottom ? docY - b.bottom : 0.0f);
+        if (dist < bestDist) {
+            bestDist = dist;
+            best = &b;
+        }
+    }
+    if (!best) return 0;
+
+    const App::TextRect* nearest = nullptr;
+    float nearestDx = 1e9f;
+    for (size_t idx : best->textRectIndices) {
+        const App::TextRect& tr = app.textRects[idx];
+        if (docX >= tr.rect.left && docX <= tr.rect.right) {
+            return std::min(offsetInRect(app, tr, docX, docY), app.docText.size());
+        }
+        float dx = docX < tr.rect.left ? tr.rect.left - docX : docX - tr.rect.right;
+        if (dx < nearestDx) {
+            nearestDx = dx;
+            nearest = &tr;
+        }
+    }
+    if (!nearest) return 0;
+    // Off the line's text: snap to the near edge of the nearest run, so
+    // drags starting in the margin select from the line start/end
+    size_t off = docX < nearest->rect.left ? nearest->docStart
+                                           : nearest->docStart + nearest->docLength;
+    return std::min(off, app.docText.size());
+}
+
+void selectionWordRange(const App& app, size_t offset, size_t& start, size_t& end) {
+    const std::wstring& t = app.docText;
+    if (t.empty()) {
+        start = end = 0;
+        return;
+    }
+    if (offset >= t.size()) offset = t.size() - 1;
+    // A caret sitting just after a word (trailing hit) belongs to that word
+    if (offset > 0 && isWordBoundary(t[offset]) && !isWordBoundary(t[offset - 1])) {
+        offset--;
+    }
+    if (isWordBoundary(t[offset])) {
+        start = offset;
+        end = offset + 1;
+        return;
+    }
+    start = offset;
+    while (start > 0 && !isWordBoundary(t[start - 1])) start--;
+    end = offset + 1;
+    while (end < t.size() && !isWordBoundary(t[end])) end++;
+}
+
+bool selectionLineRange(const App& app, size_t offset, size_t& start, size_t& end) {
+    for (const App::LineBucket& b : app.lineBuckets) {
+        size_t lo, hi;
+        bucketRange(app, b, lo, hi);
+        if (lo != SIZE_MAX && lo <= offset && offset <= hi) {
+            start = lo;
+            end = hi;
+            return true;
+        }
+    }
+    return false;
+}
+
+void selectionHighlightRects(const App& app, size_t start, size_t end,
+                             std::vector<D2D1_RECT_F>& out) {
+    if (start >= end) return;
+    for (const App::LineBucket& b : app.lineBuckets) {
+        size_t lo, hi;
+        bucketRange(app, b, lo, hi);
+        if (lo == SIZE_MAX || hi <= start || lo >= end) continue;
+        // Interior lines fill their text extents; boundary lines get a
+        // precise caret edge. At most two caret lookups per frame.
+        float left = start > lo ? caretXInBucket(app, b, start, b.minX) : b.minX;
+        float right = end < hi ? caretXInBucket(app, b, end, b.maxX) : b.maxX;
+        if (right > left) {
+            out.push_back(D2D1::RectF(left, b.top, right, b.bottom));
+        }
+    }
+}
+
+std::wstring selectionTextForRange(const App& app, size_t start, size_t end) {
+    start = std::min(start, app.docText.size());
+    end = std::min(end, app.docText.size());
+    if (start >= end) return std::wstring();
+    return app.docText.substr(start, end - start);
+}
+
+void clearSelection(App& app) {
+    app.selecting = false;
+    app.hasSelection = false;
+    app.selAnchor = 0;
+    app.selFocus = 0;
+    app.selectedText.clear();
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -88,49 +88,6 @@ const App::TextRect* findTextRectAt(const App& app, int x, int y) {
     return nullptr;
 }
 
-bool findWordBoundsAt(const App& app, const App::TextRect& tr, int x,
-                      float& wordLeft, float& wordRight) {
-    std::wstring_view text = textViewForRect(app, tr);
-    if (text.empty()) return false;
-
-    float totalWidth = tr.rect.right - tr.rect.left;
-    float charWidth = totalWidth / (float)text.length();
-
-    // Find which character was clicked
-    int charIndex = (int)((x - tr.rect.left) / charWidth);
-    charIndex = std::max(0, std::min(charIndex, (int)text.length() - 1));
-
-    // Find word start (scan left)
-    int wordStart = charIndex;
-    while (wordStart > 0 && !isWordBoundary(text[wordStart - 1])) {
-        wordStart--;
-    }
-
-    // Find word end (scan right)
-    int wordEnd = charIndex;
-    while (wordEnd < (int)text.length() - 1 && !isWordBoundary(text[wordEnd + 1])) {
-        wordEnd++;
-    }
-
-    wordLeft = tr.rect.left + wordStart * charWidth;
-    wordRight = tr.rect.left + (wordEnd + 1) * charWidth;
-    return true;
-}
-
-void findLineRects(const App& app, float y, float& lineLeft, float& lineRight,
-                   float& lineTop, float& lineBottom) {
-    lineLeft = 99999.0f;
-    lineRight = 0.0f;
-    lineTop = 0.0f;
-    lineBottom = 0.0f;
-    const auto* line = findLineBucketAt(app, y);
-    if (!line) return;
-
-    lineLeft = line->minX;
-    lineRight = line->maxX;
-    lineTop = line->top;
-    lineBottom = line->bottom;
-}
 
 void updateWindowTitle(App& app) {
     std::wstring title = L"Tinta";


### PR DESCRIPTION
Fixes #83 — the selection overhaul committed for v2.8.

## The model
Selection is now a pair of character offsets into `docText` (`selAnchor`/`selFocus`) instead of a screen-space rectangle. Highlights and the clipboard derive from the same range, so what's highlighted, what was aimed at, and what gets copied always agree.

- **Glyph-precise edges**: `TextRect` records its covering `LayoutTextRun`; hit-testing uses `IDWriteTextLayout::HitTestPoint` (cluster snapping — no more mid-character highlights) and boundary caret-x via `HitTestTextPosition`. Only the two boundary lines need caret lookups per frame; interior lines fill their text extents as continuous bars.
- **Drags start anywhere**: off-text points snap to the nearest line and run edge — margin drags select from line start (previously selected nothing).
- **Selection survives relayout**: offsets stay valid across zoom and resize.
- **Word/line selection** (double/triple click) as offset ranges with drag-union extension; **Shift+click** extends an existing selection.
- **Drag auto-scroll**: selection drags capture the mouse (also fixes losing the mouse-up outside the window); dragging past the top/bottom edge scrolls, speed scaling with penetration (`TIMER_SELECT_SCROLL`).
- **Search highlights** share the range machinery (`selectionRangeRect`) — matches in CJK/proportional text align exactly instead of uniform char-width interpolation.
- **Select All** = the full docText range; the equal-coords renderer signal and per-frame re-extraction of `selectedText` are gone.
- Syntax-highlighted code lines keep monospace interpolation (no single covering layout); accurate in practice.

## Verified (screenshots in session)
Single-line mid-word precision; multi-line across headings; margin-start drags; code blocks in flow selection; tables (within-row continuous bars across cells, multi-row row-major with partial boundary rows — Latin + CJK); auto-scroll through a full document, pinned at the end.

Deferred by design: images/mermaid diagrams as atomic selection units.

User-tested side-by-side against v2.7.0. Not tagged — first v2.8 item.