### PR TITLE
TOC pushes the content aside too, honoring its docked side

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -845,12 +845,27 @@ inline float folderBrowserPanelWidth(const App& app) {
     return w;
 }
 
+// TOC panel width — shared by input hit-testing, the panel renderer, and
+// the viewport shift
+inline float tocPanelWidth(const App& app) {
+    float cap = dpi(app, 280.0f);
+    float floor_ = dpi(app, 220.0f);
+    float w = app.width * 0.2f;
+    if (w < floor_) w = floor_;
+    if (w > cap) w = cap;
+    return w;
+}
+
 inline float documentViewportX(const App& app) {
     if (!app.editMode) {
-        // The folder browser pushes the content right instead of covering
-        // it; the shift follows the panel's slide-in animation
+        // Side panels push the content aside instead of covering it; the
+        // shift follows the panel's slide-in animation. A right-docked TOC
+        // leaves x at 0 and only narrows the viewport.
         if (app.showFolderBrowser) {
             return folderBrowserPanelWidth(app) * app.folderBrowserAnimation;
+        }
+        if (app.showToc && app.tocOnLeft) {
+            return tocPanelWidth(app) * app.tocAnimation;
         }
         return 0.0f;
     }
@@ -869,6 +884,7 @@ inline float documentViewportWidth(const App& app) {
         // Snap to the panel's final width (not the animated position) so
         // the reading column relayouts once per toggle, not per frame
         if (app.showFolderBrowser) width -= folderBrowserPanelWidth(app);
+        else if (app.showToc) width -= tocPanelWidth(app);
     }
     return width > 0.0f ? width : 0.0f;
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -552,7 +552,7 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
     // Handle folder browser scroll (not when Ctrl is held — that's zoom)
     if (app.showFolderBrowser && !ctrl) {
-        float panelWidth = std::min(dpi(app, 300.0f), std::max(dpi(app, 250.0f), app.width * 0.2f));
+        float panelWidth = folderBrowserPanelWidth(app);
         float panelX = -panelWidth * (1.0f - app.folderBrowserAnimation);
         if (app.mouseX >= panelX && app.mouseX <= panelX + panelWidth) {
             // Scroll folder list
@@ -571,7 +571,7 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
     // Handle TOC scroll (not when Ctrl is held — that's zoom)
     if (app.showToc && !ctrl) {
-        float panelWidth = std::min(dpi(app, 280.0f), std::max(dpi(app, 220.0f), app.width * 0.2f));
+        float panelWidth = tocPanelWidth(app);
         float panelX = tocPanelX(app, panelWidth);
         if (app.mouseX >= panelX && app.mouseX <= panelX + panelWidth) {
             app.tocScroll -= delta * dpi(app, 60.0f);
@@ -794,12 +794,14 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         return;
     }
 
-    // Check vertical scrollbar hover
+    // Check vertical scrollbar hover. The bar draws at the viewport's
+    // right edge, which a right-docked TOC pushes left of the window edge.
     bool wasHovered = app.scrollbarHovered;
     app.scrollbarHovered = false;
     if (app.contentHeight > app.height) {
         float sbWidth = dpi(app, 14.0f);  // hit area
-        if (app.mouseX >= app.width - sbWidth) {
+        float sbRight = documentViewportX(app) + documentViewportWidth(app);
+        if (app.mouseX >= sbRight - sbWidth && app.mouseX <= sbRight) {
             app.scrollbarHovered = true;
         }
     }
@@ -847,7 +849,7 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
 
     // Update cursor (using cached handles)
     if (app.showFolderBrowser) {
-        float panelWidth = std::min(dpi(app, 300.0f), std::max(dpi(app, 250.0f), app.width * 0.2f));
+        float panelWidth = folderBrowserPanelWidth(app);
         float panelX = -panelWidth * (1.0f - app.folderBrowserAnimation);
         bool inPanel = (app.mouseX >= panelX && app.mouseX <= panelX + panelWidth);
         if (inPanel && app.hoveredFolderIndex >= 0) {
@@ -859,7 +861,7 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         if (inPanel)
             InvalidateRect(hwnd, nullptr, FALSE);
     } else if (app.showToc) {
-        float panelWidth = std::min(dpi(app, 280.0f), std::max(dpi(app, 220.0f), app.width * 0.2f));
+        float panelWidth = tocPanelWidth(app);
         float panelX = tocPanelX(app, panelWidth);
         bool inPanel = (app.mouseX >= panelX && app.mouseX <= panelX + panelWidth);
         if (inPanel && app.hoveredTocIndex >= 0) {
@@ -1168,17 +1170,18 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
     // If theme chooser, folder browser, or TOC is open, don't start selection - just record for click handling
     if (app.showThemeChooser || app.showFolderBrowser || app.showToc) {
-        // Clicking the content scrollbar while the folder browser is open
-        // reads as "back to the document": dismiss the browser and let the
-        // click work the scrollbar normally
+        // The content scrollbar stays usable beside a side panel: a click
+        // on it dismisses the folder browser ("back to the document") and
+        // simply works alongside the TOC, which is a navigation aid
         bool scrollbarClick =
             (app.scrollbarHovered && app.contentHeight > app.height) ||
             (app.hScrollbarHovered &&
              app.contentWidth > documentViewportWidth(app));
-        if (app.showFolderBrowser && !app.showThemeChooser && !app.showToc &&
-            scrollbarClick) {
-            app.showFolderBrowser = false;
-            closeFolderBrowserInput(app);
+        if (!app.showThemeChooser && scrollbarClick) {
+            if (app.showFolderBrowser) {
+                app.showFolderBrowser = false;
+                closeFolderBrowserInput(app);
+            }
             // fall through to the scrollbar handling below
         } else {
             return;
@@ -1555,7 +1558,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     if (app.showToc) {
         int clickX = GET_X_LPARAM(lParam);
 
-        float panelWidth = std::min(dpi(app, 280.0f), std::max(dpi(app, 220.0f), app.width * 0.2f));
+        float panelWidth = tocPanelWidth(app);
         float panelX = tocPanelX(app, panelWidth);
 
         if (clickX >= panelX && (float)clickX <= panelX + panelWidth) {
@@ -1584,7 +1587,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         int clickY = GET_Y_LPARAM(lParam);
 
         // Calculate panel bounds (must match render code)
-        float panelWidth = std::min(dpi(app, 300.0f), std::max(dpi(app, 250.0f), app.width * 0.2f));
+        float panelWidth = folderBrowserPanelWidth(app);
         float panelX = -panelWidth * (1.0f - app.folderBrowserAnimation);
 
         // Check if click is inside panel

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -149,7 +149,7 @@ void renderFolderBrowser(App& app) {
     float anim = app.folderBrowserAnimation;
 
     // Panel dimensions
-    float panelWidth = std::min(dpi(app, 300.0f), std::max(dpi(app, 250.0f), app.width * 0.2f));
+    float panelWidth = folderBrowserPanelWidth(app);
     float panelX = -panelWidth * (1.0f - anim);  // Slide in from left
     float panelY = 0;
     float panelHeight = (float)app.height;
@@ -494,7 +494,7 @@ void renderToc(App& app) {
     float anim = app.tocAnimation;
 
     // Panel dimensions
-    float panelWidth = std::min(dpi(app, 280.0f), std::max(dpi(app, 220.0f), app.width * 0.2f));
+    float panelWidth = tocPanelWidth(app);
     float panelX = tocPanelX(app, panelWidth);  // slides from the chosen side
     float panelY = 0;
     float panelHeight = (float)app.height;


### PR DESCRIPTION
Follow-up to #100: Tab shifts the document like the folder browser. A left-docked TOC slides content right in sync with the panel; a right-docked TOC keeps content at the left edge and narrows the viewport - the reading-width percentage recomputes for the remaining space either way, and restores on close via the same lastViewportWidth relayout trigger.

The vertical scrollbar draws viewport-relative, so a right dock moves it left of the panel; the hover hit-test now uses the viewport edge instead of the window edge. Clicking the scrollbar beside an open TOC scrolls without dismissing it (navigation aid), while the folder browser keeps its #99 dismiss-on-scrollbar behavior. Panel width formulas deduplicated into shared inline helpers.

Verified with screenshots: right-docked TOC with reflowed content and relocated scrollbar.