### PR TITLE
Folder browser preview mode: pick files without losing the panel

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -208,9 +208,9 @@ static void commitFolderBrowserPath(App& app) {
         return;
     }
     if (isSupportedDropPath(path) && openDocumentInViewer(app, path)) {
+        // Preview mode: the browser stays open beside the document — close
+        // it by clicking the document, pressing B, or Esc
         closeFolderBrowserInput(app);
-        app.showFolderBrowser = false;
-        app.folderBrowserAnimation = 0;
     } else {
         app.folderBrowserInputError = true;
     }
@@ -1770,11 +1770,11 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                     }
                     fullPath += item.name;
 
-                    if (openDocumentInViewer(app, fullPath)) {
-                        // Close folder browser after opening file
-                        app.showFolderBrowser = false;
-                        app.folderBrowserAnimation = 0;
-                    }
+                    // Preview mode: open the file but keep the browser up,
+                    // so the list doubles as a file picker — the current
+                    // file is highlighted, and the browser closes on a
+                    // document click, B, or Esc
+                    openDocumentInViewer(app, fullPath);
                 }
             }
         } else {

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -365,6 +365,22 @@ void renderFolderBrowser(App& app) {
 
         app.hoveredFolderIndex = -1;
 
+        // Preview mode: mark the file currently loaded in the viewer so
+        // the list reads as a picker while clicking through documents
+        std::wstring currentName;
+        {
+            std::wstring wcur = toWide(app.currentFile);
+            std::wstring wdir = app.folderBrowserPath;
+            if (!wdir.empty() && wdir.back() != L'\\' && wdir.back() != L'/') {
+                wdir += L'\\';
+            }
+            if (wcur.size() > wdir.size() &&
+                _wcsnicmp(wcur.c_str(), wdir.c_str(), wdir.size()) == 0 &&
+                wcur.find_first_of(L"\\/", wdir.size()) == std::wstring::npos) {
+                currentName = wcur.substr(wdir.size());
+            }
+        }
+
         for (size_t i = 0; i < app.folderItems.size(); i++) {
             float itemY = listStartY + namingOffset + i * itemHeight - app.folderBrowserScroll;
 
@@ -379,6 +395,17 @@ void renderFolderBrowser(App& app) {
             bool isHovered = (app.mouseX >= itemX && app.mouseX <= itemX + itemW &&
                               app.mouseY >= itemY && app.mouseY <= itemY + itemHeight &&
                               app.mouseY >= listStartY && app.mouseY <= panelHeight - padding);
+
+            bool isCurrent = !item.isDirectory && !currentName.empty() &&
+                             _wcsicmp(item.name.c_str(), currentName.c_str()) == 0;
+            if (isCurrent) {
+                D2D1_COLOR_F curColor = app.theme.accent;
+                curColor.a = 0.22f * anim;
+                app.brush->SetColor(curColor);
+                app.renderTarget->FillRoundedRectangle(
+                    D2D1::RoundedRect(D2D1::RectF(itemX - dpi(app, 4.0f), itemY, itemX + itemW + dpi(app, 4.0f), itemY + itemHeight), 4, 4),
+                    app.brush);
+            }
 
             if (isHovered) {
                 app.hoveredFolderIndex = (int)i;


### PR DESCRIPTION
Clicking a markdown file in the folder browser (B) now opens it **without dismissing the panel**, so the list doubles as a file picker: flip through files and settle on the one you want to read. Combined with the content shift from #100, the document stays fully readable beside the panel while you browse.

- File clicks (and path-input jumps) keep the browser open
- The currently open file gets an accent highlight in the list, and the highlight follows as you preview
- Dismissal is deliberate: click inside the document, press B or Esc, or click the scrollbar

Verified with a synthetic run over the mermaid corpus: open B, click through files (panel persists, highlight tracks, document swaps), click the document (panel closes, content slides back to full width).