### PR TITLE
Folder browser pushes the content aside instead of covering it

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -614,6 +614,9 @@ struct App {
     };
     std::vector<TaskRect> taskRects;
 
+    // Viewport width at the last layout: a change (folder browser toggle,
+    // preview split drag) triggers a relayout in the render loop
+    float lastViewportWidth = -1.0f;
     std::vector<LayoutTextRun> layoutTextRuns;
     std::vector<LayoutRect> layoutRects;
     std::vector<LayoutLine> layoutLines;
@@ -831,8 +834,26 @@ inline float editorPaneWidth(const App& app) {
         : static_cast<float>(app.width);
 }
 
+// Folder browser panel width — shared by input hit-testing, the panel
+// renderer, and the viewport shift
+inline float folderBrowserPanelWidth(const App& app) {
+    float cap = dpi(app, 300.0f);
+    float floor_ = dpi(app, 250.0f);
+    float w = app.width * 0.2f;
+    if (w < floor_) w = floor_;
+    if (w > cap) w = cap;
+    return w;
+}
+
 inline float documentViewportX(const App& app) {
-    if (!app.editMode) return 0.0f;
+    if (!app.editMode) {
+        // The folder browser pushes the content right instead of covering
+        // it; the shift follows the panel's slide-in animation
+        if (app.showFolderBrowser) {
+            return folderBrowserPanelWidth(app) * app.folderBrowserAnimation;
+        }
+        return 0.0f;
+    }
     // Preview hidden: zero-width viewport at the right edge — document
     // rendering flows through unchanged and clips to nothing
     if (!app.editorShowPreview) return static_cast<float>(app.width);
@@ -840,9 +861,15 @@ inline float documentViewportX(const App& app) {
 }
 
 inline float documentViewportWidth(const App& app) {
-    float width = app.editMode
-        ? static_cast<float>(app.width) - documentViewportX(app)
-        : static_cast<float>(app.width);
+    float width;
+    if (app.editMode) {
+        width = static_cast<float>(app.width) - documentViewportX(app);
+    } else {
+        width = static_cast<float>(app.width);
+        // Snap to the panel's final width (not the animated position) so
+        // the reading column relayouts once per toggle, not per frame
+        if (app.showFolderBrowser) width -= folderBrowserPanelWidth(app);
+    }
     return width > 0.0f ? width : 0.0f;
 }
 

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -93,6 +93,16 @@ void render(App& app) {
         return;
     }
 
+    // Any viewport width change (folder browser toggle, preview split)
+    // re-flows the reading column for the space that remains
+    {
+        float vw = documentViewportWidth(app);
+        if (vw > 0.0f && vw != app.lastViewportWidth) {
+            app.lastViewportWidth = vw;
+            app.layoutDirty = true;
+        }
+    }
+
     if (app.layoutDirty) {
         if (app.editMode && !app.editorShowPreview) {
             // Preview hidden: defer document layout until it's shown again
@@ -205,6 +215,13 @@ void render(App& app) {
     // Clear background
     app.renderTarget->Clear(app.theme.background);
     app.drawCalls++;
+
+    // Folder browser open: the document shifts right in sync with the
+    // panel's slide so it stays fully readable beside it
+    if (documentViewportX(app) > 0.0f) {
+        app.renderTarget->SetTransform(
+            D2D1::Matrix3x2F::Translation(documentViewportX(app), 0));
+    }
 
 render_document:
 
@@ -694,6 +711,12 @@ render_document:
                 app.brush);
             app.drawCalls++;
         }
+    }
+
+    // Back to screen coordinates: notifications, stats, and overlays
+    // (including the folder browser panel itself) are not shifted
+    if (!app.editMode && documentViewportX(app) > 0.0f) {
+        app.renderTarget->SetTransform(D2D1::Matrix3x2F::Identity());
     }
 
     // "Copied!" notification with fade out (cached layout)


### PR DESCRIPTION
Opening the browser (B) shifts the document right in sync with the panel slide, and the reading-width percentage recomputes against the remaining space - the text stays fully readable beside the panel and restores to full width on close.

Implementation: documentViewportX/Width account for the open browser in viewer mode, so layout, mouse mapping, selection, links, and the viewport-relative scrollbars all follow through the existing helpers. The render loop tracks viewport width and relayouts once per toggle (the width snaps to the panel target while the x-shift follows the slide animation, so there is no per-frame reflow). Verified with screenshots: shifted+reflowed reading column while open, full-width restore on close.