### PR TITLE
Mermaid expansion: 12 new native diagram families (#108)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SOURCES
     src/mermaid_ext.cpp
     src/mermaid_seq.cpp
     src/mermaid_pie.cpp
+    src/mermaid_uml.cpp
     src/document.cpp
     src/inline_style.cpp
     src/print.cpp
@@ -123,6 +124,7 @@ if(BUILD_TESTING)
         src/mermaid_ext.cpp
         src/mermaid_seq.cpp
         src/mermaid_pie.cpp
+        src/mermaid_uml.cpp
     )
     target_include_directories(mermaid_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SOURCES
     src/mermaid.cpp
     src/mermaid_ext.cpp
     src/mermaid_seq.cpp
+    src/mermaid_pie.cpp
     src/document.cpp
     src/inline_style.cpp
     src/print.cpp
@@ -121,6 +122,7 @@ if(BUILD_TESTING)
         src/mermaid.cpp
         src/mermaid_ext.cpp
         src/mermaid_seq.cpp
+        src/mermaid_pie.cpp
     )
     target_include_directories(mermaid_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,8 @@ set(SOURCES
     src/input.cpp
     src/editor.cpp
     src/mermaid.cpp
+    src/mermaid_ext.cpp
+    src/mermaid_seq.cpp
     src/document.cpp
     src/inline_style.cpp
     src/print.cpp
@@ -71,6 +73,7 @@ set(HEADERS
     include/input.h
     include/editor.h
     include/mermaid.h
+    include/mermaid_ext.h
     include/document.h
     include/inline_style.h
     include/print.h
@@ -116,6 +119,8 @@ if(BUILD_TESTING)
     add_executable(mermaid_tests
         tests/mermaid_tests.cpp
         src/mermaid.cpp
+        src/mermaid_ext.cpp
+        src/mermaid_seq.cpp
     )
     target_include_directories(mermaid_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ set(SOURCES
     src/mermaid_seq.cpp
     src/mermaid_pie.cpp
     src/mermaid_uml.cpp
+    src/mermaid_git.cpp
+    src/mermaid_gantt.cpp
+    src/mermaid_charts.cpp
+    src/mermaid_narrative.cpp
     src/document.cpp
     src/inline_style.cpp
     src/print.cpp
@@ -125,6 +129,10 @@ if(BUILD_TESTING)
         src/mermaid_seq.cpp
         src/mermaid_pie.cpp
         src/mermaid_uml.cpp
+        src/mermaid_git.cpp
+        src/mermaid_gantt.cpp
+        src/mermaid_charts.cpp
+        src/mermaid_narrative.cpp
     )
     target_include_directories(mermaid_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 - **Word wrap** - Optional soft wrap in the editor (Ctrl+W)
 - **Native LaTeX math** - `$inline$` and `$$display$$` equations rendered natively (fractions, scripts, stretchy delimiters, Greek — no MathJax, no web engine)
 - **Focused editing** - Hide the preview pane while writing (Ctrl+E)
-- **Native Mermaid flowcharts** - Render `.mmd` files and fenced `mermaid` blocks without a web engine
+- **Native Mermaid diagrams** - Flowcharts, sequence, class, state, ER, pie, git graphs, gantt, mindmaps, timelines, journeys, and charts — rendered without a web engine
 - **Rich tables** - Tables with bold, italic, code, and clickable links in cells
 - **Folder browser** - Press B to browse and open Markdown or Mermaid files
 - **Table of contents** - Press Tab to see document headings, click to jump
@@ -190,7 +190,16 @@ This registers `.md`, `.markdown`, and `.mmd` so you can select Tinta as their d
 
 ## Mermaid Support
 
-Tinta natively renders Mermaid `flowchart` and `graph` diagrams in `.mmd` files and fenced `mermaid` code blocks. It supports TB/TD, BT, LR, and RL layouts; common node shapes; directed and labeled edges; `classDef`, `class`, and `style` styling. Unsupported Mermaid diagram families fall back to readable source code.
+Tinta natively renders thirteen Mermaid diagram families in `.mmd` files and fenced `mermaid` code blocks — no web engine involved:
+
+- **Flowcharts** (`flowchart` / `graph`) - TB/TD, BT, LR, RL layouts, common node shapes, directed and labeled edges, `classDef`/`class`/`style` styling
+- **Sequence diagrams** - participants and actors with aliases and `<br/>` breaks, every arrow family, activations, notes, `autonumber`, and `loop`/`alt`/`opt`/`par`/`critical`/`break` frames
+- **Class diagrams** - member blocks, stereotypes, `~T~` generics, all relation kinds with multiplicities
+- **State diagrams** - `[*]` start/end, choice/fork/join, descriptions, directions, inline notes
+- **ER diagrams** - attribute tables with keys, full crow's-foot cardinality notation
+- **Pie charts**, **git graphs**, **gantt charts**, **mindmaps**, **timelines**, **user journeys**, **quadrant charts**, and **XY charts** (`xychart-beta`)
+
+Diagrams follow the active theme, print through Ctrl+P, and their text is selectable and searchable like any other content. Anything a native renderer does not cover yet (composite states, class notes, and the remaining families such as C4) falls back to readable source code.
 
 ## Themes
 

--- a/include/app.h
+++ b/include/app.h
@@ -599,6 +599,10 @@ struct App {
         Stadium,
         Ellipse,
         Hexagon,
+        // Arbitrary geometry built eagerly at layout time (pie slices,
+        // arrowheads, crow's feet); `geometry` is in local space with the
+        // origin at rect top-left, rect doubles as the culling bounds
+        Path,
     };
     struct LayoutShape {
         LayoutShapeType type = LayoutShapeType::Rectangle;

--- a/include/mermaid_ext.h
+++ b/include/mermaid_ext.h
@@ -1,0 +1,157 @@
+#ifndef TINTA_MERMAID_EXT_H
+#define TINTA_MERMAID_EXT_H
+
+// Native renderers for the Mermaid diagram families beyond flowcharts.
+// Each family parses its source into a flat list of drawing primitives in
+// diagram-local pixel coordinates (already scaled); the app translates the
+// primitives into its layout structures and theme colors. The library is
+// pure C++ (no Direct2D/DirectWrite) so parsers stay unit-testable: text
+// measurement is injected through a callback.
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace mermaidext {
+
+enum class Kind {
+    None,       // not a diagram this library handles
+    Flowchart,  // handled by the original mermaid:: flowchart engine
+    Sequence,
+    Class,
+    State,
+    Er,
+    Pie,
+    Git,
+    Gantt,
+    Mindmap,
+    Timeline,
+    Journey,
+    Quadrant,
+    XyChart,
+};
+
+// Inspects the first meaningful line's keyword.
+Kind detectKind(std::string_view source);
+
+struct Size {
+    float w = 0.0f;
+    float h = 0.0f;
+};
+
+struct Point {
+    float x = 0.0f;
+    float y = 0.0f;
+};
+
+struct TextStyle {
+    float scale = 1.0f;  // multiplier on the app's body size
+    bool bold = false;
+    bool italic = false;
+    bool mono = false;
+};
+
+// (utf8 text, style, wrap width or 0 = no wrap) -> measured size.
+// Text may contain '\n' which always breaks lines.
+using Measure =
+    std::function<Size(const std::string&, const TextStyle&, float)>;
+
+enum class PrimType {
+    Rect,       // x1,y1,x2,y2 bounds
+    RoundRect,  // + radius
+    Ellipse,    // bounds
+    Line,       // x1,y1 -> x2,y2 (+ dashed, arrow flags)
+    Polygon,    // pts (closed, filled and/or stroked)
+    Slice,      // pie slice: center (x1,y1), radius, angles a0->a1 radians
+    Text,       // bounds + text + style + align
+};
+
+// Color roles resolved against the app theme at translation time.
+enum class Role {
+    Text,        // theme text
+    Muted,       // theme text at reduced alpha
+    Stroke,      // theme accent (node outline color)
+    Fill,        // theme code background (node fill)
+    Accent,      // theme accent
+    AccentSoft,  // theme accent at low alpha (note/band fills)
+    Background,  // theme background
+    Series,      // categorical palette color [seriesIndex]
+    SeriesSoft,  // same, low alpha
+    None,        // do not draw this half (no fill / no stroke)
+};
+
+struct Prim {
+    PrimType type = PrimType::Rect;
+    float x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+    float radius = 0.0f;
+    float a0 = 0.0f, a1 = 0.0f;
+    std::vector<Point> pts;
+    std::string text;
+    TextStyle style;
+    Role fill = Role::None;
+    Role stroke = Role::None;
+    int seriesIndex = 0;
+    float strokeWidth = 0.0f;
+    bool dashed = false;
+    bool arrow = false;      // Line: filled arrowhead at (x2,y2)
+    bool openArrow = false;  // Line: two-stroke arrowhead at (x2,y2)
+    int alignH = 0;          // Text: -1 left, 0 center, 1 right
+    int alignV = 0;          // Text: -1 top, 0 center, 1 bottom
+};
+
+struct Built {
+    bool ok = false;
+    float width = 0.0f;
+    float height = 0.0f;
+    std::vector<Prim> prims;
+    std::string error;
+};
+
+// Parses and lays out `source` for the given kind. `scale` multiplies every
+// base coordinate (the app passes contentScale * zoomFactor). Returns
+// ok=false when the source uses constructs the native renderer does not
+// support; the caller falls back to showing the source.
+Built build(Kind kind, std::string_view source, const Measure& measure,
+            float scale);
+
+// --- shared parsing helpers (used by the per-family implementations and
+// exercised directly by tests) ---
+namespace detail {
+
+std::string_view trimView(std::string_view value);
+// Splits into trimmed, non-empty, non-%%-comment lines.
+std::vector<std::string_view> diagramLines(std::string_view source);
+// Replaces <br/> variants with '\n' and decodes a few common entities.
+std::string cleanLabel(std::string_view raw);
+bool startsWithWord(std::string_view line, std::string_view word,
+                    std::string_view* rest = nullptr);
+
+Built buildSequence(std::string_view source, const Measure& measure,
+                    float scale);
+Built buildPie(std::string_view source, const Measure& measure, float scale);
+Built buildState(std::string_view source, const Measure& measure,
+                 float scale);
+Built buildClass(std::string_view source, const Measure& measure,
+                 float scale);
+Built buildEr(std::string_view source, const Measure& measure, float scale);
+Built buildGit(std::string_view source, const Measure& measure, float scale);
+Built buildGantt(std::string_view source, const Measure& measure,
+                 float scale);
+Built buildMindmap(std::string_view source, const Measure& measure,
+                   float scale);
+Built buildTimeline(std::string_view source, const Measure& measure,
+                    float scale);
+Built buildJourney(std::string_view source, const Measure& measure,
+                   float scale);
+Built buildQuadrant(std::string_view source, const Measure& measure,
+                    float scale);
+Built buildXyChart(std::string_view source, const Measure& measure,
+                   float scale);
+
+}  // namespace detail
+
+}  // namespace mermaidext
+
+#endif  // TINTA_MERMAID_EXT_H

--- a/include/mermaid_ext.h
+++ b/include/mermaid_ext.h
@@ -127,6 +127,9 @@ std::vector<std::string_view> diagramLines(std::string_view source);
 std::string cleanLabel(std::string_view raw);
 bool startsWithWord(std::string_view line, std::string_view word,
                     std::string_view* rest = nullptr);
+// Shifts every primitive right so nothing sits at negative x, growing the
+// diagram width to match (notes and markers can overhang the layout box).
+void normalizeLeft(Built& built);
 
 Built buildSequence(std::string_view source, const Measure& measure,
                     float scale);

--- a/include/mermaid_ext.h
+++ b/include/mermaid_ext.h
@@ -79,6 +79,7 @@ enum class Role {
     Background,  // theme background
     Series,      // categorical palette color [seriesIndex]
     SeriesSoft,  // same, low alpha
+    Custom,      // the prim's own customR/G/B (journey scores, crit tasks)
     None,        // do not draw this half (no fill / no stroke)
 };
 
@@ -93,6 +94,7 @@ struct Prim {
     Role fill = Role::None;
     Role stroke = Role::None;
     int seriesIndex = 0;
+    float customR = 0.0f, customG = 0.0f, customB = 0.0f;
     float strokeWidth = 0.0f;
     bool dashed = false;
     bool arrow = false;      // Line: filled arrowhead at (x2,y2)

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -391,6 +391,30 @@ render_document:
             shape.rect.right - app.scrollX,
             shape.rect.bottom - app.scrollY);
 
+        if (shape.type == App::LayoutShapeType::Path) {
+            // Geometry was built eagerly at layout time in local space
+            if (!shape.geometry) continue;
+            D2D1_MATRIX_3X2_F previous;
+            app.renderTarget->GetTransform(&previous);
+            app.renderTarget->SetTransform(
+                D2D1::Matrix3x2F::Translation(shape.rect.left - app.scrollX,
+                                              shape.rect.top - app.scrollY) *
+                previous);
+            if (shape.fill.a > 0.0f) {
+                app.brush->SetColor(shape.fill);
+                app.renderTarget->FillGeometry(shape.geometry, app.brush);
+                app.drawCalls++;
+            }
+            if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                app.brush->SetColor(shape.stroke);
+                app.renderTarget->DrawGeometry(
+                    shape.geometry, app.brush, shape.strokeWidth);
+                app.drawCalls++;
+            }
+            app.renderTarget->SetTransform(previous);
+            continue;
+        }
+
         if (shape.type == App::LayoutShapeType::Diamond) {
             float w = shape.rect.right - shape.rect.left;
             float h = shape.rect.bottom - shape.rect.top;

--- a/src/mermaid_charts.cpp
+++ b/src/mermaid_charts.cpp
@@ -1,0 +1,687 @@
+// Native Mermaid quadrant charts and xy charts (xychart-beta).
+
+#include "mermaid_ext.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace mermaidext {
+namespace detail {
+
+namespace {
+
+std::string unquote(std::string_view text) {
+    text = trimView(text);
+    if (text.size() >= 2 && text.front() == '"' && text.back() == '"') {
+        text = text.substr(1, text.size() - 2);
+    }
+    return std::string(text);
+}
+
+bool parseNumber(std::string_view text, float& out) {
+    try {
+        out = std::stof(std::string(trimView(text)));
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// [a, b, c] -> items (quotes optional)
+bool parseBracketList(std::string_view text,
+                      std::vector<std::string>& items) {
+    text = trimView(text);
+    if (text.size() < 2 || text.front() != '[' || text.back() != ']') {
+        return false;
+    }
+    text = text.substr(1, text.size() - 2);
+    size_t position = 0;
+    while (position <= text.size()) {
+        size_t comma = text.find(',', position);
+        if (comma == std::string_view::npos) comma = text.size();
+        items.push_back(unquote(text.substr(position, comma - position)));
+        if (comma == text.size()) break;
+        position = comma + 1;
+    }
+    return true;
+}
+
+}  // namespace
+
+// --------------------------------------------------------------------------
+// Quadrant charts
+// --------------------------------------------------------------------------
+
+Built buildQuadrant(std::string_view source, const Measure& measure,
+                    float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    std::string title;
+    std::string xLow, xHigh, yLow, yHigh;
+    std::string quadrants[4];
+    struct QuadrantPoint {
+        std::string name;
+        float x = 0.0f, y = 0.0f;
+    };
+    std::vector<QuadrantPoint> points;
+
+    auto parseAxis = [](std::string_view rest, std::string& low,
+                        std::string& high) {
+        size_t arrow = rest.find("-->");
+        if (arrow == std::string_view::npos) {
+            low = unquote(rest);
+            high.clear();
+        } else {
+            low = unquote(trimView(rest.substr(0, arrow)));
+            high = unquote(trimView(rest.substr(arrow + 3)));
+        }
+    };
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            if (!startsWithWord(line, "quadrantChart")) {
+                result.error = "Expected quadrantChart header";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "title", &rest)) {
+            title = cleanLabel(rest);
+            continue;
+        }
+        if (startsWithWord(line, "x-axis", &rest)) {
+            parseAxis(rest, xLow, xHigh);
+            continue;
+        }
+        if (startsWithWord(line, "y-axis", &rest)) {
+            parseAxis(rest, yLow, yHigh);
+            continue;
+        }
+        bool isQuadrant = false;
+        for (int i = 0; i < 4; i++) {
+            char keyword[12];
+            snprintf(keyword, sizeof(keyword), "quadrant-%d", i + 1);
+            if (startsWithWord(line, keyword, &rest)) {
+                quadrants[i] = cleanLabel(rest);
+                isQuadrant = true;
+                break;
+            }
+        }
+        if (isQuadrant) continue;
+        // Point: Name: [x, y]
+        size_t colon = line.find(':');
+        if (colon != std::string_view::npos) {
+            std::string_view coords = trimView(line.substr(colon + 1));
+            std::vector<std::string> pair;
+            if (parseBracketList(coords, pair) && pair.size() == 2) {
+                QuadrantPoint point;
+                point.name = cleanLabel(trimView(line.substr(0, colon)));
+                if (parseNumber(pair[0], point.x) &&
+                    parseNumber(pair[1], point.y)) {
+                    points.push_back(std::move(point));
+                    continue;
+                }
+            }
+        }
+        result.error = "Unsupported quadrant statement";
+        return result;
+    }
+
+    TextStyle titleStyle;
+    titleStyle.bold = true;
+    titleStyle.scale = 1.1f;
+    TextStyle quadrantStyle;
+    quadrantStyle.bold = true;
+    quadrantStyle.scale = 0.95f;
+    TextStyle axisStyle;
+    axisStyle.scale = 0.85f;
+    TextStyle pointStyle;
+    pointStyle.scale = 0.8f;
+
+    float plotSize = 380.0f * scale;
+    float leftGutter = 8.0f * scale;
+    float axisBand = 22.0f * scale;
+
+    float y = 4.0f * scale;
+    float plotLeft = leftGutter + axisBand;
+    if (!title.empty()) {
+        Size titleSize = measure(title, titleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = title;
+        text.style = titleStyle;
+        text.fill = Role::Text;
+        text.x1 = plotLeft;
+        text.y1 = y;
+        text.x2 = plotLeft + plotSize;
+        text.y2 = y + titleSize.h;
+        result.prims.push_back(std::move(text));
+        y += titleSize.h + 10.0f * scale;
+    }
+    float plotTop = y;
+
+    // Quadrant fills: 1 = top right, 2 = top left, 3 = bottom left,
+    // 4 = bottom right
+    struct QuadrantRect {
+        float x, ycoord;
+    };
+    QuadrantRect origins[4] = {
+        {plotLeft + plotSize * 0.5f, plotTop},
+        {plotLeft, plotTop},
+        {plotLeft, plotTop + plotSize * 0.5f},
+        {plotLeft + plotSize * 0.5f, plotTop + plotSize * 0.5f},
+    };
+    for (int i = 0; i < 4; i++) {
+        Prim fill;
+        fill.type = PrimType::Rect;
+        fill.x1 = origins[i].x;
+        fill.y1 = origins[i].ycoord;
+        fill.x2 = origins[i].x + plotSize * 0.5f;
+        fill.y2 = origins[i].ycoord + plotSize * 0.5f;
+        fill.fill = Role::SeriesSoft;
+        fill.seriesIndex = i;
+        result.prims.push_back(fill);
+        if (!quadrants[i].empty()) {
+            Prim label;
+            label.type = PrimType::Text;
+            label.text = quadrants[i];
+            label.style = quadrantStyle;
+            label.fill = Role::Muted;
+            label.x1 = origins[i].x + 6.0f * scale;
+            label.y1 = origins[i].ycoord + 6.0f * scale;
+            label.x2 = origins[i].x + plotSize * 0.5f - 6.0f * scale;
+            label.y2 = origins[i].ycoord + plotSize * 0.5f - 6.0f * scale;
+            result.prims.push_back(std::move(label));
+        }
+    }
+    // Border + midlines
+    Prim border;
+    border.type = PrimType::Rect;
+    border.x1 = plotLeft;
+    border.y1 = plotTop;
+    border.x2 = plotLeft + plotSize;
+    border.y2 = plotTop + plotSize;
+    border.stroke = Role::Muted;
+    border.strokeWidth = 1.2f * scale;
+    result.prims.push_back(border);
+    for (int vertical = 0; vertical < 2; vertical++) {
+        Prim mid;
+        mid.type = PrimType::Line;
+        if (vertical) {
+            mid.x1 = plotLeft + plotSize * 0.5f;
+            mid.y1 = plotTop;
+            mid.x2 = plotLeft + plotSize * 0.5f;
+            mid.y2 = plotTop + plotSize;
+        } else {
+            mid.x1 = plotLeft;
+            mid.y1 = plotTop + plotSize * 0.5f;
+            mid.x2 = plotLeft + plotSize;
+            mid.y2 = plotTop + plotSize * 0.5f;
+        }
+        mid.stroke = Role::Muted;
+        mid.strokeWidth = 0.8f * scale;
+        result.prims.push_back(mid);
+    }
+
+    // Points
+    for (const auto& point : points) {
+        float px = plotLeft + point.x * plotSize;
+        float py = plotTop + (1.0f - point.y) * plotSize;
+        float radius = 5.0f * scale;
+        Prim dot;
+        dot.type = PrimType::Ellipse;
+        dot.x1 = px - radius;
+        dot.y1 = py - radius;
+        dot.x2 = px + radius;
+        dot.y2 = py + radius;
+        dot.fill = Role::Accent;
+        result.prims.push_back(dot);
+        Size size = measure(point.name, pointStyle, 0.0f);
+        Prim label;
+        label.type = PrimType::Text;
+        label.text = point.name;
+        label.style = pointStyle;
+        label.fill = Role::Text;
+        label.x1 = px - size.w * 0.5f - 2.0f;
+        label.y1 = py - radius - size.h - 2.0f * scale;
+        label.x2 = px + size.w * 0.5f + 2.0f;
+        label.y2 = py - radius - 2.0f * scale;
+        result.prims.push_back(std::move(label));
+    }
+
+    // Axis labels
+    float plotBottom = plotTop + plotSize;
+    auto axisText = [&](const std::string& value, float x1, float x2,
+                        float top, int alignH) {
+        if (value.empty()) return;
+        Size size = measure(value, axisStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = value;
+        text.style = axisStyle;
+        text.fill = Role::Muted;
+        text.alignH = alignH;
+        text.x1 = x1;
+        text.y1 = top;
+        text.x2 = x2;
+        text.y2 = top + size.h;
+        result.prims.push_back(std::move(text));
+    };
+    axisText(xLow, plotLeft, plotLeft + plotSize * 0.5f,
+             plotBottom + 6.0f * scale, -1);
+    axisText(xHigh, plotLeft + plotSize * 0.5f, plotLeft + plotSize,
+             plotBottom + 6.0f * scale, 1);
+    // Y labels sit sideways in mermaid; horizontal text goes beside the axis
+    if (!yHigh.empty() || !yLow.empty()) {
+        Size lowSize = measure(yLow, axisStyle, 0.0f);
+        Size highSize = measure(yHigh, axisStyle, 0.0f);
+        float axisWidth = std::max(lowSize.w, highSize.w);
+        // shift the whole plot right by drawing labels at negative x and
+        // normalizing afterwards
+        if (!yHigh.empty()) {
+            Prim text;
+            text.type = PrimType::Text;
+            text.text = yHigh;
+            text.style = axisStyle;
+            text.fill = Role::Muted;
+            text.alignH = 1;
+            text.x1 = plotLeft - axisWidth - 10.0f * scale;
+            text.y1 = plotTop;
+            text.x2 = plotLeft - 10.0f * scale;
+            text.y2 = plotTop + highSize.h;
+            result.prims.push_back(std::move(text));
+        }
+        if (!yLow.empty()) {
+            Prim text;
+            text.type = PrimType::Text;
+            text.text = yLow;
+            text.style = axisStyle;
+            text.fill = Role::Muted;
+            text.alignH = 1;
+            text.x1 = plotLeft - axisWidth - 10.0f * scale;
+            text.y1 = plotBottom - lowSize.h;
+            text.x2 = plotLeft - 10.0f * scale;
+            text.y2 = plotBottom;
+            result.prims.push_back(std::move(text));
+        }
+    }
+
+    result.width = plotLeft + plotSize + 8.0f * scale;
+    result.height = plotBottom + 26.0f * scale;
+    normalizeLeft(result);
+    result.ok = true;
+    return result;
+}
+
+// --------------------------------------------------------------------------
+// XY charts (xychart-beta)
+// --------------------------------------------------------------------------
+
+Built buildXyChart(std::string_view source, const Measure& measure,
+                   float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    std::string title, xTitle, yTitle;
+    std::vector<std::string> categories;
+    float yMin = 0.0f, yMax = 0.0f;
+    bool yRangeSet = false;
+    struct XySeries {
+        bool isLine = false;
+        std::vector<float> values;
+    };
+    std::vector<XySeries> series;
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            std::string_view rest;
+            if (!startsWithWord(line, "xychart-beta", &rest) &&
+                !startsWithWord(line, "xychart", &rest)) {
+                result.error = "Expected xychart header";
+                return result;
+            }
+            if (!trimView(rest).empty()) {
+                result.error = "Horizontal xy charts are not supported";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "title", &rest)) {
+            title = unquote(rest);
+            continue;
+        }
+        if (startsWithWord(line, "x-axis", &rest)) {
+            std::string_view remainder = trimView(rest);
+            if (!remainder.empty() && remainder.front() == '"') {
+                size_t close = remainder.find('"', 1);
+                if (close != std::string_view::npos) {
+                    xTitle = std::string(remainder.substr(1, close - 1));
+                    remainder = trimView(remainder.substr(close + 1));
+                }
+            }
+            if (!remainder.empty()) {
+                if (!parseBracketList(remainder, categories)) {
+                    // numeric range: min --> max; render as two categories
+                    size_t arrow = remainder.find("-->");
+                    if (arrow == std::string_view::npos) {
+                        result.error = "Bad x-axis";
+                        return result;
+                    }
+                    categories.push_back(
+                        unquote(trimView(remainder.substr(0, arrow))));
+                    categories.push_back(
+                        unquote(trimView(remainder.substr(arrow + 3))));
+                }
+            }
+            continue;
+        }
+        if (startsWithWord(line, "y-axis", &rest)) {
+            std::string_view remainder = trimView(rest);
+            if (!remainder.empty() && remainder.front() == '"') {
+                size_t close = remainder.find('"', 1);
+                if (close != std::string_view::npos) {
+                    yTitle = std::string(remainder.substr(1, close - 1));
+                    remainder = trimView(remainder.substr(close + 1));
+                }
+            }
+            size_t arrow = remainder.find("-->");
+            if (arrow != std::string_view::npos) {
+                if (parseNumber(remainder.substr(0, arrow), yMin) &&
+                    parseNumber(remainder.substr(arrow + 3), yMax)) {
+                    yRangeSet = true;
+                }
+            }
+            continue;
+        }
+        bool isBar = startsWithWord(line, "bar", &rest);
+        bool isLine = !isBar && startsWithWord(line, "line", &rest);
+        if (isBar || isLine) {
+            // optional series title before the list
+            std::string_view remainder = trimView(rest);
+            if (!remainder.empty() && remainder.front() == '"') {
+                size_t close = remainder.find('"', 1);
+                if (close != std::string_view::npos) {
+                    remainder = trimView(remainder.substr(close + 1));
+                }
+            }
+            std::vector<std::string> raw;
+            if (!parseBracketList(remainder, raw)) {
+                result.error = "Bad series data";
+                return result;
+            }
+            XySeries one;
+            one.isLine = isLine;
+            for (const auto& value : raw) {
+                float number = 0.0f;
+                if (!parseNumber(value, number)) {
+                    result.error = "Bad series value";
+                    return result;
+                }
+                one.values.push_back(number);
+            }
+            series.push_back(std::move(one));
+            continue;
+        }
+        result.error = "Unsupported xychart statement";
+        return result;
+    }
+
+    if (series.empty()) {
+        result.error = "No series";
+        return result;
+    }
+    size_t categoryCount = 0;
+    for (const auto& one : series) {
+        categoryCount = std::max(categoryCount, one.values.size());
+    }
+    while (categories.size() < categoryCount) {
+        categories.push_back(std::to_string(categories.size() + 1));
+    }
+    if (!yRangeSet) {
+        yMin = series[0].values.empty() ? 0.0f : series[0].values[0];
+        yMax = yMin;
+        for (const auto& one : series) {
+            for (float value : one.values) {
+                yMin = std::min(yMin, value);
+                yMax = std::max(yMax, value);
+            }
+        }
+        if (yMin > 0.0f) yMin = 0.0f;
+        if (yMax == yMin) yMax = yMin + 1.0f;
+    }
+
+    TextStyle titleStyle;
+    titleStyle.bold = true;
+    titleStyle.scale = 1.1f;
+    TextStyle axisStyle;
+    axisStyle.scale = 0.75f;
+    TextStyle axisTitleStyle;
+    axisTitleStyle.scale = 0.85f;
+
+    // Nice tick step for ~5 ticks
+    float range = yMax - yMin;
+    float roughStep = range / 5.0f;
+    float magnitude = std::pow(10.0f, std::floor(std::log10(roughStep)));
+    float normalized = roughStep / magnitude;
+    float step = magnitude * (normalized <= 1.0f   ? 1.0f
+                              : normalized <= 2.0f ? 2.0f
+                              : normalized <= 5.0f ? 5.0f
+                                                   : 10.0f);
+    float tickStart = std::ceil(yMin / step) * step;
+
+    // Measure y tick labels for the gutter
+    float yGutter = 0.0f;
+    auto formatValue = [](float value) {
+        char buffer[32];
+        if (std::fabs(value - std::round(value)) < 0.001f &&
+            std::fabs(value) < 1e7f) {
+            snprintf(buffer, sizeof(buffer), "%d",
+                     static_cast<int>(std::lround(value)));
+        } else {
+            snprintf(buffer, sizeof(buffer), "%.4g", value);
+        }
+        return std::string(buffer);
+    };
+    for (float tick = tickStart; tick <= yMax + step * 0.01f; tick += step) {
+        yGutter = std::max(yGutter,
+                           measure(formatValue(tick), axisStyle, 0.0f).w);
+    }
+    yGutter += 12.0f * scale;
+
+    float plotWidth =
+        std::max(340.0f, std::min(640.0f, categoryCount * 90.0f)) * scale;
+    float plotHeight = 280.0f * scale;
+
+    float y = 4.0f * scale;
+    float plotLeft = yGutter;
+    if (!title.empty()) {
+        Size titleSize = measure(title, titleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = title;
+        text.style = titleStyle;
+        text.fill = Role::Text;
+        text.x1 = plotLeft;
+        text.y1 = y;
+        text.x2 = plotLeft + plotWidth;
+        text.y2 = y + titleSize.h;
+        result.prims.push_back(std::move(text));
+        y += titleSize.h + 8.0f * scale;
+    }
+    if (!yTitle.empty()) {
+        Size size = measure(yTitle, axisTitleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = yTitle;
+        text.style = axisTitleStyle;
+        text.fill = Role::Muted;
+        text.alignH = -1;
+        text.x1 = 2.0f;
+        text.y1 = y;
+        text.x2 = 2.0f + size.w + 4.0f;
+        text.y2 = y + size.h;
+        result.prims.push_back(std::move(text));
+        y += size.h + 6.0f * scale;
+    }
+    float plotTop = y;
+    float plotBottom = plotTop + plotHeight;
+
+    auto valueY = [&](float value) {
+        return plotBottom - (value - yMin) / (yMax - yMin) * plotHeight;
+    };
+
+    // Gridlines + tick labels
+    for (float tick = tickStart; tick <= yMax + step * 0.01f; tick += step) {
+        float gy = valueY(tick);
+        Prim grid;
+        grid.type = PrimType::Line;
+        grid.x1 = plotLeft;
+        grid.y1 = gy;
+        grid.x2 = plotLeft + plotWidth;
+        grid.y2 = gy;
+        grid.stroke = Role::Muted;
+        grid.strokeWidth = 0.5f * scale;
+        result.prims.push_back(grid);
+        std::string label = formatValue(tick);
+        Size size = measure(label, axisStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = label;
+        text.style = axisStyle;
+        text.fill = Role::Muted;
+        text.alignH = 1;
+        text.x1 = plotLeft - size.w - 8.0f * scale;
+        text.y1 = gy - size.h * 0.5f;
+        text.x2 = plotLeft - 6.0f * scale;
+        text.y2 = gy + size.h * 0.5f;
+        result.prims.push_back(std::move(text));
+    }
+    // Axis lines
+    for (int vertical = 0; vertical < 2; vertical++) {
+        Prim axis;
+        axis.type = PrimType::Line;
+        axis.x1 = plotLeft;
+        axis.y1 = vertical ? plotTop : plotBottom;
+        axis.x2 = vertical ? plotLeft : plotLeft + plotWidth;
+        axis.y2 = plotBottom;
+        axis.stroke = Role::Muted;
+        axis.strokeWidth = 1.2f * scale;
+        result.prims.push_back(axis);
+    }
+
+    float categoryWidth = plotWidth / static_cast<float>(categoryCount);
+    size_t barSeriesCount = 0;
+    for (const auto& one : series) {
+        if (!one.isLine) barSeriesCount++;
+    }
+
+    // Bars first, then lines on top
+    size_t barIndex = 0;
+    for (size_t s = 0; s < series.size(); s++) {
+        if (series[s].isLine) continue;
+        float groupWidth = categoryWidth * 0.62f;
+        float barWidth = groupWidth / static_cast<float>(barSeriesCount);
+        for (size_t i = 0; i < series[s].values.size(); i++) {
+            float centerX = plotLeft + (i + 0.5f) * categoryWidth;
+            float x1 = centerX - groupWidth * 0.5f + barIndex * barWidth;
+            Prim bar;
+            bar.type = PrimType::Rect;
+            bar.x1 = x1 + 1.0f * scale;
+            bar.y1 = valueY(series[s].values[i]);
+            bar.x2 = x1 + barWidth - 1.0f * scale;
+            bar.y2 = valueY(std::max(yMin, 0.0f));
+            if (bar.y2 < bar.y1) std::swap(bar.y1, bar.y2);
+            bar.fill = Role::Series;
+            bar.seriesIndex = static_cast<int>(s);
+            result.prims.push_back(bar);
+        }
+        barIndex++;
+    }
+    for (size_t s = 0; s < series.size(); s++) {
+        if (!series[s].isLine) continue;
+        for (size_t i = 0; i + 1 < series[s].values.size(); i++) {
+            Prim segment;
+            segment.type = PrimType::Line;
+            segment.x1 = plotLeft + (i + 0.5f) * categoryWidth;
+            segment.y1 = valueY(series[s].values[i]);
+            segment.x2 = plotLeft + (i + 1.5f) * categoryWidth;
+            segment.y2 = valueY(series[s].values[i + 1]);
+            segment.stroke = Role::Series;
+            segment.seriesIndex = static_cast<int>(s);
+            segment.strokeWidth = 2.2f * scale;
+            result.prims.push_back(segment);
+        }
+        for (size_t i = 0; i < series[s].values.size(); i++) {
+            float radius = 3.5f * scale;
+            float cx = plotLeft + (i + 0.5f) * categoryWidth;
+            float cy = valueY(series[s].values[i]);
+            Prim dot;
+            dot.type = PrimType::Ellipse;
+            dot.x1 = cx - radius;
+            dot.y1 = cy - radius;
+            dot.x2 = cx + radius;
+            dot.y2 = cy + radius;
+            dot.fill = Role::Series;
+            dot.seriesIndex = static_cast<int>(s);
+            result.prims.push_back(dot);
+        }
+    }
+
+    // Category labels
+    float labelBottom = plotBottom;
+    for (size_t i = 0; i < categoryCount; i++) {
+        Size size = measure(categories[i], axisStyle,
+                            categoryWidth - 6.0f * scale);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = categories[i];
+        text.style = axisStyle;
+        text.fill = Role::Muted;
+        text.x1 = plotLeft + i * categoryWidth + 3.0f * scale;
+        text.y1 = plotBottom + 5.0f * scale;
+        text.x2 = plotLeft + (i + 1) * categoryWidth - 3.0f * scale;
+        text.y2 = plotBottom + 5.0f * scale + size.h;
+        labelBottom = std::max(labelBottom, text.y2);
+        result.prims.push_back(std::move(text));
+    }
+    if (!xTitle.empty()) {
+        Size size = measure(xTitle, axisTitleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = xTitle;
+        text.style = axisTitleStyle;
+        text.fill = Role::Muted;
+        text.x1 = plotLeft;
+        text.y1 = labelBottom + 4.0f * scale;
+        text.x2 = plotLeft + plotWidth;
+        text.y2 = labelBottom + 4.0f * scale + size.h;
+        labelBottom = text.y2;
+        result.prims.push_back(std::move(text));
+    }
+
+    result.width = plotLeft + plotWidth + 8.0f * scale;
+    result.height = labelBottom + 8.0f * scale;
+    result.ok = true;
+    return result;
+}
+
+}  // namespace detail
+}  // namespace mermaidext

--- a/src/mermaid_ext.cpp
+++ b/src/mermaid_ext.cpp
@@ -235,7 +235,6 @@ static Built notYet() {
     return failed;
 }
 
-Built buildEr(std::string_view, const Measure&, float) { return notYet(); }
 Built buildGit(std::string_view, const Measure&, float) { return notYet(); }
 Built buildGantt(std::string_view, const Measure&, float) { return notYet(); }
 Built buildMindmap(std::string_view, const Measure&, float) { return notYet(); }

--- a/src/mermaid_ext.cpp
+++ b/src/mermaid_ext.cpp
@@ -129,6 +129,27 @@ bool startsWithWord(std::string_view line, std::string_view word,
     return true;
 }
 
+void normalizeLeft(Built& built) {
+    float minX = 0.0f;
+    for (const auto& prim : built.prims) {
+        if (prim.type == PrimType::Slice) {
+            minX = std::min(minX, prim.x1 - prim.radius);
+        } else if (prim.type == PrimType::Polygon) {
+            for (const auto& point : prim.pts) minX = std::min(minX, point.x);
+        } else {
+            minX = std::min(minX, std::min(prim.x1, prim.x2));
+        }
+    }
+    if (minX >= 0.0f) return;
+    float shift = -minX;
+    for (auto& prim : built.prims) {
+        prim.x1 += shift;
+        prim.x2 += shift;
+        for (auto& point : prim.pts) point.x += shift;
+    }
+    built.width += shift;
+}
+
 }  // namespace detail
 
 Kind detectKind(std::string_view source) {
@@ -214,8 +235,6 @@ static Built notYet() {
     return failed;
 }
 
-Built buildState(std::string_view, const Measure&, float) { return notYet(); }
-Built buildClass(std::string_view, const Measure&, float) { return notYet(); }
 Built buildEr(std::string_view, const Measure&, float) { return notYet(); }
 Built buildGit(std::string_view, const Measure&, float) { return notYet(); }
 Built buildGantt(std::string_view, const Measure&, float) { return notYet(); }

--- a/src/mermaid_ext.cpp
+++ b/src/mermaid_ext.cpp
@@ -225,24 +225,4 @@ Built build(Kind kind, std::string_view source, const Measure& measure,
     return failed;
 }
 
-// Temporary stubs for families whose builders have not landed yet; each is
-// deleted when the real implementation arrives in its own source file.
-namespace detail {
-
-static Built notYet() {
-    Built failed;
-    failed.error = "Not implemented yet";
-    return failed;
-}
-
-Built buildGit(std::string_view, const Measure&, float) { return notYet(); }
-Built buildGantt(std::string_view, const Measure&, float) { return notYet(); }
-Built buildMindmap(std::string_view, const Measure&, float) { return notYet(); }
-Built buildTimeline(std::string_view, const Measure&, float) { return notYet(); }
-Built buildJourney(std::string_view, const Measure&, float) { return notYet(); }
-Built buildQuadrant(std::string_view, const Measure&, float) { return notYet(); }
-Built buildXyChart(std::string_view, const Measure&, float) { return notYet(); }
-
-}  // namespace detail
-
 }  // namespace mermaidext

--- a/src/mermaid_ext.cpp
+++ b/src/mermaid_ext.cpp
@@ -214,7 +214,6 @@ static Built notYet() {
     return failed;
 }
 
-Built buildPie(std::string_view, const Measure&, float) { return notYet(); }
 Built buildState(std::string_view, const Measure&, float) { return notYet(); }
 Built buildClass(std::string_view, const Measure&, float) { return notYet(); }
 Built buildEr(std::string_view, const Measure&, float) { return notYet(); }

--- a/src/mermaid_ext.cpp
+++ b/src/mermaid_ext.cpp
@@ -1,0 +1,231 @@
+// Shared entry points and helpers for the extended Mermaid renderers.
+
+#include "mermaid_ext.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace mermaidext {
+
+namespace detail {
+
+std::string_view trimView(std::string_view value) {
+    size_t begin = 0;
+    size_t end = value.size();
+    while (begin < end &&
+           std::isspace(static_cast<unsigned char>(value[begin]))) {
+        begin++;
+    }
+    while (end > begin &&
+           std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        end--;
+    }
+    return value.substr(begin, end - begin);
+}
+
+std::vector<std::string_view> diagramLines(std::string_view source) {
+    std::vector<std::string_view> lines;
+    size_t position = 0;
+    while (position <= source.size()) {
+        size_t newline = source.find('\n', position);
+        if (newline == std::string_view::npos) newline = source.size();
+        std::string_view line =
+            trimView(source.substr(position, newline - position));
+        if (!line.empty() && line.substr(0, 2) != "%%") {
+            lines.push_back(line);
+        }
+        if (newline == source.size()) break;
+        position = newline + 1;
+    }
+    return lines;
+}
+
+std::string cleanLabel(std::string_view raw) {
+    std::string result;
+    result.reserve(raw.size());
+    for (size_t i = 0; i < raw.size();) {
+        if (raw[i] == '<') {
+            // <br>, <br/>, <br />
+            size_t close = raw.find('>', i);
+            if (close != std::string_view::npos && close - i <= 6) {
+                std::string tag(raw.substr(i + 1, close - i - 1));
+                std::transform(tag.begin(), tag.end(), tag.begin(),
+                               [](unsigned char c) {
+                                   return static_cast<char>(std::tolower(c));
+                               });
+                tag.erase(std::remove_if(tag.begin(), tag.end(),
+                                         [](unsigned char c) {
+                                             return c == '/' || c == ' ';
+                                         }),
+                          tag.end());
+                if (tag == "br") {
+                    result += '\n';
+                    i = close + 1;
+                    continue;
+                }
+            }
+        }
+        if (raw[i] == '&') {
+            struct Entity {
+                std::string_view name;
+                char replacement;
+            };
+            static const Entity kEntities[] = {
+                {"&amp;", '&'}, {"&lt;", '<'},   {"&gt;", '>'},
+                {"&quot;", '"'}, {"&#39;", '\''}, {"&nbsp;", ' '},
+            };
+            bool matched = false;
+            for (const auto& entity : kEntities) {
+                if (raw.substr(i, entity.name.size()) == entity.name) {
+                    result += entity.replacement;
+                    i += entity.name.size();
+                    matched = true;
+                    break;
+                }
+            }
+            if (matched) continue;
+        }
+        result += raw[i];
+        i++;
+    }
+    // Trim each produced line
+    std::string trimmed;
+    size_t start = 0;
+    while (start <= result.size()) {
+        size_t end = result.find('\n', start);
+        if (end == std::string::npos) end = result.size();
+        std::string_view line =
+            trimView(std::string_view(result).substr(start, end - start));
+        if (!trimmed.empty()) trimmed += '\n';
+        trimmed.append(line);
+        if (end == result.size()) break;
+        start = end + 1;
+    }
+    return trimmed;
+}
+
+bool startsWithWord(std::string_view line, std::string_view word,
+                    std::string_view* rest) {
+    if (line.size() < word.size()) return false;
+    for (size_t i = 0; i < word.size(); i++) {
+        if (std::tolower(static_cast<unsigned char>(line[i])) !=
+            std::tolower(static_cast<unsigned char>(word[i]))) {
+            return false;
+        }
+    }
+    if (line.size() > word.size()) {
+        char next = line[word.size()];
+        if (!std::isspace(static_cast<unsigned char>(next)) && next != ':') {
+            return false;
+        }
+    }
+    if (rest) {
+        std::string_view remainder = line.substr(word.size());
+        if (!remainder.empty() && remainder.front() == ':') {
+            remainder.remove_prefix(1);
+        }
+        *rest = trimView(remainder);
+    }
+    return true;
+}
+
+}  // namespace detail
+
+Kind detectKind(std::string_view source) {
+    using detail::trimView;
+    size_t position = 0;
+    while (position <= source.size()) {
+        size_t newline = source.find('\n', position);
+        if (newline == std::string_view::npos) newline = source.size();
+        std::string_view line =
+            trimView(source.substr(position, newline - position));
+        if (!line.empty() && line.substr(0, 2) != "%%" &&
+            line.substr(0, 3) != "---") {  // skip frontmatter fences too
+            size_t wordEnd = 0;
+            while (wordEnd < line.size() &&
+                   (std::isalnum(static_cast<unsigned char>(line[wordEnd])) ||
+                    line[wordEnd] == '-')) {
+                wordEnd++;
+            }
+            std::string keyword(line.substr(0, wordEnd));
+            std::transform(keyword.begin(), keyword.end(), keyword.begin(),
+                           [](unsigned char c) {
+                               return static_cast<char>(std::tolower(c));
+                           });
+            if (keyword == "graph" || keyword == "flowchart") {
+                return Kind::Flowchart;
+            }
+            if (keyword == "sequencediagram") return Kind::Sequence;
+            if (keyword == "classdiagram" || keyword == "classdiagram-v2") {
+                return Kind::Class;
+            }
+            if (keyword == "statediagram" || keyword == "statediagram-v2") {
+                return Kind::State;
+            }
+            if (keyword == "erdiagram") return Kind::Er;
+            if (keyword == "pie") return Kind::Pie;
+            if (keyword == "gitgraph") return Kind::Git;
+            if (keyword == "gantt") return Kind::Gantt;
+            if (keyword == "mindmap") return Kind::Mindmap;
+            if (keyword == "timeline") return Kind::Timeline;
+            if (keyword == "journey") return Kind::Journey;
+            if (keyword == "quadrantchart") return Kind::Quadrant;
+            if (keyword == "xychart" || keyword == "xychart-beta") {
+                return Kind::XyChart;
+            }
+            return Kind::None;
+        }
+        if (newline == source.size()) break;
+        position = newline + 1;
+    }
+    return Kind::None;
+}
+
+Built build(Kind kind, std::string_view source, const Measure& measure,
+            float scale) {
+    using namespace detail;
+    switch (kind) {
+        case Kind::Sequence: return buildSequence(source, measure, scale);
+        case Kind::Pie: return buildPie(source, measure, scale);
+        case Kind::State: return buildState(source, measure, scale);
+        case Kind::Class: return buildClass(source, measure, scale);
+        case Kind::Er: return buildEr(source, measure, scale);
+        case Kind::Git: return buildGit(source, measure, scale);
+        case Kind::Gantt: return buildGantt(source, measure, scale);
+        case Kind::Mindmap: return buildMindmap(source, measure, scale);
+        case Kind::Timeline: return buildTimeline(source, measure, scale);
+        case Kind::Journey: return buildJourney(source, measure, scale);
+        case Kind::Quadrant: return buildQuadrant(source, measure, scale);
+        case Kind::XyChart: return buildXyChart(source, measure, scale);
+        default: break;
+    }
+    Built failed;
+    failed.error = "Unsupported diagram kind";
+    return failed;
+}
+
+// Temporary stubs for families whose builders have not landed yet; each is
+// deleted when the real implementation arrives in its own source file.
+namespace detail {
+
+static Built notYet() {
+    Built failed;
+    failed.error = "Not implemented yet";
+    return failed;
+}
+
+Built buildPie(std::string_view, const Measure&, float) { return notYet(); }
+Built buildState(std::string_view, const Measure&, float) { return notYet(); }
+Built buildClass(std::string_view, const Measure&, float) { return notYet(); }
+Built buildEr(std::string_view, const Measure&, float) { return notYet(); }
+Built buildGit(std::string_view, const Measure&, float) { return notYet(); }
+Built buildGantt(std::string_view, const Measure&, float) { return notYet(); }
+Built buildMindmap(std::string_view, const Measure&, float) { return notYet(); }
+Built buildTimeline(std::string_view, const Measure&, float) { return notYet(); }
+Built buildJourney(std::string_view, const Measure&, float) { return notYet(); }
+Built buildQuadrant(std::string_view, const Measure&, float) { return notYet(); }
+Built buildXyChart(std::string_view, const Measure&, float) { return notYet(); }
+
+}  // namespace detail
+
+}  // namespace mermaidext

--- a/src/mermaid_gantt.cpp
+++ b/src/mermaid_gantt.cpp
@@ -1,0 +1,527 @@
+// Native Mermaid gantt chart renderer.
+//
+// Sections color their task bars from the categorical palette; tasks parse
+// the mermaid CSV form (tags crit/done/active/milestone, optional id,
+// start date / "after id" / carry-on, end date or duration). A date axis
+// with day/week/month gridlines sits under the bars. `excludes` and
+// `axisFormat` are accepted but ignored.
+
+#include "mermaid_ext.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace mermaidext {
+namespace detail {
+
+namespace {
+
+constexpr float kRowHeight = 26.0f;
+constexpr float kRowGap = 6.0f;
+constexpr float kChartWidth = 640.0f;
+constexpr float kLabelGutter = 10.0f;
+
+// days since 1970-01-01 (proleptic civil calendar)
+long long civilDays(int y, int m, int d) {
+    y -= m <= 2;
+    long long era = (y >= 0 ? y : y - 399) / 400;
+    unsigned yoe = static_cast<unsigned>(y - era * 400);
+    unsigned doy = (153u * (m + (m > 2 ? -3 : 9)) + 2u) / 5u + d - 1u;
+    unsigned doe = yoe * 365u + yoe / 4u - yoe / 100u + doy;
+    return era * 146097LL + doe - 719468LL;
+}
+
+void civilFromDays(long long z, int& y, unsigned& m, unsigned& d) {
+    z += 719468;
+    long long era = (z >= 0 ? z : z - 146096) / 146097;
+    unsigned doe = static_cast<unsigned>(z - era * 146097);
+    unsigned yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    long long year = yoe + era * 400;
+    unsigned doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    unsigned mp = (5 * doy + 2) / 153;
+    d = doy - (153 * mp + 2) / 5 + 1;
+    m = mp + (mp < 10 ? 3 : -9);
+    y = static_cast<int>(year + (m <= 2));
+}
+
+struct DateFormat {
+    int yearIndex = 0, monthIndex = 1, dayIndex = 2;  // token order
+};
+
+// Parses "2014-01-06" style strings against the token order
+bool parseDate(std::string_view text, const DateFormat& format,
+               double& outDays) {
+    int numbers[3] = {0, 0, 0};
+    int count = 0;
+    size_t i = 0;
+    while (i < text.size() && count < 3) {
+        if (std::isdigit(static_cast<unsigned char>(text[i]))) {
+            int value = 0;
+            while (i < text.size() &&
+                   std::isdigit(static_cast<unsigned char>(text[i]))) {
+                value = value * 10 + (text[i] - '0');
+                i++;
+            }
+            numbers[count++] = value;
+        } else {
+            i++;
+        }
+    }
+    if (count != 3) return false;
+    int year = numbers[format.yearIndex];
+    int month = numbers[format.monthIndex];
+    int day = numbers[format.dayIndex];
+    if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+    outDays = static_cast<double>(civilDays(year, month, day));
+    return true;
+}
+
+bool parseDuration(std::string_view text, double& outDays) {
+    if (text.size() < 2) return false;
+    char unit = text.back();
+    double scale = 0.0;
+    if (unit == 'd') scale = 1.0;
+    else if (unit == 'w') scale = 7.0;
+    else if (unit == 'h') scale = 1.0 / 24.0;
+    else if (unit == 'm') scale = 30.0;  // months, coarse
+    else return false;
+    double value = 0.0;
+    try {
+        value = std::stod(std::string(text.substr(0, text.size() - 1)));
+    } catch (...) {
+        return false;
+    }
+    outDays = value * scale;
+    return true;
+}
+
+struct GanttTask {
+    std::string name;
+    std::string id;
+    size_t section = 0;
+    double start = 0.0;
+    double finish = 0.0;
+    bool done = false;
+    bool active = false;
+    bool crit = false;
+    bool milestone = false;
+};
+
+}  // namespace
+
+Built buildGantt(std::string_view source, const Measure& measure,
+                 float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    std::string title;
+    std::vector<std::string> sections;
+    std::vector<GanttTask> tasks;
+    std::map<std::string, size_t, std::less<>> taskIds;
+    DateFormat dateFormat;
+    double cursor = 0.0;  // running end for tasks without a start
+    bool haveCursor = false;
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            if (!startsWithWord(line, "gantt")) {
+                result.error = "Expected gantt header";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "title", &rest)) {
+            title = cleanLabel(rest);
+            continue;
+        }
+        if (startsWithWord(line, "dateFormat", &rest)) {
+            // token order of YYYY / MM / DD in the format string
+            std::string format(rest);
+            size_t yearAt = format.find('Y');
+            size_t monthAt = format.find('M');
+            size_t dayAt = format.find('D');
+            if (yearAt == std::string::npos ||
+                monthAt == std::string::npos || dayAt == std::string::npos) {
+                result.error = "Unsupported dateFormat";
+                return result;
+            }
+            size_t order[3] = {yearAt, monthAt, dayAt};
+            int position[3];
+            for (int i = 0; i < 3; i++) {
+                position[i] = 0;
+                for (int j = 0; j < 3; j++) {
+                    if (order[j] < order[i]) position[i]++;
+                }
+            }
+            dateFormat.yearIndex = position[0];
+            dateFormat.monthIndex = position[1];
+            dateFormat.dayIndex = position[2];
+            continue;
+        }
+        if (startsWithWord(line, "axisFormat", &rest) ||
+            startsWithWord(line, "excludes", &rest) ||
+            startsWithWord(line, "tickInterval", &rest) ||
+            startsWithWord(line, "todayMarker", &rest) ||
+            startsWithWord(line, "weekday", &rest)) {
+            continue;
+        }
+        if (startsWithWord(line, "section", &rest)) {
+            sections.push_back(cleanLabel(rest));
+            continue;
+        }
+
+        // Task: name : csv parts
+        size_t colon = line.rfind(':');
+        if (colon == std::string_view::npos || colon == 0) {
+            result.error = "Unsupported gantt statement";
+            return result;
+        }
+        GanttTask task;
+        task.name = cleanLabel(trimView(line.substr(0, colon)));
+        task.section = sections.empty() ? 0 : sections.size() - 1;
+        std::vector<std::string_view> parts;
+        {
+            std::string_view remainder = line.substr(colon + 1);
+            size_t position = 0;
+            while (position <= remainder.size()) {
+                size_t comma = remainder.find(',', position);
+                if (comma == std::string_view::npos) comma = remainder.size();
+                std::string_view part =
+                    trimView(remainder.substr(position, comma - position));
+                if (!part.empty()) parts.push_back(part);
+                if (comma == remainder.size()) break;
+                position = comma + 1;
+            }
+        }
+        size_t index = 0;
+        while (index < parts.size()) {
+            if (parts[index] == "done") task.done = true;
+            else if (parts[index] == "active") task.active = true;
+            else if (parts[index] == "crit") task.crit = true;
+            else if (parts[index] == "milestone") task.milestone = true;
+            else break;
+            index++;
+        }
+        // Optional id: not a date, not a duration, not "after x"
+        double parsed = 0.0;
+        if (index < parts.size() &&
+            !parseDate(parts[index], dateFormat, parsed) &&
+            !parseDuration(parts[index], parsed) &&
+            parts[index].substr(0, 6) != "after " &&
+            parts.size() - index >= 2) {
+            task.id = std::string(parts[index]);
+            index++;
+        }
+        // Start
+        bool haveStart = false;
+        if (index < parts.size()) {
+            if (parseDate(parts[index], dateFormat, task.start)) {
+                haveStart = true;
+                index++;
+            } else if (parts[index].substr(0, 6) == "after ") {
+                std::string_view ids = trimView(parts[index].substr(6));
+                double latest = haveCursor ? cursor : 0.0;
+                size_t position = 0;
+                while (position <= ids.size()) {
+                    size_t space = ids.find(' ', position);
+                    if (space == std::string_view::npos) space = ids.size();
+                    std::string_view one =
+                        trimView(ids.substr(position, space - position));
+                    auto found = taskIds.find(one);
+                    if (found != taskIds.end()) {
+                        latest = std::max(latest, tasks[found->second].finish);
+                    }
+                    if (space == ids.size()) break;
+                    position = space + 1;
+                }
+                task.start = latest;
+                haveStart = true;
+                index++;
+            }
+        }
+        if (!haveStart) {
+            if (!haveCursor) {
+                result.error = "First task needs a start date";
+                return result;
+            }
+            task.start = cursor;
+        }
+        // End: date or duration (milestones may omit it)
+        if (index < parts.size()) {
+            double endValue = 0.0;
+            if (parseDate(parts[index], dateFormat, endValue)) {
+                task.finish = endValue;
+            } else if (parseDuration(parts[index], endValue)) {
+                task.finish = task.start + endValue;
+            } else {
+                result.error = "Bad task end";
+                return result;
+            }
+        } else {
+            task.finish = task.start;
+        }
+        if (task.milestone) task.finish = task.start;
+        if (task.finish < task.start) std::swap(task.finish, task.start);
+        cursor = task.finish;
+        haveCursor = true;
+        if (!task.id.empty()) taskIds[task.id] = tasks.size();
+        tasks.push_back(std::move(task));
+    }
+
+    if (tasks.empty()) {
+        result.error = "No tasks";
+        return result;
+    }
+    if (sections.empty()) sections.push_back("");
+
+    double minDay = tasks[0].start, maxDay = tasks[0].finish;
+    for (const auto& task : tasks) {
+        minDay = std::min(minDay, task.start);
+        maxDay = std::max(maxDay, task.finish);
+    }
+    double span = std::max(1.0, maxDay - minDay);
+    minDay -= span * 0.02;
+    maxDay += span * 0.04;
+    span = maxDay - minDay;
+
+    // --- measure ---
+    TextStyle titleStyle;
+    titleStyle.bold = true;
+    titleStyle.scale = 1.1f;
+    TextStyle sectionStyle;
+    sectionStyle.bold = true;
+    sectionStyle.scale = 0.9f;
+    TextStyle taskStyle;
+    taskStyle.scale = 0.85f;
+    TextStyle axisStyle;
+    axisStyle.scale = 0.75f;
+
+    float gutter = 0.0f;
+    for (const auto& section : sections) {
+        gutter = std::max(gutter, measure(section, sectionStyle, 0.0f).w);
+    }
+    gutter += kLabelGutter * 2.0f * scale;
+
+    float chartWidth = kChartWidth * scale;
+    float dayWidth = chartWidth / static_cast<float>(span);
+    auto dayX = [&](double day) {
+        return gutter + static_cast<float>(day - minDay) * dayWidth;
+    };
+
+    float y = 4.0f * scale;
+    if (!title.empty()) {
+        Size titleSize = measure(title, titleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = title;
+        text.style = titleStyle;
+        text.fill = Role::Text;
+        text.x1 = gutter;
+        text.y1 = y;
+        text.x2 = gutter + chartWidth;
+        text.y2 = y + titleSize.h;
+        result.prims.push_back(std::move(text));
+        y += titleSize.h + 10.0f * scale;
+    }
+    float chartTop = y;
+
+    // Rows in declaration order, grouped visually by section color
+    float rowStride = (kRowHeight + kRowGap) * scale;
+    float chartBottom = chartTop + tasks.size() * rowStride;
+
+    // Gridlines: daily under 21 days, weekly under 130, else monthly
+    {
+        long long firstDay = static_cast<long long>(std::floor(minDay));
+        long long lastDay = static_cast<long long>(std::ceil(maxDay));
+        int step = span <= 21 ? 1 : span <= 130 ? 7 : 0;  // 0 = monthly
+        for (long long day = firstDay; day <= lastDay; day++) {
+            int year;
+            unsigned month, dayOfMonth;
+            civilFromDays(day, year, month, dayOfMonth);
+            bool tick = false;
+            if (step == 0) {
+                tick = dayOfMonth == 1;
+            } else if (step == 7) {
+                tick = (day % 7) == 4;  // Mondays (1970-01-05 was Monday)
+            } else {
+                tick = true;
+            }
+            if (!tick) continue;
+            float x = dayX(static_cast<double>(day));
+            if (x < gutter - 1.0f || x > gutter + chartWidth + 1.0f) continue;
+            Prim grid;
+            grid.type = PrimType::Line;
+            grid.x1 = x;
+            grid.y1 = chartTop;
+            grid.x2 = x;
+            grid.y2 = chartBottom + 4.0f * scale;
+            grid.stroke = Role::Muted;
+            grid.strokeWidth = 0.5f * scale;
+            result.prims.push_back(grid);
+            char buffer[16];
+            if (step == 0) {
+                snprintf(buffer, sizeof(buffer), "%04d-%02u", year, month);
+            } else {
+                snprintf(buffer, sizeof(buffer), "%02u-%02u", month,
+                         dayOfMonth);
+            }
+            Size size = measure(buffer, axisStyle, 0.0f);
+            Prim label;
+            label.type = PrimType::Text;
+            label.text = buffer;
+            label.style = axisStyle;
+            label.fill = Role::Muted;
+            label.x1 = x - size.w * 0.5f - 2.0f;
+            label.y1 = chartBottom + 6.0f * scale;
+            label.x2 = x + size.w * 0.5f + 2.0f;
+            label.y2 = chartBottom + 6.0f * scale + size.h;
+            result.prims.push_back(std::move(label));
+        }
+    }
+
+    // Section labels beside their first row + soft row banding per section
+    size_t lastSection = SIZE_MAX;
+    for (size_t i = 0; i < tasks.size(); i++) {
+        const auto& task = tasks[i];
+        float rowTop = chartTop + i * rowStride;
+        if (task.section != lastSection) {
+            lastSection = task.section;
+            size_t rows = 0;
+            for (size_t j = i; j < tasks.size(); j++) {
+                if (tasks[j].section != task.section) break;
+                rows++;
+            }
+            Prim band;
+            band.type = PrimType::Rect;
+            band.x1 = 0;
+            band.y1 = rowTop - kRowGap * 0.5f * scale;
+            band.x2 = gutter + chartWidth;
+            band.y2 = rowTop + rows * rowStride - kRowGap * 0.5f * scale;
+            band.fill = Role::SeriesSoft;
+            band.seriesIndex = static_cast<int>(task.section);
+            // Halve the tint so bars stay dominant
+            result.prims.push_back(band);
+            if (!sections[task.section].empty()) {
+                Size size =
+                    measure(sections[task.section], sectionStyle, 0.0f);
+                Prim label;
+                label.type = PrimType::Text;
+                label.text = sections[task.section];
+                label.style = sectionStyle;
+                label.fill = Role::Text;
+                label.alignH = -1;
+                label.x1 = kLabelGutter * scale;
+                label.y1 = rowTop;
+                label.x2 = gutter - kLabelGutter * scale;
+                label.y2 = rowTop + size.h + 4.0f * scale;
+                result.prims.push_back(std::move(label));
+            }
+        }
+    }
+
+    // Bars
+    for (size_t i = 0; i < tasks.size(); i++) {
+        const auto& task = tasks[i];
+        float rowTop = chartTop + i * rowStride;
+        float barTop = rowTop + 2.0f * scale;
+        float barBottom = rowTop + kRowHeight * scale - 2.0f * scale;
+        float x1 = dayX(task.start);
+        float x2 = std::max(dayX(task.finish), x1 + 4.0f * scale);
+
+        if (task.milestone) {
+            float cx = x1;
+            float cy = (barTop + barBottom) * 0.5f;
+            float radius = (barBottom - barTop) * 0.5f;
+            Prim diamond;
+            diamond.type = PrimType::Polygon;
+            diamond.pts = {{cx, cy - radius},
+                           {cx + radius, cy},
+                           {cx, cy + radius},
+                           {cx - radius, cy}};
+            diamond.fill = Role::Accent;
+            result.prims.push_back(std::move(diamond));
+            Size size = measure(task.name, taskStyle, 0.0f);
+            Prim label;
+            label.type = PrimType::Text;
+            label.text = task.name;
+            label.style = taskStyle;
+            label.fill = Role::Text;
+            label.alignH = -1;
+            label.x1 = cx + radius + 6.0f * scale;
+            label.y1 = barTop;
+            label.x2 = label.x1 + size.w + 4.0f;
+            label.y2 = barBottom;
+            result.prims.push_back(std::move(label));
+            continue;
+        }
+
+        Prim bar;
+        bar.type = PrimType::RoundRect;
+        bar.radius = 4.0f * scale;
+        bar.x1 = x1;
+        bar.y1 = barTop;
+        bar.x2 = x2;
+        bar.y2 = barBottom;
+        if (task.done) {
+            bar.fill = Role::Fill;
+            bar.stroke = Role::Muted;
+        } else if (task.active) {
+            bar.fill = Role::AccentSoft;
+            bar.stroke = Role::Accent;
+        } else {
+            bar.fill = Role::Series;
+            bar.seriesIndex = static_cast<int>(task.section);
+            bar.stroke = Role::None;
+        }
+        bar.strokeWidth = 1.2f * scale;
+        if (task.crit) {
+            bar.stroke = Role::Custom;
+            bar.customR = 0.83f;
+            bar.customG = 0.28f;
+            bar.customB = 0.24f;
+            bar.strokeWidth = 2.0f * scale;
+        }
+        result.prims.push_back(bar);
+
+        Size size = measure(task.name, taskStyle, 0.0f);
+        Prim label;
+        label.type = PrimType::Text;
+        label.text = task.name;
+        label.style = taskStyle;
+        if (size.w + 8.0f * scale < x2 - x1) {
+            label.fill = task.done || task.active ? Role::Text
+                                                  : Role::Background;
+            label.x1 = x1;
+            label.y1 = barTop;
+            label.x2 = x2;
+            label.y2 = barBottom;
+        } else {
+            label.fill = Role::Text;
+            label.alignH = -1;
+            label.x1 = x2 + 6.0f * scale;
+            label.y1 = barTop;
+            label.x2 = label.x1 + size.w + 4.0f;
+            label.y2 = barBottom;
+        }
+        result.prims.push_back(std::move(label));
+    }
+
+    result.width = gutter + chartWidth + 90.0f * scale;
+    result.height = chartBottom + 24.0f * scale;
+    result.ok = true;
+    return result;
+}
+
+}  // namespace detail
+}  // namespace mermaidext

--- a/src/mermaid_git.cpp
+++ b/src/mermaid_git.cpp
@@ -1,0 +1,408 @@
+// Native Mermaid gitGraph renderer.
+//
+// Left-to-right commit graph: lanes per branch (colored from the
+// categorical palette), commit dots in sequence order, branch/merge
+// connector elbows, id labels under the dots, tag chips above them, and
+// branch name chips at the left edge. Supported statements: commit
+// (id/tag/type), branch, checkout/switch, merge, cherry-pick.
+
+#include "mermaid_ext.h"
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace mermaidext {
+namespace detail {
+
+namespace {
+
+constexpr float kCommitGap = 46.0f;
+constexpr float kLaneGap = 44.0f;
+constexpr float kDotRadius = 7.0f;
+
+struct GitCommit {
+    size_t seq = 0;
+    size_t lane = 0;
+    std::string id;      // displayed under the dot
+    std::string tag;     // chip above the dot
+    bool merge = false;
+    bool highlight = false;
+    size_t parent = SIZE_MAX;       // previous commit on the same lane chain
+    size_t mergeParent = SIZE_MAX;  // second parent for merges
+    bool dashedParent = false;      // cherry-pick source link
+};
+
+struct GitBranch {
+    std::string name;
+    size_t lane = 0;
+    size_t tip = SIZE_MAX;
+};
+
+// key: "value" pairs after a statement keyword
+std::map<std::string, std::string> parseKeyValues(std::string_view rest) {
+    std::map<std::string, std::string> values;
+    size_t position = 0;
+    while (position < rest.size()) {
+        while (position < rest.size() &&
+               (rest[position] == ' ' || rest[position] == '\t')) {
+            position++;
+        }
+        size_t colon = rest.find(':', position);
+        if (colon == std::string_view::npos) break;
+        std::string key(trimView(rest.substr(position, colon - position)));
+        // A leading branch name ("merge featureA tag: ...") glues onto the
+        // first key; the key proper is the last word
+        size_t lastSpace = key.rfind(' ');
+        if (lastSpace != std::string::npos) key = key.substr(lastSpace + 1);
+        position = colon + 1;
+        while (position < rest.size() && rest[position] == ' ') position++;
+        std::string value;
+        if (position < rest.size() && rest[position] == '"') {
+            size_t close = rest.find('"', position + 1);
+            if (close == std::string_view::npos) break;
+            value = std::string(rest.substr(position + 1,
+                                            close - position - 1));
+            position = close + 1;
+        } else {
+            size_t end = rest.find(' ', position);
+            if (end == std::string_view::npos) end = rest.size();
+            value = std::string(rest.substr(position, end - position));
+            position = end;
+        }
+        values[key] = std::move(value);
+    }
+    return values;
+}
+
+}  // namespace
+
+Built buildGit(std::string_view source, const Measure& measure, float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    std::vector<GitCommit> commits;
+    std::vector<GitBranch> branches;
+    std::map<std::string, size_t, std::less<>> branchIds;
+    std::map<std::string, size_t, std::less<>> commitIds;
+    size_t current = 0;
+    int anonymous = 0;
+
+    branches.push_back({"main", 0, SIZE_MAX});
+    branchIds.emplace("main", 0);
+
+    auto addCommit = [&](std::string id, std::string tag, bool merge,
+                         bool highlight, size_t mergeParent,
+                         size_t dashedFrom) -> size_t {
+        GitCommit commit;
+        commit.seq = commits.size();
+        commit.lane = branches[current].lane;
+        commit.merge = merge;
+        commit.highlight = highlight;
+        if (id.empty()) {
+            // mermaid shows generated hashes; short ordinals read better
+            id = std::to_string(++anonymous);
+        }
+        commit.id = std::move(id);
+        commit.tag = std::move(tag);
+        commit.parent = branches[current].tip;
+        commit.mergeParent = mergeParent;
+        if (dashedFrom != SIZE_MAX) {
+            commit.mergeParent = dashedFrom;
+            commit.dashedParent = true;
+        }
+        commits.push_back(std::move(commit));
+        branches[current].tip = commits.size() - 1;
+        commitIds[commits.back().id] = commits.size() - 1;
+        return commits.size() - 1;
+    };
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            std::string_view rest;
+            if (!startsWithWord(line, "gitGraph", &rest)) {
+                result.error = "Expected gitGraph header";
+                return result;
+            }
+            rest = trimView(rest);
+            if (!rest.empty() && rest != "LR:" && rest != "LR") {
+                result.error = "Only left-to-right git graphs are supported";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "commit", &rest)) {
+            auto values = parseKeyValues(rest);
+            bool highlight = values.count("type") &&
+                             values["type"] == "HIGHLIGHT";
+            addCommit(values.count("id") ? values["id"] : std::string(),
+                      values.count("tag") ? values["tag"] : std::string(),
+                      false, highlight, SIZE_MAX, SIZE_MAX);
+            continue;
+        }
+        if (startsWithWord(line, "branch", &rest)) {
+            // strip optional order: N
+            size_t order = rest.find("order:");
+            std::string_view name =
+                trimView(order == std::string_view::npos
+                             ? rest
+                             : rest.substr(0, order));
+            if (name.empty()) {
+                result.error = "branch needs a name";
+                return result;
+            }
+            if (branchIds.find(name) == branchIds.end()) {
+                GitBranch branch;
+                branch.name = std::string(name);
+                branch.lane = branches.size();
+                branch.tip = branches[current].tip;  // branch point
+                branches.push_back(branch);
+                branchIds.emplace(std::string(name), branches.size() - 1);
+            }
+            current = branchIds.find(name)->second;
+            continue;
+        }
+        if (startsWithWord(line, "checkout", &rest) ||
+            startsWithWord(line, "switch", &rest)) {
+            auto found = branchIds.find(trimView(rest));
+            if (found == branchIds.end()) {
+                result.error = "checkout of unknown branch";
+                return result;
+            }
+            current = found->second;
+            continue;
+        }
+        if (startsWithWord(line, "merge", &rest)) {
+            std::string_view name = trimView(rest);
+            auto values = parseKeyValues(rest);
+            size_t space = name.find(' ');
+            if (space != std::string_view::npos) {
+                name = trimView(name.substr(0, space));
+            }
+            auto found = branchIds.find(name);
+            if (found == branchIds.end()) {
+                result.error = "merge of unknown branch";
+                return result;
+            }
+            size_t otherTip = branches[found->second].tip;
+            addCommit(values.count("id") ? values["id"] : std::string(),
+                      values.count("tag") ? values["tag"] : std::string(),
+                      true, false, otherTip, SIZE_MAX);
+            continue;
+        }
+        if (startsWithWord(line, "cherry-pick", &rest)) {
+            auto values = parseKeyValues(rest);
+            size_t from = SIZE_MAX;
+            if (values.count("id")) {
+                auto found = commitIds.find(values["id"]);
+                if (found != commitIds.end()) from = found->second;
+            }
+            std::string display = values.count("id")
+                                      ? values["id"] + "'"
+                                      : std::string();
+            addCommit(std::move(display),
+                      values.count("tag") ? values["tag"] : std::string(),
+                      false, false, SIZE_MAX, from);
+            continue;
+        }
+        result.error = "Unsupported gitGraph statement";
+        return result;
+    }
+
+    if (commits.empty()) {
+        result.error = "No commits";
+        return result;
+    }
+
+    // --- measure and place ---
+    TextStyle idStyle;
+    idStyle.scale = 0.8f;
+    idStyle.mono = true;
+    TextStyle tagStyle;
+    tagStyle.scale = 0.8f;
+    TextStyle branchStyle;
+    branchStyle.scale = 0.85f;
+    branchStyle.bold = true;
+
+    float branchLabelWidth = 0.0f;
+    std::vector<Size> branchLabelSizes(branches.size());
+    for (size_t i = 0; i < branches.size(); i++) {
+        branchLabelSizes[i] = measure(branches[i].name, branchStyle, 0.0f);
+        branchLabelWidth =
+            std::max(branchLabelWidth,
+                     branchLabelSizes[i].w + 16.0f * scale);
+    }
+
+    float left = branchLabelWidth + 16.0f * scale;
+    float top = 26.0f * scale;  // room for tag chips
+    auto commitX = [&](size_t seq) {
+        return left + (seq + 0.5f) * kCommitGap * scale;
+    };
+    auto laneY = [&](size_t lane) {
+        return top + (lane + 0.5f) * kLaneGap * scale;
+    };
+
+    // Connectors first (under the dots)
+    for (const auto& commit : commits) {
+        float x = commitX(commit.seq);
+        float y = laneY(commit.lane);
+        auto connect = [&](size_t parentIndex, bool dashed) {
+            if (parentIndex == SIZE_MAX) return;
+            const auto& parent = commits[parentIndex];
+            float px = commitX(parent.seq);
+            float py = laneY(parent.lane);
+            int lane = static_cast<int>(
+                parent.lane > commit.lane ? parent.lane : commit.lane);
+            auto lineSegment = [&](float ax, float ay, float bx, float by) {
+                Prim segment;
+                segment.type = PrimType::Line;
+                segment.x1 = ax;
+                segment.y1 = ay;
+                segment.x2 = bx;
+                segment.y2 = by;
+                segment.stroke = Role::Series;
+                segment.seriesIndex = lane;
+                segment.strokeWidth = 2.2f * scale;
+                segment.dashed = dashed;
+                result.prims.push_back(segment);
+            };
+            if (parent.lane == commit.lane) {
+                lineSegment(px, py, x, y);
+            } else {
+                // Elbow just before the child commit
+                float bendX = x - kCommitGap * 0.5f * scale;
+                lineSegment(px, py, bendX, py);
+                lineSegment(bendX, py, x, y);
+            }
+        };
+        connect(commit.parent, false);
+        connect(commit.mergeParent, commit.dashedParent);
+    }
+
+    // Dots + labels
+    float maxBottom = 0.0f;
+    for (const auto& commit : commits) {
+        float x = commitX(commit.seq);
+        float y = laneY(commit.lane);
+        float radius = kDotRadius * scale;
+        Prim dot;
+        dot.type = PrimType::Ellipse;
+        dot.x1 = x - radius;
+        dot.y1 = y - radius;
+        dot.x2 = x + radius;
+        dot.y2 = y + radius;
+        dot.fill = Role::Series;
+        dot.seriesIndex = static_cast<int>(commit.lane);
+        if (commit.highlight) {
+            dot.stroke = Role::Text;
+            dot.strokeWidth = 2.0f * scale;
+        }
+        result.prims.push_back(dot);
+        if (commit.merge) {
+            Prim inner;
+            inner.type = PrimType::Ellipse;
+            float innerRadius = radius * 0.45f;
+            inner.x1 = x - innerRadius;
+            inner.y1 = y - innerRadius;
+            inner.x2 = x + innerRadius;
+            inner.y2 = y + innerRadius;
+            inner.fill = Role::Background;
+            result.prims.push_back(inner);
+        }
+
+        if (!commit.id.empty()) {
+            Size size = measure(commit.id, idStyle, 0.0f);
+            Prim id;
+            id.type = PrimType::Text;
+            id.text = commit.id;
+            id.style = idStyle;
+            id.fill = Role::Muted;
+            id.x1 = x - size.w * 0.5f - 2.0f;
+            id.y1 = y + radius + 3.0f * scale;
+            id.x2 = x + size.w * 0.5f + 2.0f;
+            id.y2 = id.y1 + size.h;
+            maxBottom = std::max(maxBottom, id.y2);
+            result.prims.push_back(std::move(id));
+        }
+        if (!commit.tag.empty()) {
+            Size size = measure(commit.tag, tagStyle, 0.0f);
+            Prim chip;
+            chip.type = PrimType::RoundRect;
+            chip.radius = 4.0f * scale;
+            chip.x1 = x - size.w * 0.5f - 6.0f * scale;
+            chip.y1 = y - radius - size.h - 9.0f * scale;
+            chip.x2 = x + size.w * 0.5f + 6.0f * scale;
+            chip.y2 = y - radius - 3.0f * scale;
+            chip.fill = Role::AccentSoft;
+            chip.stroke = Role::Stroke;
+            chip.strokeWidth = 1.0f * scale;
+            result.prims.push_back(chip);
+            Prim tag;
+            tag.type = PrimType::Text;
+            tag.text = commit.tag;
+            tag.style = tagStyle;
+            tag.fill = Role::Text;
+            tag.x1 = chip.x1;
+            tag.y1 = chip.y1;
+            tag.x2 = chip.x2;
+            tag.y2 = chip.y2;
+            result.prims.push_back(std::move(tag));
+        }
+        maxBottom = std::max(maxBottom, y + radius);
+    }
+
+    // Branch name chips on the left, only for branches that have commits
+    for (size_t i = 0; i < branches.size(); i++) {
+        bool hasCommits = false;
+        for (const auto& commit : commits) {
+            if (commit.lane == branches[i].lane) {
+                hasCommits = true;
+                break;
+            }
+        }
+        if (!hasCommits) continue;
+        float y = laneY(branches[i].lane);
+        const Size& size = branchLabelSizes[i];
+        Prim chip;
+        chip.type = PrimType::RoundRect;
+        chip.radius = 4.0f * scale;
+        chip.x1 = 2.0f;
+        chip.y1 = y - size.h * 0.5f - 3.0f * scale;
+        chip.x2 = 2.0f + size.w + 12.0f * scale;
+        chip.y2 = y + size.h * 0.5f + 3.0f * scale;
+        chip.fill = Role::SeriesSoft;
+        chip.seriesIndex = static_cast<int>(branches[i].lane);
+        chip.stroke = Role::Series;
+        chip.strokeWidth = 1.0f * scale;
+        result.prims.push_back(chip);
+        Prim name;
+        name.type = PrimType::Text;
+        name.text = branches[i].name;
+        name.style = branchStyle;
+        name.fill = Role::Text;
+        name.x1 = chip.x1;
+        name.y1 = chip.y1;
+        name.x2 = chip.x2;
+        name.y2 = chip.y2;
+        result.prims.push_back(std::move(name));
+        maxBottom = std::max(maxBottom, chip.y2);
+    }
+
+    result.width = commitX(commits.size() - 1) + kCommitGap * 0.5f * scale +
+                   8.0f * scale;
+    result.height = maxBottom + 8.0f * scale;
+    result.ok = true;
+    return result;
+}
+
+}  // namespace detail
+}  // namespace mermaidext

--- a/src/mermaid_narrative.cpp
+++ b/src/mermaid_narrative.cpp
@@ -1,0 +1,859 @@
+// Native Mermaid mindmaps, timelines, and user journeys.
+
+#include "mermaid_ext.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace mermaidext {
+namespace detail {
+
+// --------------------------------------------------------------------------
+// Mindmaps
+// --------------------------------------------------------------------------
+
+namespace {
+
+enum class MindShape { Plain, Rounded, Square, Circle, Hexagon, Cloud, Bang };
+
+struct MindNode {
+    std::string text;
+    MindShape shape = MindShape::Plain;
+    int indent = 0;
+    size_t parent = SIZE_MAX;
+    std::vector<size_t> children;
+    int branch = -1;  // top-level child index for coloring
+    Size textSize;
+    float width = 0.0f, height = 0.0f;  // node box
+    float subtreeHeight = 0.0f;
+    float x = 0.0f, y = 0.0f;           // box top-left after layout
+};
+
+// id((text)), id(text), id[text], id{{text}}, id)text(, id))text(( --
+// the optional leading id is dropped, the delimited label is displayed
+MindShape stripMindShape(std::string& text) {
+    struct Delimiter {
+        const char* open;
+        const char* close;
+        MindShape shape;
+    };
+    static const Delimiter kDelimiters[] = {
+        {"((", "))", MindShape::Circle},
+        {"))", "((", MindShape::Bang},
+        {"{{", "}}", MindShape::Hexagon},
+        {")", "(", MindShape::Cloud},
+        {"(", ")", MindShape::Rounded},
+        {"[", "]", MindShape::Square},
+    };
+    for (const auto& delimiter : kDelimiters) {
+        size_t openLength = strlen(delimiter.open);
+        size_t closeLength = strlen(delimiter.close);
+        size_t open = text.find(delimiter.open);
+        if (open == std::string::npos) continue;
+        if (text.size() < closeLength ||
+            text.compare(text.size() - closeLength, closeLength,
+                         delimiter.close) != 0) {
+            continue;
+        }
+        size_t innerStart = open + openLength;
+        if (text.size() - closeLength <= innerStart) continue;
+        text = text.substr(innerStart,
+                           text.size() - closeLength - innerStart);
+        return delimiter.shape;
+    }
+    return MindShape::Plain;
+}
+
+}  // namespace
+
+Built buildMindmap(std::string_view source, const Measure& measure,
+                   float scale) {
+    Built result;
+
+    // Indentation matters here: parse raw lines, not diagramLines
+    std::vector<MindNode> nodes;
+    std::vector<size_t> stack;  // node indices by ancestry
+    bool sawHeader = false;
+    size_t position = 0;
+    while (position <= source.size()) {
+        size_t newline = source.find('\n', position);
+        if (newline == std::string_view::npos) newline = source.size();
+        std::string_view raw = source.substr(position, newline - position);
+        position = newline + 1;
+        bool lastLine = newline == source.size();
+
+        int indent = 0;
+        size_t start = 0;
+        while (start < raw.size() &&
+               (raw[start] == ' ' || raw[start] == '\t')) {
+            indent += raw[start] == '\t' ? 4 : 1;
+            start++;
+        }
+        std::string_view line = trimView(raw.substr(start));
+        if (line.empty() || line.substr(0, 2) == "%%") {
+            if (lastLine) break;
+            continue;
+        }
+        if (!sawHeader) {
+            if (!startsWithWord(line, "mindmap")) {
+                result.error = "Expected mindmap header";
+                return result;
+            }
+            sawHeader = true;
+            if (lastLine) break;
+            continue;
+        }
+        if (line.substr(0, 6) == "::icon") {
+            if (lastLine) break;
+            continue;  // icon decoration, nothing to draw natively
+        }
+        MindNode node;
+        node.text = cleanLabel(line);
+        node.shape = stripMindShape(node.text);
+        node.indent = indent;
+        // Parent: nearest shallower indent on the stack
+        while (!stack.empty() && nodes[stack.back()].indent >= indent) {
+            stack.pop_back();
+        }
+        if (stack.empty()) {
+            if (!nodes.empty()) {
+                result.error = "Multiple mindmap roots";
+                return result;
+            }
+        } else {
+            node.parent = stack.back();
+        }
+        nodes.push_back(std::move(node));
+        size_t index = nodes.size() - 1;
+        if (nodes[index].parent != SIZE_MAX) {
+            nodes[nodes[index].parent].children.push_back(index);
+        }
+        stack.push_back(index);
+        if (lastLine) break;
+    }
+
+    if (nodes.empty()) {
+        result.error = "Empty mindmap";
+        return result;
+    }
+
+    // Branch colors: each child of the root starts a colored branch
+    for (size_t i = 0; i < nodes[0].children.size(); i++) {
+        nodes[nodes[0].children[i]].branch = static_cast<int>(i);
+    }
+    for (size_t i = 1; i < nodes.size(); i++) {
+        if (nodes[i].branch < 0 && nodes[i].parent != SIZE_MAX) {
+            nodes[i].branch = nodes[nodes[i].parent].branch;
+        }
+    }
+
+    // --- measure ---
+    TextStyle rootStyle;
+    rootStyle.bold = true;
+    TextStyle nodeStyle;
+    nodeStyle.scale = 0.9f;
+    for (size_t i = 0; i < nodes.size(); i++) {
+        const TextStyle& style = i == 0 ? rootStyle : nodeStyle;
+        nodes[i].textSize = measure(nodes[i].text, style, 190.0f * scale);
+        float padX = nodes[i].shape == MindShape::Circle ? 16.0f : 12.0f;
+        float padY = nodes[i].shape == MindShape::Circle ? 12.0f : 6.0f;
+        nodes[i].width = nodes[i].textSize.w + padX * 2.0f * scale;
+        nodes[i].height = nodes[i].textSize.h + padY * 2.0f * scale;
+    }
+
+    // Right-growing tree: subtree heights bottom-up (children listed after
+    // parents, so a reverse pass suffices)
+    float rowGap = 10.0f * scale;
+    float levelGap = 46.0f * scale;
+    for (size_t i = nodes.size(); i-- > 0;) {
+        if (nodes[i].children.empty()) {
+            nodes[i].subtreeHeight = nodes[i].height;
+        } else {
+            float total = 0.0f;
+            for (size_t child : nodes[i].children) {
+                total += nodes[child].subtreeHeight;
+            }
+            total += rowGap * (nodes[i].children.size() - 1);
+            nodes[i].subtreeHeight = std::max(nodes[i].height, total);
+        }
+    }
+    // Positions top-down
+    struct PlaceItem {
+        size_t node;
+        float x, top;
+    };
+    std::vector<PlaceItem> queue{{0, 4.0f * scale, 4.0f * scale}};
+    float maxRight = 0.0f, maxBottom = 0.0f;
+    while (!queue.empty()) {
+        PlaceItem item = queue.back();
+        queue.pop_back();
+        MindNode& node = nodes[item.node];
+        node.x = item.x;
+        node.y = item.top + (node.subtreeHeight - node.height) * 0.5f;
+        maxRight = std::max(maxRight, node.x + node.width);
+        maxBottom = std::max(maxBottom, item.top + node.subtreeHeight);
+        float childX = item.x + node.width + levelGap;
+        float childTop = item.top;
+        if (!node.children.empty()) {
+            float childrenHeight = 0.0f;
+            for (size_t child : node.children) {
+                childrenHeight += nodes[child].subtreeHeight;
+            }
+            childrenHeight += rowGap * (node.children.size() - 1);
+            childTop += (node.subtreeHeight - childrenHeight) * 0.5f;
+        }
+        for (size_t child : node.children) {
+            queue.push_back({child, childX, childTop});
+            childTop += nodes[child].subtreeHeight + rowGap;
+        }
+    }
+
+    // Edges (elbow from parent right edge to child left edge)
+    for (size_t i = 1; i < nodes.size(); i++) {
+        const MindNode& node = nodes[i];
+        const MindNode& parent = nodes[node.parent];
+        float x1 = parent.x + parent.width;
+        float y1 = parent.y + parent.height * 0.5f;
+        float x2 = node.x;
+        float y2 = node.y + node.height * 0.5f;
+        float bend = x1 + (x2 - x1) * 0.5f;
+        int branch = std::max(0, node.branch);
+        auto lineSegment = [&](float ax, float ay, float bx, float by) {
+            Prim segment;
+            segment.type = PrimType::Line;
+            segment.x1 = ax;
+            segment.y1 = ay;
+            segment.x2 = bx;
+            segment.y2 = by;
+            segment.stroke = Role::Series;
+            segment.seriesIndex = branch;
+            segment.strokeWidth = 2.0f * scale;
+            result.prims.push_back(segment);
+        };
+        lineSegment(x1, y1, bend, y1);
+        if (std::abs(y2 - y1) > 0.5f) lineSegment(bend, y1, bend, y2);
+        lineSegment(bend, y2, x2, y2);
+    }
+
+    // Nodes
+    for (size_t i = 0; i < nodes.size(); i++) {
+        const MindNode& node = nodes[i];
+        int branch = std::max(0, node.branch);
+        Prim box;
+        box.x1 = node.x;
+        box.y1 = node.y;
+        box.x2 = node.x + node.width;
+        box.y2 = node.y + node.height;
+        bool drawBox = true;
+        switch (node.shape) {
+            case MindShape::Circle:
+            case MindShape::Bang:
+            case MindShape::Cloud:
+                box.type = PrimType::Ellipse;
+                break;
+            case MindShape::Square:
+                box.type = PrimType::Rect;
+                break;
+            case MindShape::Plain:
+                if (i != 0) {
+                    drawBox = false;  // plain text over the branch line
+                    break;
+                }
+                box.type = PrimType::RoundRect;
+                box.radius = 10.0f * scale;
+                break;
+            case MindShape::Rounded:
+            case MindShape::Hexagon:
+                box.type = PrimType::RoundRect;
+                box.radius =
+                    node.shape == MindShape::Rounded
+                        ? (box.y2 - box.y1) * 0.5f
+                        : 8.0f * scale;
+                break;
+        }
+        if (drawBox) {
+            if (i == 0) {
+                box.fill = Role::Accent;
+                box.stroke = Role::None;
+            } else {
+                box.fill = Role::SeriesSoft;
+                box.seriesIndex = branch;
+                box.stroke = Role::Series;
+                box.strokeWidth = 1.3f * scale;
+            }
+            result.prims.push_back(box);
+        }
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = node.text;
+        text.style = i == 0 ? rootStyle : nodeStyle;
+        text.fill = i == 0 ? Role::Background : Role::Text;
+        text.x1 = node.x;
+        text.y1 = node.y;
+        text.x2 = node.x + node.width;
+        text.y2 = node.y + node.height;
+        result.prims.push_back(std::move(text));
+    }
+
+    result.width = maxRight + 8.0f * scale;
+    result.height = maxBottom + 8.0f * scale;
+    result.ok = true;
+    return result;
+}
+
+// --------------------------------------------------------------------------
+// Timelines
+// --------------------------------------------------------------------------
+
+namespace {
+
+struct TimelinePeriod {
+    std::string label;
+    std::vector<std::string> events;
+    size_t section = 0;
+};
+
+}  // namespace
+
+Built buildTimeline(std::string_view source, const Measure& measure,
+                    float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    std::string title;
+    std::vector<std::string> sections;
+    std::vector<TimelinePeriod> periods;
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            if (!startsWithWord(line, "timeline")) {
+                result.error = "Expected timeline header";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "title", &rest)) {
+            title = cleanLabel(rest);
+            continue;
+        }
+        if (startsWithWord(line, "section", &rest)) {
+            sections.push_back(cleanLabel(rest));
+            continue;
+        }
+        // period : event : event ...  (or a continuation ": event")
+        if (line.front() == ':') {
+            if (periods.empty()) {
+                result.error = "Event before any period";
+                return result;
+            }
+            periods.back().events.push_back(
+                cleanLabel(trimView(line.substr(1))));
+            continue;
+        }
+        size_t colon = line.find(':');
+        TimelinePeriod period;
+        period.section = sections.empty() ? 0 : sections.size() - 1;
+        if (colon == std::string_view::npos) {
+            period.label = cleanLabel(line);
+        } else {
+            period.label = cleanLabel(trimView(line.substr(0, colon)));
+            std::string_view remainder = line.substr(colon + 1);
+            size_t start = 0;
+            while (start <= remainder.size()) {
+                size_t next = remainder.find(':', start);
+                if (next == std::string_view::npos) next = remainder.size();
+                std::string event =
+                    cleanLabel(trimView(remainder.substr(start, next - start)));
+                if (!event.empty()) period.events.push_back(std::move(event));
+                if (next == remainder.size()) break;
+                start = next + 1;
+            }
+        }
+        periods.push_back(std::move(period));
+    }
+
+    if (periods.empty()) {
+        result.error = "No periods";
+        return result;
+    }
+    if (sections.empty()) sections.push_back("");
+
+    TextStyle titleStyle;
+    titleStyle.bold = true;
+    titleStyle.scale = 1.1f;
+    TextStyle sectionStyle;
+    sectionStyle.bold = true;
+    sectionStyle.scale = 0.9f;
+    TextStyle periodStyle;
+    periodStyle.bold = true;
+    TextStyle eventStyle;
+    eventStyle.scale = 0.85f;
+
+    // Column widths
+    float maxColumn = 150.0f * scale;
+    std::vector<float> columnWidths(periods.size());
+    std::vector<Size> periodSizes(periods.size());
+    std::vector<std::vector<Size>> eventSizes(periods.size());
+    for (size_t i = 0; i < periods.size(); i++) {
+        periodSizes[i] = measure(periods[i].label, periodStyle, maxColumn);
+        float width = periodSizes[i].w + 20.0f * scale;
+        for (const auto& event : periods[i].events) {
+            Size size = measure(event, eventStyle, maxColumn);
+            eventSizes[i].push_back(size);
+            width = std::max(width, size.w + 16.0f * scale);
+        }
+        columnWidths[i] = std::max(70.0f * scale, width);
+    }
+
+    float columnGap = 10.0f * scale;
+    float y = 4.0f * scale;
+    float totalWidth = 0.0f;
+    for (float width : columnWidths) totalWidth += width + columnGap;
+    totalWidth -= columnGap;
+
+    if (!title.empty()) {
+        Size size = measure(title, titleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = title;
+        text.style = titleStyle;
+        text.fill = Role::Text;
+        text.x1 = 0;
+        text.y1 = y;
+        text.x2 = totalWidth;
+        text.y2 = y + size.h;
+        result.prims.push_back(std::move(text));
+        y += size.h + 12.0f * scale;
+    }
+
+    // Section bands (only when sections are named)
+    bool hasSections = sections.size() > 1 || !sections[0].empty();
+    if (hasSections) {
+        float bandHeight = 24.0f * scale;
+        float x = 0.0f;
+        size_t start = 0;
+        while (start < periods.size()) {
+            size_t section = periods[start].section;
+            size_t end = start;
+            float width = 0.0f;
+            while (end < periods.size() && periods[end].section == section) {
+                width += columnWidths[end] + columnGap;
+                end++;
+            }
+            width -= columnGap;
+            Prim band;
+            band.type = PrimType::RoundRect;
+            band.radius = 5.0f * scale;
+            band.x1 = x;
+            band.y1 = y;
+            band.x2 = x + width;
+            band.y2 = y + bandHeight;
+            band.fill = Role::SeriesSoft;
+            band.seriesIndex = static_cast<int>(section);
+            result.prims.push_back(band);
+            if (!sections[section].empty()) {
+                Prim text;
+                text.type = PrimType::Text;
+                text.text = sections[section];
+                text.style = sectionStyle;
+                text.fill = Role::Text;
+                text.x1 = band.x1;
+                text.y1 = band.y1;
+                text.x2 = band.x2;
+                text.y2 = band.y2;
+                result.prims.push_back(std::move(text));
+            }
+            x += width + columnGap;
+            start = end;
+        }
+        y += bandHeight + 10.0f * scale;
+    }
+
+    // Period row height
+    float periodHeight = 0.0f;
+    for (const auto& size : periodSizes) {
+        periodHeight = std::max(periodHeight, size.h + 12.0f * scale);
+    }
+    float periodTop = y;
+    float periodBottom = y + periodHeight;
+
+    // Timeline spine behind the period boxes
+    Prim spine;
+    spine.type = PrimType::Line;
+    spine.x1 = 0;
+    spine.y1 = (periodTop + periodBottom) * 0.5f;
+    spine.x2 = totalWidth;
+    spine.y2 = spine.y1;
+    spine.stroke = Role::Muted;
+    spine.strokeWidth = 2.0f * scale;
+    result.prims.push_back(spine);
+
+    float x = 0.0f;
+    float maxBottom = periodBottom;
+    for (size_t i = 0; i < periods.size(); i++) {
+        size_t section = periods[i].section;
+        Prim box;
+        box.type = PrimType::RoundRect;
+        box.radius = 6.0f * scale;
+        box.x1 = x;
+        box.y1 = periodTop;
+        box.x2 = x + columnWidths[i];
+        box.y2 = periodBottom;
+        box.fill = Role::Series;
+        box.seriesIndex = static_cast<int>(section);
+        result.prims.push_back(box);
+        Prim label;
+        label.type = PrimType::Text;
+        label.text = periods[i].label;
+        label.style = periodStyle;
+        label.fill = Role::Background;
+        label.x1 = box.x1;
+        label.y1 = box.y1;
+        label.x2 = box.x2;
+        label.y2 = box.y2;
+        result.prims.push_back(std::move(label));
+
+        // Events stacked below, connected by a dotted drop line
+        float eventY = periodBottom + 10.0f * scale;
+        for (size_t e = 0; e < periods[i].events.size(); e++) {
+            float boxHeight = eventSizes[i][e].h + 10.0f * scale;
+            Prim drop;
+            drop.type = PrimType::Line;
+            drop.x1 = x + columnWidths[i] * 0.5f;
+            drop.y1 = e == 0 ? periodBottom : eventY - 6.0f * scale;
+            drop.x2 = drop.x1;
+            drop.y2 = eventY;
+            drop.stroke = Role::Muted;
+            drop.strokeWidth = 1.0f * scale;
+            drop.dashed = true;
+            result.prims.push_back(drop);
+            Prim eventBox;
+            eventBox.type = PrimType::RoundRect;
+            eventBox.radius = 5.0f * scale;
+            eventBox.x1 = x + 2.0f * scale;
+            eventBox.y1 = eventY;
+            eventBox.x2 = x + columnWidths[i] - 2.0f * scale;
+            eventBox.y2 = eventY + boxHeight;
+            eventBox.fill = Role::SeriesSoft;
+            eventBox.seriesIndex = static_cast<int>(section);
+            eventBox.stroke = Role::Series;
+            eventBox.strokeWidth = 1.0f * scale;
+            result.prims.push_back(eventBox);
+            Prim text;
+            text.type = PrimType::Text;
+            text.text = periods[i].events[e];
+            text.style = eventStyle;
+            text.fill = Role::Text;
+            text.x1 = eventBox.x1 + 6.0f * scale;
+            text.y1 = eventBox.y1;
+            text.x2 = eventBox.x2 - 6.0f * scale;
+            text.y2 = eventBox.y2;
+            result.prims.push_back(std::move(text));
+            eventY += boxHeight + 6.0f * scale;
+        }
+        maxBottom = std::max(maxBottom, eventY);
+        x += columnWidths[i] + columnGap;
+    }
+
+    result.width = totalWidth;
+    result.height = maxBottom + 8.0f * scale;
+    result.ok = true;
+    return result;
+}
+
+// --------------------------------------------------------------------------
+// User journeys
+// --------------------------------------------------------------------------
+
+namespace {
+
+struct JourneyTask {
+    std::string name;
+    float score = 3.0f;
+    std::vector<std::string> actors;
+    size_t section = 0;
+};
+
+}  // namespace
+
+Built buildJourney(std::string_view source, const Measure& measure,
+                   float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    std::string title;
+    std::vector<std::string> sections;
+    std::vector<JourneyTask> tasks;
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            if (!startsWithWord(line, "journey")) {
+                result.error = "Expected journey header";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "title", &rest)) {
+            title = cleanLabel(rest);
+            continue;
+        }
+        if (startsWithWord(line, "section", &rest)) {
+            sections.push_back(cleanLabel(rest));
+            continue;
+        }
+        // Task name: score: actor, actor
+        size_t first = line.find(':');
+        if (first == std::string_view::npos) {
+            result.error = "Unsupported journey statement";
+            return result;
+        }
+        JourneyTask task;
+        task.name = cleanLabel(trimView(line.substr(0, first)));
+        task.section = sections.empty() ? 0 : sections.size() - 1;
+        std::string_view remainder = line.substr(first + 1);
+        size_t second = remainder.find(':');
+        std::string_view scoreText =
+            second == std::string_view::npos ? remainder
+                                             : remainder.substr(0, second);
+        try {
+            task.score = std::stof(std::string(trimView(scoreText)));
+        } catch (...) {
+            result.error = "Bad journey score";
+            return result;
+        }
+        if (second != std::string_view::npos) {
+            std::string_view actors = remainder.substr(second + 1);
+            size_t position = 0;
+            while (position <= actors.size()) {
+                size_t comma = actors.find(',', position);
+                if (comma == std::string_view::npos) comma = actors.size();
+                std::string actor(
+                    trimView(actors.substr(position, comma - position)));
+                if (!actor.empty()) task.actors.push_back(std::move(actor));
+                if (comma == actors.size()) break;
+                position = comma + 1;
+            }
+        }
+        tasks.push_back(std::move(task));
+    }
+
+    if (tasks.empty()) {
+        result.error = "No tasks";
+        return result;
+    }
+    if (sections.empty()) sections.push_back("");
+
+    TextStyle titleStyle;
+    titleStyle.bold = true;
+    titleStyle.scale = 1.1f;
+    TextStyle sectionStyle;
+    sectionStyle.bold = true;
+    sectionStyle.scale = 0.9f;
+    TextStyle taskStyle;
+    taskStyle.scale = 0.85f;
+    TextStyle actorStyle;
+    actorStyle.scale = 0.75f;
+    TextStyle scoreStyle;
+    scoreStyle.scale = 0.8f;
+    scoreStyle.bold = true;
+
+    float columnWidth = 96.0f * scale;
+    float columnGap = 8.0f * scale;
+    float totalWidth =
+        tasks.size() * (columnWidth + columnGap) - columnGap;
+
+    float y = 4.0f * scale;
+    if (!title.empty()) {
+        Size size = measure(title, titleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = title;
+        text.style = titleStyle;
+        text.fill = Role::Text;
+        text.x1 = 0;
+        text.y1 = y;
+        text.x2 = totalWidth;
+        text.y2 = y + size.h;
+        result.prims.push_back(std::move(text));
+        y += size.h + 12.0f * scale;
+    }
+
+    bool hasSections = sections.size() > 1 || !sections[0].empty();
+    if (hasSections) {
+        float bandHeight = 24.0f * scale;
+        size_t start = 0;
+        float x = 0.0f;
+        while (start < tasks.size()) {
+            size_t section = tasks[start].section;
+            size_t end = start;
+            float width = 0.0f;
+            while (end < tasks.size() && tasks[end].section == section) {
+                width += columnWidth + columnGap;
+                end++;
+            }
+            width -= columnGap;
+            Prim band;
+            band.type = PrimType::RoundRect;
+            band.radius = 5.0f * scale;
+            band.x1 = x;
+            band.y1 = y;
+            band.x2 = x + width;
+            band.y2 = y + bandHeight;
+            band.fill = Role::SeriesSoft;
+            band.seriesIndex = static_cast<int>(section);
+            result.prims.push_back(band);
+            if (!sections[section].empty()) {
+                Prim text;
+                text.type = PrimType::Text;
+                text.text = sections[section];
+                text.style = sectionStyle;
+                text.fill = Role::Text;
+                text.x1 = band.x1;
+                text.y1 = band.y1;
+                text.x2 = band.x2;
+                text.y2 = band.y2;
+                result.prims.push_back(std::move(text));
+            }
+            x += width + columnGap;
+            start = end;
+        }
+        y += bandHeight + 10.0f * scale;
+    }
+
+    // Task labels (wrapped) above the score band
+    float labelHeight = 0.0f;
+    std::vector<Size> labelSizes(tasks.size());
+    for (size_t i = 0; i < tasks.size(); i++) {
+        labelSizes[i] =
+            measure(tasks[i].name, taskStyle, columnWidth - 8.0f * scale);
+        labelHeight = std::max(labelHeight, labelSizes[i].h);
+    }
+    float labelTop = y;
+    y += labelHeight + 10.0f * scale;
+
+    // Score lane: higher score = higher dot, 1..7
+    float laneHeight = 110.0f * scale;
+    float laneTop = y;
+    float laneBottom = y + laneHeight;
+    auto scoreY = [&](float score) {
+        float clamped = std::max(1.0f, std::min(7.0f, score));
+        return laneBottom -
+               (clamped - 1.0f) / 6.0f * (laneHeight - 18.0f * scale) -
+               9.0f * scale;
+    };
+    auto scoreColor = [](float score, float& r, float& g, float& b) {
+        // 1 = red, 4 = amber, 7 = green
+        float t = (std::max(1.0f, std::min(7.0f, score)) - 1.0f) / 6.0f;
+        if (t < 0.5f) {
+            float k = t * 2.0f;
+            r = 0.83f + (0.93f - 0.83f) * k;
+            g = 0.28f + (0.69f - 0.28f) * k;
+            b = 0.24f + (0.17f - 0.24f) * k;
+        } else {
+            float k = (t - 0.5f) * 2.0f;
+            r = 0.93f + (0.30f - 0.93f) * k;
+            g = 0.69f + (0.69f - 0.69f) * k;
+            b = 0.17f + (0.35f - 0.17f) * k;
+        }
+    };
+
+    // Connecting line through the dots
+    for (size_t i = 0; i + 1 < tasks.size(); i++) {
+        Prim segment;
+        segment.type = PrimType::Line;
+        segment.x1 = (i + 0.5f) * (columnWidth + columnGap);
+        segment.y1 = scoreY(tasks[i].score);
+        segment.x2 = (i + 1.5f) * (columnWidth + columnGap);
+        segment.y2 = scoreY(tasks[i + 1].score);
+        segment.stroke = Role::Muted;
+        segment.strokeWidth = 1.4f * scale;
+        result.prims.push_back(segment);
+    }
+
+    float maxBottom = laneBottom;
+    for (size_t i = 0; i < tasks.size(); i++) {
+        float x = i * (columnWidth + columnGap);
+        float centerX = x + columnWidth * 0.5f;
+        Prim label;
+        label.type = PrimType::Text;
+        label.text = tasks[i].name;
+        label.style = taskStyle;
+        label.fill = Role::Text;
+        label.x1 = x + 4.0f * scale;
+        label.y1 = labelTop;
+        label.x2 = x + columnWidth - 4.0f * scale;
+        label.y2 = labelTop + labelHeight;
+        result.prims.push_back(std::move(label));
+
+        float dotY = scoreY(tasks[i].score);
+        float radius = 11.0f * scale;
+        Prim dot;
+        dot.type = PrimType::Ellipse;
+        dot.x1 = centerX - radius;
+        dot.y1 = dotY - radius;
+        dot.x2 = centerX + radius;
+        dot.y2 = dotY + radius;
+        dot.fill = Role::Custom;
+        scoreColor(tasks[i].score, dot.customR, dot.customG, dot.customB);
+        result.prims.push_back(dot);
+        char buffer[8];
+        snprintf(buffer, sizeof(buffer), "%d",
+                 static_cast<int>(std::lround(tasks[i].score)));
+        Prim score;
+        score.type = PrimType::Text;
+        score.text = buffer;
+        score.style = scoreStyle;
+        score.fill = Role::Background;
+        score.x1 = centerX - radius;
+        score.y1 = dotY - radius;
+        score.x2 = centerX + radius;
+        score.y2 = dotY + radius;
+        result.prims.push_back(std::move(score));
+
+        if (!tasks[i].actors.empty()) {
+            std::string joined;
+            for (const auto& actor : tasks[i].actors) {
+                if (!joined.empty()) joined += ", ";
+                joined += actor;
+            }
+            Size size =
+                measure(joined, actorStyle, columnWidth - 4.0f * scale);
+            Prim actors;
+            actors.type = PrimType::Text;
+            actors.text = joined;
+            actors.style = actorStyle;
+            actors.fill = Role::Muted;
+            actors.x1 = x + 2.0f * scale;
+            actors.y1 = laneBottom + 4.0f * scale;
+            actors.x2 = x + columnWidth - 2.0f * scale;
+            actors.y2 = laneBottom + 4.0f * scale + size.h;
+            maxBottom = std::max(maxBottom, actors.y2);
+            result.prims.push_back(std::move(actors));
+        }
+    }
+
+    result.width = totalWidth;
+    result.height = maxBottom + 8.0f * scale;
+    result.ok = true;
+    return result;
+}
+
+}  // namespace detail
+}  // namespace mermaidext

--- a/src/mermaid_pie.cpp
+++ b/src/mermaid_pie.cpp
@@ -1,0 +1,249 @@
+// Native Mermaid pie chart renderer.
+//
+// Grammar: `pie` header with optional `showData` and `title <text>` (on the
+// header line or their own lines), then one `"Label" : value` entry per
+// line. Slices run clockwise from 12 o'clock in source order, colored from
+// the theme-derived categorical palette; the legend sits to the right.
+
+#include "mermaid_ext.h"
+
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace mermaidext {
+namespace detail {
+
+namespace {
+
+constexpr float kRadius = 105.0f;
+constexpr float kLegendGap = 30.0f;
+constexpr float kLegendSwatch = 12.0f;
+constexpr float kLegendRowGap = 8.0f;
+constexpr float kPi = 3.14159265f;
+
+struct PieEntry {
+    std::string label;
+    float value = 0.0f;
+};
+
+}  // namespace
+
+Built buildPie(std::string_view source, const Measure& measure, float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    bool showData = false;
+    std::string title;
+    std::vector<PieEntry> entries;
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            std::string_view rest;
+            if (!startsWithWord(line, "pie", &rest)) {
+                result.error = "Expected pie header";
+                return result;
+            }
+            sawHeader = true;
+            if (startsWithWord(rest, "showData", &rest)) showData = true;
+            std::string_view titleRest;
+            if (startsWithWord(rest, "title", &titleRest)) {
+                title = cleanLabel(titleRest);
+            }
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "showData", &rest)) {
+            showData = true;
+            continue;
+        }
+        if (startsWithWord(line, "title", &rest)) {
+            title = cleanLabel(rest);
+            continue;
+        }
+        // "Label" : value
+        if (line.front() != '"') {
+            result.error = "Expected a quoted slice label";
+            return result;
+        }
+        size_t closeQuote = line.find('"', 1);
+        if (closeQuote == std::string_view::npos) {
+            result.error = "Unterminated slice label";
+            return result;
+        }
+        PieEntry entry;
+        entry.label = cleanLabel(line.substr(1, closeQuote - 1));
+        std::string_view remainder = trimView(line.substr(closeQuote + 1));
+        if (remainder.empty() || remainder.front() != ':') {
+            result.error = "Expected : after slice label";
+            return result;
+        }
+        remainder = trimView(remainder.substr(1));
+        try {
+            entry.value = std::stof(std::string(remainder));
+        } catch (...) {
+            result.error = "Bad slice value";
+            return result;
+        }
+        if (entry.value < 0.0f) {
+            result.error = "Negative slice value";
+            return result;
+        }
+        entries.push_back(std::move(entry));
+    }
+
+    float total = 0.0f;
+    for (const auto& entry : entries) total += entry.value;
+    if (entries.empty() || total <= 0.0f) {
+        result.error = "No slice data";
+        return result;
+    }
+
+    TextStyle titleStyle;
+    titleStyle.bold = true;
+    titleStyle.scale = 1.1f;
+    TextStyle legendStyle;
+    TextStyle sliceStyle;
+    sliceStyle.scale = 0.9f;
+    sliceStyle.bold = true;
+
+    float radius = kRadius * scale;
+    float y = 4.0f * scale;
+
+    // Legend measurement
+    float legendWidth = 0.0f;
+    std::vector<std::string> legendLabels;
+    std::vector<Size> legendSizes;
+    for (const auto& entry : entries) {
+        std::string label = entry.label;
+        if (showData) {
+            char buffer[48];
+            float rounded = std::round(entry.value * 100.0f) / 100.0f;
+            if (rounded == std::floor(rounded)) {
+                snprintf(buffer, sizeof(buffer), " (%d)",
+                         static_cast<int>(rounded));
+            } else {
+                snprintf(buffer, sizeof(buffer), " (%.2f)", rounded);
+            }
+            label += buffer;
+        }
+        Size size = measure(label, legendStyle, 0.0f);
+        legendWidth = std::max(legendWidth,
+                               size.w + (kLegendSwatch + 10.0f) * scale);
+        legendLabels.push_back(std::move(label));
+        legendSizes.push_back(size);
+    }
+
+    float diagramWidth =
+        radius * 2.0f + kLegendGap * scale + legendWidth + 8.0f * scale;
+
+    if (!title.empty()) {
+        Size titleSize = measure(title, titleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = title;
+        text.style = titleStyle;
+        text.fill = Role::Text;
+        text.x1 = 0;
+        text.y1 = y;
+        text.x2 = diagramWidth;
+        text.y2 = y + titleSize.h;
+        result.prims.push_back(std::move(text));
+        y += titleSize.h + 12.0f * scale;
+    }
+
+    float centerX = radius + 4.0f * scale;
+    float centerY = y + radius;
+
+    float angle = -kPi * 0.5f;  // 12 o'clock, clockwise
+    for (size_t i = 0; i < entries.size(); i++) {
+        float sweep = entries[i].value / total * kPi * 2.0f;
+        Prim slice;
+        slice.type = PrimType::Slice;
+        slice.x1 = centerX;
+        slice.y1 = centerY;
+        slice.radius = radius;
+        slice.a0 = angle;
+        slice.a1 = angle + sweep;
+        slice.fill = Role::Series;
+        slice.seriesIndex = static_cast<int>(i);
+        slice.stroke = Role::Background;
+        slice.strokeWidth = 2.0f * scale;
+        result.prims.push_back(slice);
+
+        // Percentage label inside sufficiently large slices
+        float fraction = entries[i].value / total;
+        if (fraction >= 0.04f) {
+            char buffer[16];
+            snprintf(buffer, sizeof(buffer), "%d%%",
+                     static_cast<int>(std::round(fraction * 100.0f)));
+            float middle = angle + sweep * 0.5f;
+            float labelRadius = radius * 0.62f;
+            float labelX = centerX + labelRadius * std::cos(middle);
+            float labelY = centerY + labelRadius * std::sin(middle);
+            Prim text;
+            text.type = PrimType::Text;
+            text.text = buffer;
+            text.style = sliceStyle;
+            text.fill = Role::Background;
+            text.x1 = labelX - 24.0f * scale;
+            text.y1 = labelY - 10.0f * scale;
+            text.x2 = labelX + 24.0f * scale;
+            text.y2 = labelY + 10.0f * scale;
+            result.prims.push_back(std::move(text));
+        }
+        angle += sweep;
+    }
+
+    // Legend, vertically centered against the pie
+    float legendRowHeight = 0.0f;
+    for (const auto& size : legendSizes) {
+        legendRowHeight = std::max(legendRowHeight, size.h);
+    }
+    legendRowHeight = std::max(legendRowHeight, kLegendSwatch * scale);
+    float legendHeight =
+        entries.size() * legendRowHeight +
+        (entries.size() > 0 ? (entries.size() - 1) * kLegendRowGap * scale
+                            : 0.0f);
+    float legendX = centerX + radius + kLegendGap * scale;
+    float legendY = centerY - legendHeight * 0.5f;
+    for (size_t i = 0; i < entries.size(); i++) {
+        float rowTop = legendY + i * (legendRowHeight + kLegendRowGap * scale);
+        Prim swatch;
+        swatch.type = PrimType::RoundRect;
+        swatch.radius = 3.0f * scale;
+        swatch.x1 = legendX;
+        swatch.y1 = rowTop + (legendRowHeight - kLegendSwatch * scale) * 0.5f;
+        swatch.x2 = legendX + kLegendSwatch * scale;
+        swatch.y2 = swatch.y1 + kLegendSwatch * scale;
+        swatch.fill = Role::Series;
+        swatch.seriesIndex = static_cast<int>(i);
+        result.prims.push_back(swatch);
+
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = legendLabels[i];
+        text.style = legendStyle;
+        text.fill = Role::Text;
+        text.alignH = -1;
+        text.x1 = legendX + (kLegendSwatch + 10.0f) * scale;
+        text.y1 = rowTop;
+        text.x2 = legendX + legendWidth + 8.0f * scale;
+        text.y2 = rowTop + legendRowHeight;
+        result.prims.push_back(std::move(text));
+    }
+
+    result.width = diagramWidth;
+    result.height = std::max(centerY + radius, legendY + legendHeight) +
+                    8.0f * scale;
+    result.ok = true;
+    return result;
+}
+
+}  // namespace detail
+}  // namespace mermaidext

--- a/src/mermaid_seq.cpp
+++ b/src/mermaid_seq.cpp
@@ -1,0 +1,1012 @@
+// Native Mermaid sequence diagram renderer (issue #108).
+//
+// Supported grammar: participant/actor declarations (with `as` aliases and
+// <br/> line breaks), implicit participants, every arrow family
+// (->, -->, ->>, -->>, -), --), -x, --x), activation shorthand +/- and
+// activate/deactivate statements, Note over/left of/right of, autonumber,
+// title, and loop/alt/else/opt/par/and/critical/option/break/rect frames.
+// Unknown statements fail the parse so the document falls back to showing
+// the source instead of silently dropping content.
+
+#include "mermaid_ext.h"
+
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace mermaidext {
+namespace detail {
+
+namespace {
+
+// Base geometry in unscaled units
+constexpr float kHeaderPadX = 14.0f;
+constexpr float kHeaderPadY = 9.0f;
+constexpr float kHeaderMinWidth = 64.0f;
+constexpr float kColumnMinGap = 46.0f;
+constexpr float kMessageTextGap = 4.0f;   // text baseline gap above the line
+constexpr float kRowGap = 16.0f;          // space after each message row
+constexpr float kNotePadX = 10.0f;
+constexpr float kNotePadY = 6.0f;
+constexpr float kNoteMargin = 12.0f;
+constexpr float kFramePad = 10.0f;
+constexpr float kFrameLabelPadX = 8.0f;
+constexpr float kFrameLabelPadY = 4.0f;
+constexpr float kSelfLoopWidth = 36.0f;
+constexpr float kActivationWidth = 9.0f;
+constexpr float kActivationNudge = 5.0f;  // extra x-offset per nesting level
+constexpr float kEdgePad = 6.0f;          // outer margin around the diagram
+
+struct Participant {
+    std::string id;
+    std::string label;
+    Size headerSize;
+    float center = 0.0f;  // column x
+};
+
+enum class EventType {
+    Message,
+    Note,
+    FrameOpen,     // loop/alt/opt/par/critical/break/rect
+    FrameDivider,  // else/and/option
+    FrameClose,    // end
+    Activate,
+    Deactivate,
+};
+
+enum class ArrowLine { Solid, Dashed };
+enum class ArrowHead { Filled, Open, Cross, NoneHead };
+enum class NotePos { Over, LeftOf, RightOf };
+
+struct Event {
+    EventType type = EventType::Message;
+    size_t from = 0;
+    size_t to = 0;
+    std::string text;
+    ArrowLine line = ArrowLine::Solid;
+    ArrowHead head = ArrowHead::Filled;
+    bool activateTarget = false;
+    bool deactivateSource = false;
+    NotePos notePos = NotePos::Over;
+    std::string frameKeyword;  // loop/alt/...
+    Size textSize;
+    int number = 0;  // autonumber (0 = off)
+};
+
+struct Frame {
+    size_t openEvent = 0;
+    float top = 0.0f;
+    float labelBottom = 0.0f;
+    float bottom = 0.0f;
+    size_t minColumn = SIZE_MAX;
+    size_t maxColumn = 0;
+    float extraLeft = 0.0f;   // note/self-loop overhang past the edge columns
+    float extraRight = 0.0f;
+    int depth = 0;
+    std::vector<std::pair<float, std::string>> dividers;  // y + label
+    std::string keyword;
+    std::string label;
+    Size labelSize;
+    Size keywordSize;
+};
+
+struct ActivationSpan {
+    size_t participant = 0;
+    int level = 0;
+    float top = 0.0f;
+    float bottom = 0.0f;
+};
+
+bool parseArrow(std::string_view text, size_t& position, ArrowLine& line,
+                ArrowHead& head, bool& activate, bool& deactivate) {
+    // Longest match first: -->> --> --) --x ->> -> -) -x --
+    struct Pattern {
+        std::string_view token;
+        ArrowLine line;
+        ArrowHead head;
+    };
+    static const Pattern kPatterns[] = {
+        {"-->>", ArrowLine::Dashed, ArrowHead::Filled},
+        {"--)", ArrowLine::Dashed, ArrowHead::Open},
+        {"--x", ArrowLine::Dashed, ArrowHead::Cross},
+        {"-->", ArrowLine::Dashed, ArrowHead::NoneHead},
+        {"->>", ArrowLine::Solid, ArrowHead::Filled},
+        {"-)", ArrowLine::Solid, ArrowHead::Open},
+        {"-x", ArrowLine::Solid, ArrowHead::Cross},
+        {"->", ArrowLine::Solid, ArrowHead::NoneHead},
+    };
+    for (const auto& pattern : kPatterns) {
+        if (text.substr(position, pattern.token.size()) == pattern.token) {
+            position += pattern.token.size();
+            line = pattern.line;
+            head = pattern.head;
+            activate = false;
+            deactivate = false;
+            if (position < text.size() && text[position] == '+') {
+                activate = true;
+                position++;
+            } else if (position < text.size() && text[position] == '-') {
+                deactivate = true;
+                position++;
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+Built buildSequence(std::string_view source, const Measure& measure,
+                    float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    std::vector<Participant> participants;
+    std::map<std::string, size_t, std::less<>> participantIds;
+    std::vector<Event> events;
+    std::string title;
+    bool autonumber = false;
+    int messageNumber = 0;
+    int frameDepth = 0;
+
+    auto ensureParticipant = [&](std::string_view id,
+                                 std::string_view label) -> size_t {
+        auto found = participantIds.find(id);
+        if (found != participantIds.end()) {
+            if (!label.empty()) {
+                participants[found->second].label = cleanLabel(label);
+            }
+            return found->second;
+        }
+        Participant participant;
+        participant.id = std::string(id);
+        participant.label = cleanLabel(label.empty() ? id : label);
+        participants.push_back(std::move(participant));
+        participantIds.emplace(std::string(id), participants.size() - 1);
+        return participants.size() - 1;
+    };
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            if (!startsWithWord(line, "sequenceDiagram")) {
+                result.error = "Expected sequenceDiagram header";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+
+        std::string_view rest;
+        if (startsWithWord(line, "participant", &rest) ||
+            startsWithWord(line, "actor", &rest)) {
+            size_t asPos = std::string_view::npos;
+            for (size_t i = 0; i + 4 <= rest.size(); i++) {
+                if (rest.substr(i, 4) == " as " ||
+                    (rest.substr(i, 4) == " AS ")) {
+                    asPos = i;
+                    break;
+                }
+            }
+            if (asPos == std::string_view::npos) {
+                ensureParticipant(trimView(rest), {});
+            } else {
+                ensureParticipant(trimView(rest.substr(0, asPos)),
+                                  trimView(rest.substr(asPos + 4)));
+            }
+            continue;
+        }
+        if (startsWithWord(line, "autonumber", &rest)) {
+            autonumber = !startsWithWord(rest, "off");
+            continue;
+        }
+        if (startsWithWord(line, "title", &rest)) {
+            title = cleanLabel(rest);
+            continue;
+        }
+        if (startsWithWord(line, "link", &rest) ||
+            startsWithWord(line, "links", &rest) ||
+            startsWithWord(line, "box", &rest)) {
+            // Participant links are hover metadata in mermaid.js; boxes are
+            // cosmetic groupings. Ignore both rather than failing.
+            continue;
+        }
+        if (startsWithWord(line, "end") && frameDepth == 0 &&
+            line.size() == 3) {
+            // stray `end` closing an ignored box
+            continue;
+        }
+        if (startsWithWord(line, "activate", &rest) ||
+            startsWithWord(line, "deactivate", &rest)) {
+            Event event;
+            event.type = startsWithWord(line, "activate", nullptr)
+                             ? EventType::Activate
+                             : EventType::Deactivate;
+            event.from = ensureParticipant(trimView(rest), {});
+            events.push_back(std::move(event));
+            continue;
+        }
+        if (startsWithWord(line, "note", &rest)) {
+            Event event;
+            event.type = EventType::Note;
+            std::string_view spec = rest;
+            if (startsWithWord(spec, "over", &spec)) {
+                event.notePos = NotePos::Over;
+            } else if (startsWithWord(spec, "left", &spec)) {
+                startsWithWord(spec, "of", &spec);
+                event.notePos = NotePos::LeftOf;
+            } else if (startsWithWord(spec, "right", &spec)) {
+                startsWithWord(spec, "of", &spec);
+                event.notePos = NotePos::RightOf;
+            } else {
+                result.error = "Unsupported note position";
+                return result;
+            }
+            size_t colon = spec.find(':');
+            if (colon == std::string_view::npos) {
+                result.error = "Note without text";
+                return result;
+            }
+            std::string_view targets = trimView(spec.substr(0, colon));
+            event.text = cleanLabel(trimView(spec.substr(colon + 1)));
+            size_t comma = targets.find(',');
+            if (comma == std::string_view::npos) {
+                event.from = ensureParticipant(trimView(targets), {});
+                event.to = event.from;
+            } else {
+                event.from =
+                    ensureParticipant(trimView(targets.substr(0, comma)), {});
+                event.to = ensureParticipant(
+                    trimView(targets.substr(comma + 1)), {});
+                if (event.from > event.to) std::swap(event.from, event.to);
+            }
+            events.push_back(std::move(event));
+            continue;
+        }
+        {
+            std::string_view frameRest;
+            static const char* kFrames[] = {"loop", "alt", "opt", "par",
+                                            "critical", "break", "rect"};
+            bool isFrame = false;
+            for (const char* keyword : kFrames) {
+                if (startsWithWord(line, keyword, &frameRest)) {
+                    Event event;
+                    event.type = EventType::FrameOpen;
+                    event.frameKeyword = keyword;
+                    event.text = (event.frameKeyword == "rect")
+                                     ? std::string()
+                                     : cleanLabel(frameRest);
+                    events.push_back(std::move(event));
+                    frameDepth++;
+                    isFrame = true;
+                    break;
+                }
+            }
+            if (isFrame) continue;
+            static const char* kDividers[] = {"else", "and", "option"};
+            bool isDivider = false;
+            for (const char* keyword : kDividers) {
+                if (startsWithWord(line, keyword, &frameRest)) {
+                    if (frameDepth == 0) {
+                        result.error = "Divider outside a frame";
+                        return result;
+                    }
+                    Event event;
+                    event.type = EventType::FrameDivider;
+                    event.frameKeyword = keyword;
+                    event.text = cleanLabel(frameRest);
+                    events.push_back(std::move(event));
+                    isDivider = true;
+                    break;
+                }
+            }
+            if (isDivider) continue;
+            if (startsWithWord(line, "end")) {
+                if (frameDepth == 0) {
+                    result.error = "end without an open frame";
+                    return result;
+                }
+                Event event;
+                event.type = EventType::FrameClose;
+                events.push_back(std::move(event));
+                frameDepth--;
+                continue;
+            }
+        }
+
+        // Message: <id> <arrow> <id> [: text]
+        {
+            size_t arrowPos = std::string_view::npos;
+            size_t probe = 0;
+            ArrowLine arrowLine = ArrowLine::Solid;
+            ArrowHead arrowHead = ArrowHead::Filled;
+            bool activate = false, deactivate = false;
+            // Find the first position where an arrow token parses
+            for (size_t i = 0; i < line.size(); i++) {
+                if (line[i] != '-') continue;
+                size_t position = i;
+                if (parseArrow(line, position, arrowLine, arrowHead, activate,
+                               deactivate)) {
+                    arrowPos = i;
+                    probe = position;
+                    break;
+                }
+            }
+            if (arrowPos == std::string_view::npos || arrowPos == 0) {
+                result.error = "Unsupported sequence statement";
+                return result;
+            }
+            std::string_view fromId = trimView(line.substr(0, arrowPos));
+            std::string_view afterArrow = line.substr(probe);
+            std::string_view toId = afterArrow;
+            std::string_view text;
+            size_t colon = afterArrow.find(':');
+            if (colon != std::string_view::npos) {
+                toId = trimView(afterArrow.substr(0, colon));
+                text = trimView(afterArrow.substr(colon + 1));
+            } else {
+                toId = trimView(afterArrow);
+            }
+            if (fromId.empty() || toId.empty()) {
+                result.error = "Message needs two participants";
+                return result;
+            }
+            Event event;
+            event.type = EventType::Message;
+            event.from = ensureParticipant(fromId, {});
+            event.to = ensureParticipant(toId, {});
+            event.text = cleanLabel(text);
+            event.line = arrowLine;
+            event.head = arrowHead;
+            event.activateTarget = activate;
+            event.deactivateSource = deactivate;
+            if (autonumber) event.number = ++messageNumber;
+            events.push_back(std::move(event));
+        }
+    }
+
+    if (participants.empty()) {
+        result.error = "No participants";
+        return result;
+    }
+
+    // --- measure ---
+    TextStyle headerStyle;
+    headerStyle.bold = true;
+    TextStyle textStyle;
+    TextStyle frameKeywordStyle;
+    frameKeywordStyle.bold = true;
+    frameKeywordStyle.scale = 0.9f;
+    TextStyle frameLabelStyle;
+    frameLabelStyle.scale = 0.9f;
+    frameLabelStyle.italic = true;
+
+    for (auto& participant : participants) {
+        Size measured = measure(participant.label, headerStyle, 0.0f);
+        participant.headerSize.w = std::max(kHeaderMinWidth * scale,
+                                            measured.w + kHeaderPadX * 2 * scale);
+        participant.headerSize.h = measured.h + kHeaderPadY * 2 * scale;
+    }
+    float headerHeight = 0.0f;
+    for (const auto& participant : participants) {
+        headerHeight = std::max(headerHeight, participant.headerSize.h);
+    }
+
+    for (auto& event : events) {
+        if (event.type == EventType::Message) {
+            std::string display = event.text;
+            if (event.number > 0) {
+                display = std::to_string(event.number) + ". " + display;
+            }
+            event.text = display;
+            if (!display.empty()) {
+                event.textSize = measure(display, textStyle, 0.0f);
+            }
+        } else if (event.type == EventType::Note) {
+            Size measured = measure(event.text, textStyle, 220.0f * scale);
+            event.textSize.w = measured.w + kNotePadX * 2 * scale;
+            event.textSize.h = measured.h + kNotePadY * 2 * scale;
+        }
+    }
+
+    // --- column spacing ---
+    size_t count = participants.size();
+    std::vector<float> gaps(count > 0 ? count - 1 : 0,
+                            kColumnMinGap * scale);
+    float leftExtra = 0.0f;   // notes hanging left of the first column
+    float rightExtra = 0.0f;  // self loops / notes right of the last column
+
+    auto requireSpan = [&](size_t a, size_t b, float needed) {
+        if (a == b) return;
+        if (a > b) std::swap(a, b);
+        float current = 0.0f;
+        for (size_t i = a; i < b; i++) current += gaps[i];
+        // Adjacent columns must clear each other's header halves too
+        if (current < needed) {
+            float add = (needed - current) / static_cast<float>(b - a);
+            for (size_t i = a; i < b; i++) gaps[i] += add;
+        }
+    };
+
+    // Headers must not overlap
+    for (size_t i = 0; i + 1 < count; i++) {
+        requireSpan(i, i + 1,
+                    participants[i].headerSize.w * 0.5f +
+                        participants[i + 1].headerSize.w * 0.5f +
+                        kColumnMinGap * scale * 0.5f);
+    }
+
+    for (auto& event : events) {
+        if (event.type == EventType::Message) {
+            if (event.from == event.to) {
+                float needed = kSelfLoopWidth * scale + event.textSize.w +
+                               10.0f * scale;
+                if (event.from + 1 < count) {
+                    requireSpan(event.from, event.from + 1, needed);
+                } else {
+                    rightExtra = std::max(rightExtra, needed);
+                }
+            } else {
+                requireSpan(event.from, event.to,
+                            event.textSize.w + 20.0f * scale);
+            }
+        } else if (event.type == EventType::Note) {
+            if (event.notePos == NotePos::Over) {
+                if (event.from == event.to) {
+                    float half = event.textSize.w * 0.5f;
+                    if (event.from > 0) {
+                        requireSpan(event.from - 1, event.from, half);
+                    } else {
+                        leftExtra = std::max(leftExtra, half);
+                    }
+                    if (event.from + 1 < count) {
+                        requireSpan(event.from, event.from + 1, half);
+                    } else {
+                        rightExtra = std::max(rightExtra, half);
+                    }
+                } else {
+                    requireSpan(event.from, event.to,
+                                event.textSize.w - 2.0f * kNoteMargin * scale);
+                }
+            } else if (event.notePos == NotePos::LeftOf) {
+                float needed = event.textSize.w + kNoteMargin * scale;
+                if (event.from > 0) {
+                    requireSpan(event.from - 1, event.from, needed);
+                } else {
+                    leftExtra = std::max(leftExtra, needed);
+                }
+            } else {
+                float needed = event.textSize.w + kNoteMargin * scale;
+                if (event.from + 1 < count) {
+                    requireSpan(event.from, event.from + 1, needed);
+                } else {
+                    rightExtra = std::max(rightExtra, needed);
+                }
+            }
+        }
+    }
+
+    // Frames inset horizontally: reserve room for the deepest nesting
+    int maxDepth = 0, depthNow = 0;
+    for (const auto& event : events) {
+        if (event.type == EventType::FrameOpen) {
+            depthNow++;
+            maxDepth = std::max(maxDepth, depthNow);
+        } else if (event.type == EventType::FrameClose) {
+            depthNow--;
+        }
+    }
+    float frameReserve = maxDepth * kFramePad * scale +
+                         (maxDepth > 0 ? 4.0f * scale : 0.0f);
+    float x = kEdgePad * scale + leftExtra +
+              participants[0].headerSize.w * 0.5f + frameReserve;
+    for (size_t i = 0; i < count; i++) {
+        participants[i].center = x;
+        if (i + 1 < count) x += gaps[i];
+    }
+    float lastHeaderHalf = participants.back().headerSize.w * 0.5f;
+    float diagramWidth = participants.back().center + lastHeaderHalf +
+                         rightExtra + frameReserve + kEdgePad * scale;
+
+    // --- vertical layout + primitive emission ---
+    std::vector<Prim>& prims = result.prims;
+    float y = kEdgePad * scale;
+
+    if (!title.empty()) {
+        TextStyle titleStyle;
+        titleStyle.bold = true;
+        titleStyle.scale = 1.1f;
+        Size titleSize = measure(title, titleStyle, 0.0f);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = title;
+        text.style = titleStyle;
+        text.fill = Role::Text;
+        text.x1 = 0;
+        text.y1 = y;
+        text.x2 = diagramWidth;
+        text.y2 = y + titleSize.h;
+        prims.push_back(std::move(text));
+        y += titleSize.h + 10.0f * scale;
+    }
+
+    float headerTop = y;
+    float headerBottom = y + headerHeight;
+
+    auto emitHeaders = [&](float top) {
+        for (const auto& participant : participants) {
+            Prim box;
+            box.type = PrimType::RoundRect;
+            box.radius = 6.0f * scale;
+            box.x1 = participant.center - participant.headerSize.w * 0.5f;
+            box.x2 = participant.center + participant.headerSize.w * 0.5f;
+            box.y1 = top;
+            box.y2 = top + headerHeight;
+            box.fill = Role::Fill;
+            box.stroke = Role::Stroke;
+            box.strokeWidth = 1.5f * scale;
+            prims.push_back(box);
+
+            Prim text;
+            text.type = PrimType::Text;
+            text.text = participant.label;
+            text.style = headerStyle;
+            text.fill = Role::Text;
+            text.x1 = box.x1;
+            text.y1 = box.y1;
+            text.x2 = box.x2;
+            text.y2 = box.y2;
+            prims.push_back(std::move(text));
+        }
+    };
+    emitHeaders(headerTop);
+    y = headerBottom + 14.0f * scale;
+
+    std::vector<Frame> frameStack;
+    std::vector<Frame> closedFrames;
+    std::vector<int> activationDepth(count, 0);
+    std::vector<ActivationSpan> openActivations;
+    std::vector<ActivationSpan> closedActivations;
+
+    auto lifelineX = [&](size_t participant) {
+        return participants[participant].center;
+    };
+    auto activationEdgeX = [&](size_t participant, bool towardRight) {
+        int depth = activationDepth[participant];
+        if (depth <= 0) return lifelineX(participant);
+        float centerShift = (depth - 1) * kActivationNudge * scale;
+        float half = kActivationWidth * 0.5f * scale;
+        return lifelineX(participant) + centerShift +
+               (towardRight ? half : -half);
+    };
+    auto pushActivation = [&](size_t participant, float top) {
+        activationDepth[participant]++;
+        ActivationSpan span;
+        span.participant = participant;
+        span.level = activationDepth[participant];
+        span.top = top;
+        openActivations.push_back(span);
+    };
+    auto popActivation = [&](size_t participant, float bottom) {
+        for (size_t i = openActivations.size(); i-- > 0;) {
+            if (openActivations[i].participant == participant &&
+                openActivations[i].level == activationDepth[participant]) {
+                openActivations[i].bottom = bottom;
+                closedActivations.push_back(openActivations[i]);
+                openActivations.erase(openActivations.begin() + i);
+                activationDepth[participant]--;
+                return;
+            }
+        }
+    };
+    auto touchFrame = [&](size_t columnA, size_t columnB,
+                          float overhangLeft = 0.0f,
+                          float overhangRight = 0.0f) {
+        if (frameStack.empty()) return;
+        for (auto& frame : frameStack) {
+            frame.minColumn = std::min(frame.minColumn, std::min(columnA, columnB));
+            frame.maxColumn = std::max(frame.maxColumn, std::max(columnA, columnB));
+            frame.extraLeft = std::max(frame.extraLeft, overhangLeft);
+            frame.extraRight = std::max(frame.extraRight, overhangRight);
+        }
+    };
+
+    for (auto& event : events) {
+        switch (event.type) {
+            case EventType::Activate:
+                pushActivation(event.from, y);
+                break;
+            case EventType::Deactivate:
+                popActivation(event.from, y);
+                break;
+            case EventType::FrameOpen: {
+                Frame frame;
+                frame.keyword = event.frameKeyword;
+                frame.label = event.text;
+                frame.top = y;
+                frame.depth = static_cast<int>(frameStack.size());
+                frame.keywordSize =
+                    measure(frame.keyword, frameKeywordStyle, 0.0f);
+                if (!frame.label.empty()) {
+                    frame.labelSize =
+                        measure("[" + frame.label + "]", frameLabelStyle, 0.0f);
+                }
+                float labelHeight = std::max(frame.keywordSize.h,
+                                             frame.labelSize.h) +
+                                    kFrameLabelPadY * 2 * scale;
+                frame.labelBottom = y + labelHeight;
+                frameStack.push_back(std::move(frame));
+                y += labelHeight + 8.0f * scale;
+                break;
+            }
+            case EventType::FrameDivider: {
+                if (frameStack.empty()) break;
+                y += 4.0f * scale;
+                std::string label = event.text.empty()
+                                        ? event.frameKeyword
+                                        : "[" + event.text + "]";
+                frameStack.back().dividers.emplace_back(y, label);
+                Size labelSize = measure(label, frameLabelStyle, 0.0f);
+                y += labelSize.h + 10.0f * scale;
+                break;
+            }
+            case EventType::FrameClose: {
+                if (frameStack.empty()) break;
+                Frame frame = frameStack.back();
+                frameStack.pop_back();
+                y += 6.0f * scale;
+                if (frame.minColumn == SIZE_MAX) {
+                    frame.minColumn = 0;
+                    frame.maxColumn = count - 1;
+                }
+                frame.bottom = y;
+                // Inner frames widen their enclosing frames
+                if (!frameStack.empty()) {
+                    for (auto& outer : frameStack) {
+                        outer.minColumn =
+                            std::min(outer.minColumn, frame.minColumn);
+                        outer.maxColumn =
+                            std::max(outer.maxColumn, frame.maxColumn);
+                    }
+                }
+                closedFrames.push_back(std::move(frame));
+                y += 10.0f * scale;
+                break;
+            }
+            case EventType::Note: {
+                float noteOverhangLeft =
+                    event.notePos == NotePos::LeftOf
+                        ? event.textSize.w + 8.0f * scale
+                        : (event.notePos == NotePos::Over && event.from == event.to
+                               ? event.textSize.w * 0.5f
+                               : 0.0f);
+                float noteOverhangRight =
+                    event.notePos == NotePos::RightOf
+                        ? event.textSize.w + 8.0f * scale
+                        : (event.notePos == NotePos::Over && event.from == event.to
+                               ? event.textSize.w * 0.5f
+                               : 0.0f);
+                touchFrame(event.from, event.to, noteOverhangLeft,
+                           noteOverhangRight);
+                float left, right;
+                if (event.notePos == NotePos::Over) {
+                    left = lifelineX(event.from) -
+                           (event.from == event.to
+                                ? event.textSize.w * 0.5f
+                                : kNoteMargin * scale);
+                    right = lifelineX(event.to) +
+                            (event.from == event.to
+                                 ? event.textSize.w * 0.5f
+                                 : kNoteMargin * scale);
+                    if (right - left < event.textSize.w) {
+                        float middle = (left + right) * 0.5f;
+                        left = middle - event.textSize.w * 0.5f;
+                        right = middle + event.textSize.w * 0.5f;
+                    }
+                } else if (event.notePos == NotePos::LeftOf) {
+                    right = lifelineX(event.from) - 8.0f * scale;
+                    left = right - event.textSize.w;
+                } else {
+                    left = lifelineX(event.from) + 8.0f * scale;
+                    right = left + event.textSize.w;
+                }
+                Prim box;
+                box.type = PrimType::Rect;
+                box.x1 = left;
+                box.y1 = y;
+                box.x2 = right;
+                box.y2 = y + event.textSize.h;
+                box.fill = Role::AccentSoft;
+                box.stroke = Role::Stroke;
+                box.strokeWidth = 1.0f * scale;
+                prims.push_back(box);
+                Prim text;
+                text.type = PrimType::Text;
+                text.text = event.text;
+                text.style = textStyle;
+                text.fill = Role::Text;
+                text.x1 = left + kNotePadX * scale;
+                text.y1 = y + kNotePadY * scale;
+                text.x2 = right - kNotePadX * scale;
+                text.y2 = y + event.textSize.h - kNotePadY * scale;
+                prims.push_back(std::move(text));
+                y += event.textSize.h + kRowGap * scale;
+                break;
+            }
+            case EventType::Message: {
+                float selfOverhang =
+                    event.from == event.to
+                        ? kSelfLoopWidth * scale + event.textSize.w +
+                              16.0f * scale
+                        : 0.0f;
+                touchFrame(event.from, event.to, 0.0f, selfOverhang);
+                float textHeight =
+                    event.text.empty() ? 0.0f : event.textSize.h;
+                if (event.from == event.to) {
+                    // Self message: text right of a small loop
+                    float lineX = activationEdgeX(event.from, true);
+                    float loopRight = lineX + kSelfLoopWidth * scale;
+                    float topY = y + textHeight * 0.5f;
+                    float bottomY = topY + 14.0f * scale;
+                    if (event.activateTarget) {
+                        pushActivation(event.from, bottomY);
+                    }
+                    if (!event.text.empty()) {
+                        Prim text;
+                        text.type = PrimType::Text;
+                        text.text = event.text;
+                        text.style = textStyle;
+                        text.fill = Role::Text;
+                        text.alignH = -1;
+                        text.x1 = loopRight + 6.0f * scale;
+                        text.y1 = y;
+                        text.x2 = loopRight + 6.0f * scale + event.textSize.w;
+                        text.y2 = y + textHeight + 14.0f * scale;
+                        prims.push_back(std::move(text));
+                    }
+                    auto addSegment = [&](float ax, float ay, float bx,
+                                          float by, bool arrowEnd) {
+                        Prim segment;
+                        segment.type = PrimType::Line;
+                        segment.x1 = ax;
+                        segment.y1 = ay;
+                        segment.x2 = bx;
+                        segment.y2 = by;
+                        segment.stroke = Role::Muted;
+                        segment.strokeWidth = 1.4f * scale;
+                        segment.dashed = event.line == ArrowLine::Dashed;
+                        if (arrowEnd) {
+                            segment.arrow = event.head == ArrowHead::Filled;
+                            segment.openArrow = event.head != ArrowHead::Filled;
+                        }
+                        prims.push_back(segment);
+                    };
+                    addSegment(lineX, topY, loopRight, topY, false);
+                    addSegment(loopRight, topY, loopRight, bottomY, false);
+                    addSegment(loopRight, bottomY,
+                               activationEdgeX(event.from, true), bottomY,
+                               true);
+                    y = bottomY + kRowGap * scale;
+                    if (event.deactivateSource) {
+                        popActivation(event.from, y - kRowGap * scale * 0.5f);
+                    }
+                } else {
+                    bool towardRight = lifelineX(event.to) > lifelineX(event.from);
+                    float lineY = y + textHeight +
+                                  (textHeight > 0 ? kMessageTextGap * scale
+                                                  : 4.0f * scale);
+                    if (event.activateTarget) {
+                        pushActivation(event.to, lineY);
+                    }
+                    float fromX = activationEdgeX(event.from, towardRight);
+                    float toX = activationEdgeX(event.to, !towardRight);
+                    if (!event.text.empty()) {
+                        Prim text;
+                        text.type = PrimType::Text;
+                        text.text = event.text;
+                        text.style = textStyle;
+                        text.fill = Role::Text;
+                        text.x1 = std::min(fromX, toX);
+                        text.y1 = y;
+                        text.x2 = std::max(fromX, toX);
+                        text.y2 = y + textHeight;
+                        prims.push_back(std::move(text));
+                    }
+                    Prim lineSegment;
+                    lineSegment.type = PrimType::Line;
+                    lineSegment.x1 = fromX;
+                    lineSegment.y1 = lineY;
+                    lineSegment.x2 = toX;
+                    lineSegment.y2 = lineY;
+                    lineSegment.stroke = Role::Muted;
+                    lineSegment.strokeWidth = 1.4f * scale;
+                    lineSegment.dashed = event.line == ArrowLine::Dashed;
+                    lineSegment.arrow = event.head == ArrowHead::Filled;
+                    lineSegment.openArrow = event.head == ArrowHead::Open ||
+                                            event.head == ArrowHead::Cross;
+                    prims.push_back(lineSegment);
+                    if (event.head == ArrowHead::Cross) {
+                        float size = 5.0f * scale;
+                        float crossX = toX + (towardRight ? -1.0f : 1.0f) *
+                                                 10.0f * scale;
+                        for (int i = 0; i < 2; i++) {
+                            Prim cross;
+                            cross.type = PrimType::Line;
+                            cross.x1 = crossX - size;
+                            cross.y1 = lineY + (i == 0 ? -size : size);
+                            cross.x2 = crossX + size;
+                            cross.y2 = lineY + (i == 0 ? size : -size);
+                            cross.stroke = Role::Muted;
+                            cross.strokeWidth = 1.4f * scale;
+                            prims.push_back(cross);
+                        }
+                    }
+                    y = lineY + kRowGap * scale;
+                    if (event.deactivateSource) {
+                        popActivation(event.from, lineY);
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    // Close any frames left open (missing `end`)
+    while (!frameStack.empty()) {
+        Frame frame = frameStack.back();
+        frameStack.pop_back();
+        if (frame.minColumn == SIZE_MAX) {
+            frame.minColumn = 0;
+            frame.maxColumn = count - 1;
+        }
+        frame.bottom = y;
+        closedFrames.push_back(std::move(frame));
+        y += 10.0f * scale;
+    }
+    while (!openActivations.empty()) {
+        openActivations.back().bottom = y;
+        closedActivations.push_back(openActivations.back());
+        openActivations.pop_back();
+    }
+
+    float lifelineBottom = y + 4.0f * scale;
+
+    // Lifelines behind everything: prepend by inserting at the start
+    {
+        std::vector<Prim> lifelines;
+        for (const auto& participant : participants) {
+            Prim lifeline;
+            lifeline.type = PrimType::Line;
+            lifeline.x1 = participant.center;
+            lifeline.y1 = headerBottom;
+            lifeline.x2 = participant.center;
+            lifeline.y2 = lifelineBottom;
+            lifeline.stroke = Role::Muted;
+            lifeline.strokeWidth = 1.0f * scale;
+            lifeline.dashed = true;
+            lifelines.push_back(lifeline);
+        }
+        // Activation bars sit on top of lifelines but under messages
+        for (const auto& span : closedActivations) {
+            Prim bar;
+            bar.type = PrimType::Rect;
+            float centerShift = (span.level - 1) * kActivationNudge * scale;
+            float half = kActivationWidth * 0.5f * scale;
+            bar.x1 = lifelineX(span.participant) + centerShift - half;
+            bar.x2 = lifelineX(span.participant) + centerShift + half;
+            bar.y1 = span.top;
+            bar.y2 = std::max(span.bottom, span.top + 8.0f * scale);
+            bar.fill = Role::AccentSoft;
+            bar.stroke = Role::Stroke;
+            bar.strokeWidth = 1.0f * scale;
+            lifelines.push_back(bar);
+        }
+        prims.insert(prims.begin(), lifelines.begin(), lifelines.end());
+    }
+
+    // Frames drawn on top (outlines + labels)
+    for (const auto& frame : closedFrames) {
+        float bottom = frame.bottom;
+        // Outer frames get the larger inset so nested frames sit inside them
+        float inset = kFramePad * scale +
+                      (maxDepth - 1 - frame.depth) * kFramePad * 0.6f * scale;
+        float left = participants[frame.minColumn].center -
+                     std::max(participants[frame.minColumn].headerSize.w * 0.5f,
+                              frame.extraLeft) -
+                     inset;
+        float right = participants[frame.maxColumn].center +
+                      std::max(
+                          participants[frame.maxColumn].headerSize.w * 0.5f,
+                          frame.extraRight) +
+                      inset;
+        Prim box;
+        box.type = PrimType::Rect;
+        box.x1 = left;
+        box.y1 = frame.top;
+        box.x2 = right;
+        box.y2 = bottom;
+        box.fill = Role::None;
+        box.stroke = Role::Muted;
+        box.strokeWidth = 1.2f * scale;
+        prims.push_back(box);
+
+        // Keyword chip
+        float chipWidth = frame.keywordSize.w + kFrameLabelPadX * 2 * scale;
+        float chipHeight = frame.labelBottom - frame.top;
+        Prim chip;
+        chip.type = PrimType::Rect;
+        chip.x1 = left;
+        chip.y1 = frame.top;
+        chip.x2 = left + chipWidth;
+        chip.y2 = frame.top + chipHeight;
+        chip.fill = Role::AccentSoft;
+        chip.stroke = Role::Muted;
+        chip.strokeWidth = 1.0f * scale;
+        prims.push_back(chip);
+        Prim keyword;
+        keyword.type = PrimType::Text;
+        keyword.text = frame.keyword;
+        keyword.style = frameKeywordStyle;
+        keyword.fill = Role::Text;
+        keyword.x1 = chip.x1;
+        keyword.y1 = chip.y1;
+        keyword.x2 = chip.x2;
+        keyword.y2 = chip.y2;
+        prims.push_back(std::move(keyword));
+        if (!frame.label.empty()) {
+            Prim label;
+            label.type = PrimType::Text;
+            label.text = "[" + frame.label + "]";
+            label.style = frameLabelStyle;
+            label.fill = Role::Muted;
+            label.alignH = -1;
+            label.x1 = chip.x2 + 8.0f * scale;
+            label.y1 = chip.y1;
+            label.x2 = right - 4.0f * scale;
+            label.y2 = chip.y2;
+            prims.push_back(std::move(label));
+        }
+        for (const auto& divider : frame.dividers) {
+            Prim dividerLine;
+            dividerLine.type = PrimType::Line;
+            dividerLine.x1 = left;
+            dividerLine.y1 = divider.first;
+            dividerLine.x2 = right;
+            dividerLine.y2 = divider.first;
+            dividerLine.stroke = Role::Muted;
+            dividerLine.strokeWidth = 1.0f * scale;
+            dividerLine.dashed = true;
+            prims.push_back(dividerLine);
+            Prim dividerLabel;
+            dividerLabel.type = PrimType::Text;
+            dividerLabel.text = divider.second;
+            dividerLabel.style = frameLabelStyle;
+            dividerLabel.fill = Role::Muted;
+            dividerLabel.alignH = -1;
+            dividerLabel.x1 = left + kFrameLabelPadX * scale;
+            dividerLabel.y1 = divider.first + 2.0f * scale;
+            dividerLabel.x2 = right;
+            dividerLabel.y2 = divider.first + 2.0f * scale +
+                              measure(divider.second, frameLabelStyle, 0.0f).h;
+            prims.push_back(std::move(dividerLabel));
+        }
+    }
+
+    // Bottom header row mirrors the top one
+    emitHeaders(lifelineBottom);
+
+    result.width = diagramWidth;
+    result.height = lifelineBottom + headerHeight + kEdgePad * scale;
+    result.ok = true;
+    return result;
+}
+
+}  // namespace detail
+}  // namespace mermaidext

--- a/src/mermaid_uml.cpp
+++ b/src/mermaid_uml.cpp
@@ -1387,5 +1387,358 @@ Built buildClass(std::string_view source, const Measure& measure,
     return result;
 }
 
+// --------------------------------------------------------------------------
+// Entity-relationship diagrams
+// --------------------------------------------------------------------------
+
+namespace {
+
+struct ErAttribute {
+    std::string type;
+    std::string name;
+    std::string keys;  // PK, FK, UK joined
+};
+
+// ||, |o, o|, }|, |{, }o, o{ ... -> marker (read outward from the line)
+Marker cardinalityMarker(std::string_view card) {
+    bool many = card.find('{') != std::string_view::npos ||
+                card.find('}') != std::string_view::npos;
+    bool zero = card.find('o') != std::string_view::npos;
+    size_t bars = static_cast<size_t>(
+        std::count(card.begin(), card.end(), '|'));
+    if (many) {
+        if (zero) return Marker::ZeroMany;
+        if (bars > 0) return Marker::OneMany;
+        return Marker::CrowMany;
+    }
+    if (zero) return Marker::ZeroOne;
+    if (bars >= 2) return Marker::One;
+    if (bars == 1) return Marker::One;
+    return Marker::None;
+}
+
+bool isCardChar(char c) {
+    return c == '|' || c == 'o' || c == '{' || c == '}';
+}
+
+}  // namespace
+
+Built buildEr(std::string_view source, const Measure& measure, float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    GraphNodes graph;
+    graph.diagram.direction = mermaid::Direction::TopToBottom;
+    std::map<size_t, std::vector<ErAttribute>> attributes;
+    std::vector<EdgeDecor> decors;
+    size_t openBlock = SIZE_MAX;
+
+    auto entityName = [&](std::string_view id) -> std::string_view {
+        // Quoted entity names and [aliases] are trimmed to the plain name
+        id = trimView(id);
+        if (id.size() >= 2 && id.front() == '"' && id.back() == '"') {
+            id = id.substr(1, id.size() - 2);
+        }
+        size_t bracket = id.find('[');
+        if (bracket != std::string_view::npos) {
+            id = trimView(id.substr(0, bracket));
+        }
+        return id;
+    };
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            if (!startsWithWord(line, "erDiagram")) {
+                result.error = "Expected erDiagram header";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        if (openBlock != SIZE_MAX) {
+            if (line == "}") {
+                openBlock = SIZE_MAX;
+                continue;
+            }
+            // type name [PK|FK|UK ...] ["comment"]
+            ErAttribute attribute;
+            std::string cleaned = cleanLabel(line);
+            std::string_view rest(cleaned);
+            // strip trailing comment
+            size_t quote = rest.find('"');
+            if (quote != std::string_view::npos) {
+                rest = trimView(rest.substr(0, quote));
+            }
+            size_t space = rest.find(' ');
+            if (space == std::string_view::npos) {
+                attribute.name = std::string(rest);
+            } else {
+                attribute.type = std::string(rest.substr(0, space));
+                std::string_view remainder = trimView(rest.substr(space + 1));
+                size_t nameEnd = remainder.find(' ');
+                if (nameEnd == std::string_view::npos) {
+                    attribute.name = std::string(remainder);
+                } else {
+                    attribute.name = std::string(remainder.substr(0, nameEnd));
+                    attribute.keys =
+                        std::string(trimView(remainder.substr(nameEnd + 1)));
+                }
+            }
+            attributes[openBlock].push_back(std::move(attribute));
+            continue;
+        }
+        if (startsWithWord(line, "direction", nullptr)) continue;
+
+        // ENTITY { ... }  |  ENTITY  |  A <card><line><card> B : label
+        if (line.back() == '{') {
+            std::string_view name =
+                entityName(trimView(line.substr(0, line.size() - 1)));
+            if (name.empty()) {
+                result.error = "Entity block without a name";
+                return result;
+            }
+            openBlock = graph.ensure(name, name);
+            continue;
+        }
+
+        // Find the relationship line: -- or .. with cardinality chars around
+        size_t linePos = std::string_view::npos;
+        bool dashed = false;
+        for (size_t i = 0; i + 1 < line.size(); i++) {
+            if ((line[i] == '-' && line[i + 1] == '-') ||
+                (line[i] == '.' && line[i + 1] == '.')) {
+                if (i > 0 && isCardChar(line[i - 1])) {
+                    linePos = i;
+                    dashed = line[i] == '.';
+                    break;
+                }
+            }
+        }
+        if (linePos != std::string_view::npos) {
+            size_t lineEnd = linePos;
+            while (lineEnd < line.size() &&
+                   (line[lineEnd] == '-' || line[lineEnd] == '.')) {
+                lineEnd++;
+            }
+            size_t leftCardStart = linePos;
+            while (leftCardStart > 0 && isCardChar(line[leftCardStart - 1])) {
+                leftCardStart--;
+            }
+            size_t rightCardEnd = lineEnd;
+            while (rightCardEnd < line.size() &&
+                   isCardChar(line[rightCardEnd])) {
+                rightCardEnd++;
+            }
+            std::string_view leftCard =
+                line.substr(leftCardStart, linePos - leftCardStart);
+            std::string_view rightCard =
+                line.substr(lineEnd, rightCardEnd - lineEnd);
+            std::string_view leftId =
+                entityName(line.substr(0, leftCardStart));
+            std::string_view remainder = line.substr(rightCardEnd);
+            std::string label;
+            size_t colon = remainder.find(':');
+            std::string_view rightId;
+            if (colon != std::string_view::npos) {
+                rightId = entityName(remainder.substr(0, colon));
+                label = cleanLabel(trimView(remainder.substr(colon + 1)));
+                if (label.size() >= 2 && label.front() == '"' &&
+                    label.back() == '"') {
+                    label = label.substr(1, label.size() - 2);
+                }
+            } else {
+                rightId = entityName(remainder);
+            }
+            if (leftId.empty() || rightId.empty()) {
+                result.error = "Relationship needs two entities";
+                return result;
+            }
+            mermaid::Edge edge;
+            edge.from = graph.ensure(leftId, leftId);
+            edge.to = graph.ensure(rightId, rightId);
+            edge.label = label;
+            graph.diagram.edges.push_back(std::move(edge));
+            EdgeDecor decor;
+            // Cardinality glyphs read outward: the marker for the LEFT
+            // entity is the left card reversed toward that end
+            decor.atFrom = cardinalityMarker(leftCard);
+            decor.atTo = cardinalityMarker(rightCard);
+            decor.dashed = dashed;
+            decors.push_back(std::move(decor));
+            continue;
+        }
+
+        // Bare entity declaration
+        std::string_view name = entityName(line);
+        if (!name.empty() && name.find(' ') == std::string_view::npos) {
+            graph.ensure(name, name);
+            continue;
+        }
+        result.error = "Unsupported ER statement";
+        return result;
+    }
+
+    if (graph.diagram.nodes.empty()) {
+        result.error = "No entities";
+        return result;
+    }
+
+    // --- measure ---
+    TextStyle titleStyle;
+    titleStyle.bold = true;
+    TextStyle attrStyle;
+    attrStyle.scale = 0.9f;
+    TextStyle keyStyle;
+    keyStyle.scale = 0.9f;
+    keyStyle.italic = true;
+    float padX = 10.0f;
+
+    struct MeasuredEntity {
+        Size title;
+        float rowHeight = 0.0f;
+        float typeWidth = 0.0f;
+        float nameWidth = 0.0f;
+        float keysWidth = 0.0f;
+    };
+    std::vector<MeasuredEntity> measured(graph.diagram.nodes.size());
+    std::vector<mermaid::Size> sizes(graph.diagram.nodes.size());
+    for (size_t i = 0; i < graph.diagram.nodes.size(); i++) {
+        MeasuredEntity& entity = measured[i];
+        entity.title = measure(graph.diagram.nodes[i].label, titleStyle, 0.0f);
+        float width = entity.title.w;
+        float height = entity.title.h + 12.0f * scale;
+        auto found = attributes.find(i);
+        if (found != attributes.end()) {
+            for (const auto& attribute : found->second) {
+                Size typeSize = measure(attribute.type, attrStyle, 0.0f);
+                Size nameSize = measure(attribute.name, attrStyle, 0.0f);
+                Size keysSize = measure(attribute.keys, keyStyle, 0.0f);
+                entity.typeWidth = std::max(entity.typeWidth, typeSize.w);
+                entity.nameWidth = std::max(entity.nameWidth, nameSize.w);
+                entity.keysWidth = std::max(entity.keysWidth, keysSize.w);
+                entity.rowHeight = std::max(
+                    entity.rowHeight,
+                    std::max(typeSize.h, std::max(nameSize.h, keysSize.h)) +
+                        6.0f * scale);
+            }
+            float rowsWidth = entity.typeWidth + entity.nameWidth +
+                              entity.keysWidth;
+            if (entity.typeWidth > 0.0f) rowsWidth += padX * scale;
+            if (entity.keysWidth > 0.0f) rowsWidth += padX * scale;
+            width = std::max(width, rowsWidth);
+            height += found->second.size() * entity.rowHeight;
+        }
+        sizes[i] = {std::max(90.0f * scale, width + padX * 2.0f * scale),
+                    height};
+    }
+
+    mermaid::Layout layout = mermaid::layout(
+        acyclicForRanking(graph.diagram), sizes, (kNodeGap + 14.0f) * scale,
+        (kRankGap + 8.0f) * scale);
+    if (layout.nodes.size() != graph.diagram.nodes.size()) {
+        result.error = "Layout failed";
+        return result;
+    }
+
+    float maxRight = layout.width;
+    float maxBottom = layout.height;
+    auto routed =
+        routeEdges(graph.diagram, layout, scale, maxRight, maxBottom);
+    emitEdges(result.prims, graph.diagram, routed, decors, measure, scale);
+
+    for (size_t i = 0; i < graph.diagram.nodes.size(); i++) {
+        const auto& rect = layout.nodes[i];
+        const MeasuredEntity& entity = measured[i];
+
+        Prim box;
+        box.type = PrimType::Rect;
+        box.x1 = rect.left;
+        box.y1 = rect.top;
+        box.x2 = rect.right;
+        box.y2 = rect.bottom;
+        box.fill = Role::Fill;
+        box.stroke = Role::Stroke;
+        box.strokeWidth = 1.5f * scale;
+        result.prims.push_back(box);
+
+        float titleHeight = entity.title.h + 12.0f * scale;
+        Prim titleBand;
+        titleBand.type = PrimType::Rect;
+        titleBand.x1 = rect.left;
+        titleBand.y1 = rect.top;
+        titleBand.x2 = rect.right;
+        titleBand.y2 = rect.top + titleHeight;
+        titleBand.fill = Role::AccentSoft;
+        titleBand.stroke = Role::Stroke;
+        titleBand.strokeWidth = 1.0f * scale;
+        result.prims.push_back(titleBand);
+        Prim title;
+        title.type = PrimType::Text;
+        title.text = graph.diagram.nodes[i].label;
+        title.style = titleStyle;
+        title.fill = Role::Text;
+        title.x1 = rect.left;
+        title.y1 = rect.top;
+        title.x2 = rect.right;
+        title.y2 = rect.top + titleHeight;
+        result.prims.push_back(std::move(title));
+
+        auto found = attributes.find(i);
+        if (found == attributes.end()) continue;
+        float y = rect.top + titleHeight;
+        float typeX = rect.left + padX * scale;
+        float nameX = typeX + entity.typeWidth +
+                      (entity.typeWidth > 0.0f ? padX * scale : 0.0f);
+        for (size_t row = 0; row < found->second.size(); row++) {
+            const auto& attribute = found->second[row];
+            if (row > 0) {
+                Prim separator;
+                separator.type = PrimType::Line;
+                separator.x1 = rect.left;
+                separator.y1 = y;
+                separator.x2 = rect.right;
+                separator.y2 = y;
+                separator.stroke = Role::Muted;
+                separator.strokeWidth = 0.6f * scale;
+                result.prims.push_back(separator);
+            }
+            auto cell = [&](const std::string& value, float x, float width,
+                            const TextStyle& style, Role role) {
+                if (value.empty() || width <= 0.0f) return;
+                Prim text;
+                text.type = PrimType::Text;
+                text.text = value;
+                text.style = style;
+                text.fill = role;
+                text.alignH = -1;
+                text.x1 = x;
+                text.y1 = y;
+                text.x2 = x + width;
+                text.y2 = y + entity.rowHeight;
+                result.prims.push_back(std::move(text));
+            };
+            cell(attribute.type, typeX, entity.typeWidth, attrStyle,
+                 Role::Muted);
+            cell(attribute.name, nameX, entity.nameWidth, attrStyle,
+                 Role::Text);
+            cell(attribute.keys,
+                 rect.right - padX * scale - entity.keysWidth,
+                 entity.keysWidth, keyStyle, Role::Muted);
+            y += entity.rowHeight;
+        }
+    }
+
+    result.width = maxRight + 8.0f * scale;
+    result.height = maxBottom + 8.0f * scale;
+    normalizeLeft(result);
+    result.ok = true;
+    return result;
+}
+
 }  // namespace detail
 }  // namespace mermaidext

--- a/src/mermaid_uml.cpp
+++ b/src/mermaid_uml.cpp
@@ -1,0 +1,1391 @@
+// Native Mermaid renderers for the graph-shaped UML families: state
+// diagrams, class diagrams, and entity-relationship diagrams. All three
+// parse into the flowchart engine's mermaid::Diagram to reuse its rank
+// layout, then route edges and draw nodes through the primitive pipeline.
+
+#include "mermaid.h"
+#include "mermaid_ext.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace mermaidext {
+namespace detail {
+
+namespace {
+
+constexpr float kNodeGap = 34.0f;
+constexpr float kRankGap = 64.0f;
+constexpr float kEdgeLabelPad = 5.0f;
+constexpr float kMarkerDepth = 11.0f;
+
+enum class Marker {
+    None,
+    FilledArrow,
+    OpenArrow,
+    HollowTriangle,
+    HollowDiamond,
+    FilledDiamond,
+    CrowMany,     // crow's foot (+ bar/circle by flags below)
+    One,          // double bar
+    ZeroOne,      // circle + bar
+    ZeroMany,     // circle + crow's foot
+    OneMany,      // bar + crow's foot
+};
+
+struct EdgeDecor {
+    Marker atFrom = Marker::None;
+    Marker atTo = Marker::None;
+    std::string labelFrom;  // multiplicity near the from end
+    std::string labelTo;
+    bool dashed = false;
+    std::string label;
+};
+
+struct GraphNodes {
+    mermaid::Diagram diagram;
+    std::map<std::string, size_t, std::less<>> ids;
+
+    size_t ensure(std::string_view id, std::string_view label) {
+        auto found = ids.find(id);
+        if (found != ids.end()) {
+            if (!label.empty()) {
+                diagram.nodes[found->second].label = cleanLabel(label);
+            }
+            return found->second;
+        }
+        mermaid::Node node;
+        node.id = std::string(id);
+        node.label = cleanLabel(label.empty() ? id : label);
+        diagram.nodes.push_back(std::move(node));
+        ids.emplace(std::string(id), diagram.nodes.size() - 1);
+        return diagram.nodes.size() - 1;
+    }
+};
+
+struct RoutedEdge {
+    std::vector<Point> points;
+};
+
+// The rank layout is longest-path over a DAG; cyclic graphs (the norm for
+// state machines: start/stop, pause/resume) would fall into its
+// sequential-order fallback. Reverse DFS back-edges for RANKING ONLY —
+// routing still uses the original edge directions.
+mermaid::Diagram acyclicForRanking(const mermaid::Diagram& diagram) {
+    size_t count = diagram.nodes.size();
+    std::vector<std::vector<size_t>> outgoing(count);
+    for (size_t i = 0; i < diagram.edges.size(); i++) {
+        const auto& edge = diagram.edges[i];
+        if (edge.from < count && edge.to < count && edge.from != edge.to) {
+            outgoing[edge.from].push_back(i);
+        }
+    }
+    std::vector<size_t> indegree(count, 0);
+    for (const auto& edge : diagram.edges) {
+        if (edge.to < count && edge.from != edge.to) indegree[edge.to]++;
+    }
+
+    enum : unsigned char { White, Gray, Black };
+    std::vector<unsigned char> color(count, White);
+    std::vector<bool> reversed(diagram.edges.size(), false);
+
+    struct StackFrame {
+        size_t node;
+        size_t next = 0;
+    };
+    auto dfs = [&](size_t root) {
+        std::vector<StackFrame> stack{{root}};
+        color[root] = Gray;
+        while (!stack.empty()) {
+            StackFrame& frame = stack.back();
+            if (frame.next < outgoing[frame.node].size()) {
+                size_t edgeIndex = outgoing[frame.node][frame.next++];
+                size_t target = diagram.edges[edgeIndex].to;
+                if (color[target] == Gray) {
+                    reversed[edgeIndex] = true;  // back edge
+                } else if (color[target] == White) {
+                    color[target] = Gray;
+                    stack.push_back({target});
+                }
+            } else {
+                color[frame.node] = Black;
+                stack.pop_back();
+            }
+        }
+    };
+    for (size_t i = 0; i < count; i++) {
+        if (indegree[i] == 0 && color[i] == White) dfs(i);
+    }
+    for (size_t i = 0; i < count; i++) {
+        if (color[i] == White) dfs(i);
+    }
+
+    mermaid::Diagram ranking = diagram;
+    for (size_t i = 0; i < ranking.edges.size(); i++) {
+        if (reversed[i]) std::swap(ranking.edges[i].from, ranking.edges[i].to);
+    }
+    return ranking;
+}
+
+// Elbow-routes every edge the way the flowchart renderer does, against
+// laid-out node rects. Returns per-edge polylines (diagram coordinates).
+std::vector<RoutedEdge> routeEdges(const mermaid::Diagram& diagram,
+                                   const mermaid::Layout& layout,
+                                   float scale, float& maxRight,
+                                   float& maxBottom) {
+    std::vector<RoutedEdge> routed(diagram.edges.size());
+    bool vertical =
+        diagram.direction == mermaid::Direction::TopToBottom ||
+        diagram.direction == mermaid::Direction::BottomToTop;
+    bool topToBottom = diagram.direction == mermaid::Direction::TopToBottom;
+    bool leftToRight = diagram.direction == mermaid::Direction::LeftToRight;
+    size_t exteriorLane = 0;
+
+    for (size_t i = 0; i < diagram.edges.size(); i++) {
+        const auto& edge = diagram.edges[i];
+        if (edge.from >= layout.nodes.size() ||
+            edge.to >= layout.nodes.size()) {
+            continue;
+        }
+        const auto& from = layout.nodes[edge.from];
+        const auto& to = layout.nodes[edge.to];
+        float fromCx = (from.left + from.right) * 0.5f;
+        float fromCy = (from.top + from.bottom) * 0.5f;
+        float toCx = (to.left + to.right) * 0.5f;
+        float toCy = (to.top + to.bottom) * 0.5f;
+        bool selfLoop = edge.from == edge.to;
+        bool skipsRanks = false;
+        if (edge.from < layout.ranks.size() && edge.to < layout.ranks.size()) {
+            size_t fromRank = layout.ranks[edge.from];
+            size_t toRank = layout.ranks[edge.to];
+            skipsRanks = (fromRank < toRank ? toRank - fromRank
+                                            : fromRank - toRank) > 1;
+        }
+
+        auto& points = routed[i].points;
+        if (selfLoop) {
+            float lane = (30.0f + exteriorLane++ * 14.0f) * scale;
+            points = {
+                {from.right, fromCy - 8.0f * scale},
+                {from.right + lane, fromCy - 8.0f * scale},
+                {from.right + lane, fromCy + 8.0f * scale},
+                {from.right, fromCy + 8.0f * scale},
+            };
+        } else if (vertical) {
+            bool forward =
+                !skipsRanks &&
+                (topToBottom ? toCy > fromCy : toCy < fromCy);
+            if (forward) {
+                float startY = topToBottom ? from.bottom : from.top;
+                float endY = topToBottom ? to.top : to.bottom;
+                float middle = (startY + endY) * 0.5f;
+                points = {
+                    {fromCx, startY},
+                    {fromCx, middle},
+                    {toCx, middle},
+                    {toCx, endY},
+                };
+            } else {
+                float lane = (30.0f + exteriorLane++ * 14.0f) * scale;
+                float laneX = std::max(from.right, to.right) + lane;
+                points = {
+                    {from.right, fromCy},
+                    {laneX, fromCy},
+                    {laneX, toCy},
+                    {to.right, toCy},
+                };
+            }
+        } else {
+            bool forward =
+                !skipsRanks &&
+                (leftToRight ? toCx > fromCx : toCx < fromCx);
+            if (forward) {
+                float startX = leftToRight ? from.right : from.left;
+                float endX = leftToRight ? to.left : to.right;
+                float middle = (startX + endX) * 0.5f;
+                points = {
+                    {startX, fromCy},
+                    {middle, fromCy},
+                    {middle, toCy},
+                    {endX, toCy},
+                };
+            } else {
+                float lane = (30.0f + exteriorLane++ * 14.0f) * scale;
+                float laneY = std::max(from.bottom, to.bottom) + lane;
+                points = {
+                    {fromCx, from.bottom},
+                    {fromCx, laneY},
+                    {toCx, laneY},
+                    {toCx, to.bottom},
+                };
+            }
+        }
+        for (const auto& point : points) {
+            maxRight = std::max(maxRight, point.x);
+            maxBottom = std::max(maxBottom, point.y);
+        }
+    }
+    return routed;
+}
+
+// Removes duplicate consecutive points so direction vectors are non-zero
+void dedupePoints(std::vector<Point>& points) {
+    for (size_t i = points.size(); i-- > 1;) {
+        if (std::abs(points[i].x - points[i - 1].x) < 0.01f &&
+            std::abs(points[i].y - points[i - 1].y) < 0.01f) {
+            points.erase(points.begin() + i);
+        }
+    }
+}
+
+// Emits an end marker at points[index] (0 = start, back = end); the marker
+// apex touches the node border and the line is shortened underneath solid
+// markers so it does not poke through
+void emitMarker(std::vector<Prim>& prims, std::vector<Point>& points,
+                bool atStart, Marker marker, float scale) {
+    if (marker == Marker::None || points.size() < 2) return;
+    Point& tip = atStart ? points.front() : points.back();
+    const Point& neighbor = atStart ? points[1] : points[points.size() - 2];
+    float dx = neighbor.x - tip.x;
+    float dy = neighbor.y - tip.y;
+    float length = std::sqrt(dx * dx + dy * dy);
+    if (length < 0.01f) return;
+    dx /= length;  // direction AWAY from the node, along the line
+    dy /= length;
+    float px = -dy, py = dx;  // perpendicular
+    float depth = kMarkerDepth * scale;
+
+    auto polygon = [&](std::vector<Point> pts, Role fill, Role stroke) {
+        Prim prim;
+        prim.type = PrimType::Polygon;
+        prim.pts = std::move(pts);
+        prim.fill = fill;
+        prim.stroke = stroke;
+        prim.strokeWidth = 1.3f * scale;
+        prims.push_back(std::move(prim));
+    };
+    auto lineAt = [&](Point a, Point b) {
+        Prim prim;
+        prim.type = PrimType::Line;
+        prim.x1 = a.x;
+        prim.y1 = a.y;
+        prim.x2 = b.x;
+        prim.y2 = b.y;
+        prim.stroke = Role::Muted;
+        prim.strokeWidth = 1.4f * scale;
+        prims.push_back(prim);
+    };
+    auto shorten = [&](float amount) {
+        tip.x += dx * amount;
+        tip.y += dy * amount;
+    };
+
+    switch (marker) {
+        case Marker::FilledArrow: {
+            float wing = 4.5f * scale;
+            polygon({{tip.x, tip.y},
+                     {tip.x + dx * depth * 0.85f + px * wing,
+                      tip.y + dy * depth * 0.85f + py * wing},
+                     {tip.x + dx * depth * 0.85f - px * wing,
+                      tip.y + dy * depth * 0.85f - py * wing}},
+                    Role::Muted, Role::None);
+            shorten(depth * 0.6f);
+            break;
+        }
+        case Marker::OpenArrow: {
+            float wing = 4.5f * scale;
+            lineAt(tip, {tip.x + dx * depth * 0.85f + px * wing,
+                         tip.y + dy * depth * 0.85f + py * wing});
+            lineAt(tip, {tip.x + dx * depth * 0.85f - px * wing,
+                         tip.y + dy * depth * 0.85f - py * wing});
+            break;
+        }
+        case Marker::HollowTriangle: {
+            float wing = 6.0f * scale;
+            float triDepth = depth * 1.15f;
+            polygon({{tip.x, tip.y},
+                     {tip.x + dx * triDepth + px * wing,
+                      tip.y + dy * triDepth + py * wing},
+                     {tip.x + dx * triDepth - px * wing,
+                      tip.y + dy * triDepth - py * wing}},
+                    Role::Background, Role::Muted);
+            shorten(depth * 1.15f);
+            break;
+        }
+        case Marker::HollowDiamond:
+        case Marker::FilledDiamond: {
+            float wing = 5.0f * scale;
+            float half = depth * 0.75f;
+            polygon({{tip.x, tip.y},
+                     {tip.x + dx * half + px * wing,
+                      tip.y + dy * half + py * wing},
+                     {tip.x + dx * half * 2.0f, tip.y + dy * half * 2.0f},
+                     {tip.x + dx * half - px * wing,
+                      tip.y + dy * half - py * wing}},
+                    marker == Marker::FilledDiamond ? Role::Muted
+                                                    : Role::Background,
+                    Role::Muted);
+            shorten(half * 2.0f);
+            break;
+        }
+        case Marker::CrowMany:
+        case Marker::ZeroMany:
+        case Marker::OneMany: {
+            float wing = 5.5f * scale;
+            Point base = {tip.x + dx * depth, tip.y + dy * depth};
+            lineAt(base, tip);
+            lineAt(base, {tip.x + px * wing, tip.y + py * wing});
+            lineAt(base, {tip.x - px * wing, tip.y - py * wing});
+            if (marker == Marker::ZeroMany) {
+                float r = 3.5f * scale;
+                Prim circle;
+                circle.type = PrimType::Ellipse;
+                circle.x1 = base.x + dx * (r + 2.0f * scale) - r;
+                circle.y1 = base.y + dy * (r + 2.0f * scale) - r;
+                circle.x2 = circle.x1 + r * 2.0f;
+                circle.y2 = circle.y1 + r * 2.0f;
+                circle.fill = Role::Background;
+                circle.stroke = Role::Muted;
+                circle.strokeWidth = 1.3f * scale;
+                prims.push_back(circle);
+            } else if (marker == Marker::OneMany) {
+                float barAt = depth + 4.0f * scale;
+                float wing2 = 5.0f * scale;
+                lineAt({tip.x + dx * barAt + px * wing2,
+                        tip.y + dy * barAt + py * wing2},
+                       {tip.x + dx * barAt - px * wing2,
+                        tip.y + dy * barAt - py * wing2});
+            }
+            break;
+        }
+        case Marker::One: {
+            float wing = 5.0f * scale;
+            for (float at : {7.0f, 11.0f}) {
+                float depth2 = at * scale;
+                lineAt({tip.x + dx * depth2 + px * wing,
+                        tip.y + dy * depth2 + py * wing},
+                       {tip.x + dx * depth2 - px * wing,
+                        tip.y + dy * depth2 - py * wing});
+            }
+            break;
+        }
+        case Marker::ZeroOne: {
+            float wing = 5.0f * scale;
+            float barAt = 7.0f * scale;
+            lineAt({tip.x + dx * barAt + px * wing,
+                    tip.y + dy * barAt + py * wing},
+                   {tip.x + dx * barAt - px * wing,
+                    tip.y + dy * barAt - py * wing});
+            float r = 3.5f * scale;
+            float circleAt = barAt + 3.0f * scale + r;
+            Prim circle;
+            circle.type = PrimType::Ellipse;
+            circle.x1 = tip.x + dx * circleAt - r;
+            circle.y1 = tip.y + dy * circleAt - r;
+            circle.x2 = circle.x1 + r * 2.0f;
+            circle.y2 = circle.y1 + r * 2.0f;
+            circle.fill = Role::Background;
+            circle.stroke = Role::Muted;
+            circle.strokeWidth = 1.3f * scale;
+            prims.push_back(circle);
+            break;
+        }
+        case Marker::None:
+            break;
+    }
+}
+
+// Emits the routed edge polylines with markers and label chips
+void emitEdges(std::vector<Prim>& prims, const mermaid::Diagram& diagram,
+               std::vector<RoutedEdge>& routed,
+               const std::vector<EdgeDecor>& decors, const Measure& measure,
+               float scale) {
+    TextStyle labelStyle;
+    labelStyle.scale = 0.9f;
+    for (size_t i = 0; i < diagram.edges.size(); i++) {
+        auto& points = routed[i].points;
+        if (points.size() < 2) continue;
+        dedupePoints(points);
+        if (points.size() < 2) continue;
+        const EdgeDecor& decor =
+            i < decors.size() ? decors[i] : EdgeDecor{};
+
+        emitMarker(prims, points, true, decor.atFrom, scale);
+        emitMarker(prims, points, false, decor.atTo, scale);
+
+        for (size_t p = 1; p < points.size(); p++) {
+            Prim line;
+            line.type = PrimType::Line;
+            line.x1 = points[p - 1].x;
+            line.y1 = points[p - 1].y;
+            line.x2 = points[p].x;
+            line.y2 = points[p].y;
+            line.stroke = Role::Muted;
+            line.strokeWidth = 1.4f * scale;
+            line.dashed = decor.dashed;
+            prims.push_back(line);
+        }
+
+        const std::string& label =
+            !decor.label.empty() ? decor.label : diagram.edges[i].label;
+        if (!label.empty()) {
+            Size size = measure(label, labelStyle, 0.0f);
+            // Chip at the half-length point of the polyline
+            float total = 0.0f;
+            for (size_t p = 1; p < points.size(); p++) {
+                total += std::abs(points[p].x - points[p - 1].x) +
+                         std::abs(points[p].y - points[p - 1].y);
+            }
+            float remaining = total * 0.5f;
+            float cx = (points.front().x + points.back().x) * 0.5f;
+            float cy = (points.front().y + points.back().y) * 0.5f;
+            for (size_t p = 1; p < points.size(); p++) {
+                float segment =
+                    std::abs(points[p].x - points[p - 1].x) +
+                    std::abs(points[p].y - points[p - 1].y);
+                if (segment >= remaining && segment > 0.0f) {
+                    float t = remaining / segment;
+                    cx = points[p - 1].x + (points[p].x - points[p - 1].x) * t;
+                    cy = points[p - 1].y + (points[p].y - points[p - 1].y) * t;
+                    break;
+                }
+                remaining -= segment;
+            }
+            Prim chip;
+            chip.type = PrimType::RoundRect;
+            chip.radius = 4.0f * scale;
+            chip.x1 = cx - size.w * 0.5f - kEdgeLabelPad * scale;
+            chip.y1 = cy - size.h * 0.5f - 2.0f * scale;
+            chip.x2 = cx + size.w * 0.5f + kEdgeLabelPad * scale;
+            chip.y2 = cy + size.h * 0.5f + 2.0f * scale;
+            chip.fill = Role::Fill;
+            chip.stroke = Role::Muted;
+            chip.strokeWidth = 1.0f * scale;
+            prims.push_back(chip);
+            Prim text;
+            text.type = PrimType::Text;
+            text.text = label;
+            text.style = labelStyle;
+            text.fill = Role::Text;
+            text.x1 = chip.x1;
+            text.y1 = chip.y1;
+            text.x2 = chip.x2;
+            text.y2 = chip.y2;
+            prims.push_back(std::move(text));
+        }
+
+        // Multiplicity labels near the ends
+        auto endLabel = [&](const std::string& value, bool atStart) {
+            if (value.empty()) return;
+            Size size = measure(value, labelStyle, 0.0f);
+            const Point& tip = atStart ? points.front() : points.back();
+            const Point& neighbor =
+                atStart ? points[1] : points[points.size() - 2];
+            float dx = neighbor.x - tip.x;
+            float dy = neighbor.y - tip.y;
+            float length = std::sqrt(dx * dx + dy * dy);
+            if (length < 0.01f) return;
+            dx /= length;
+            dy /= length;
+            float alongX = tip.x + dx * 16.0f * scale;
+            float alongY = tip.y + dy * 16.0f * scale;
+            float sideX = -dy, sideY = dx;
+            Prim text;
+            text.type = PrimType::Text;
+            text.text = value;
+            text.style = labelStyle;
+            text.fill = Role::Muted;
+            text.x1 = alongX + sideX * 8.0f * scale -
+                      (sideX < -0.5f ? size.w : sideX > 0.5f ? 0.0f
+                                                             : size.w * 0.5f);
+            text.y1 = alongY + sideY * 8.0f * scale -
+                      (sideY < -0.5f ? size.h : sideY > 0.5f ? 0.0f
+                                                             : size.h * 0.5f);
+            text.x2 = text.x1 + size.w;
+            text.y2 = text.y1 + size.h;
+            text.alignH = -1;
+            prims.push_back(std::move(text));
+        };
+        endLabel(decor.labelFrom, true);
+        endLabel(decor.labelTo, false);
+    }
+}
+
+}  // namespace
+
+// --------------------------------------------------------------------------
+// State diagrams
+// --------------------------------------------------------------------------
+
+namespace {
+
+enum class StateKind { Normal, Start, End, Choice, Fork };
+
+struct StateNote {
+    size_t node = 0;
+    bool rightOf = true;
+    std::string text;
+};
+
+}  // namespace
+
+Built buildState(std::string_view source, const Measure& measure,
+                 float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    GraphNodes graph;
+    graph.diagram.direction = mermaid::Direction::TopToBottom;
+    std::vector<StateKind> kinds;
+    std::vector<std::vector<std::string>> descriptions;
+    std::vector<EdgeDecor> decors;
+    std::vector<StateNote> notes;
+    size_t startNode = SIZE_MAX;
+    size_t endNode = SIZE_MAX;
+
+    auto ensureState = [&](std::string_view id,
+                           std::string_view label) -> size_t {
+        size_t index = graph.ensure(id, label);
+        while (kinds.size() < graph.diagram.nodes.size()) {
+            kinds.push_back(StateKind::Normal);
+            descriptions.emplace_back();
+        }
+        return index;
+    };
+    auto ensureEndpoint = [&](bool isStart) -> size_t {
+        size_t& node = isStart ? startNode : endNode;
+        if (node == SIZE_MAX) {
+            node = ensureState(isStart ? "__start" : "__end", " ");
+            kinds[node] = isStart ? StateKind::Start : StateKind::End;
+            graph.diagram.nodes[node].label.clear();
+        }
+        return node;
+    };
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            if (!startsWithWord(line, "stateDiagram-v2") &&
+                !startsWithWord(line, "stateDiagram")) {
+                result.error = "Expected stateDiagram header";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "direction", &rest)) {
+            if (rest == "LR") {
+                graph.diagram.direction = mermaid::Direction::LeftToRight;
+            } else if (rest == "RL") {
+                graph.diagram.direction = mermaid::Direction::RightToLeft;
+            } else if (rest == "BT") {
+                graph.diagram.direction = mermaid::Direction::BottomToTop;
+            } else {
+                graph.diagram.direction = mermaid::Direction::TopToBottom;
+            }
+            continue;
+        }
+        if (line.find('{') != std::string_view::npos ||
+            line == "--" || line == "}") {
+            result.error = "Composite states are not supported";
+            return result;
+        }
+        if (startsWithWord(line, "note", &rest)) {
+            StateNote note;
+            std::string_view spec = rest;
+            if (startsWithWord(spec, "right", &spec)) {
+                note.rightOf = true;
+            } else if (startsWithWord(spec, "left", &spec)) {
+                note.rightOf = false;
+            } else {
+                result.error = "Unsupported note position";
+                return result;
+            }
+            startsWithWord(spec, "of", &spec);
+            size_t colon = spec.find(':');
+            if (colon == std::string_view::npos) {
+                result.error = "Multi-line notes are not supported";
+                return result;
+            }
+            note.node = ensureState(trimView(spec.substr(0, colon)), {});
+            note.text = cleanLabel(trimView(spec.substr(colon + 1)));
+            notes.push_back(std::move(note));
+            continue;
+        }
+        if (startsWithWord(line, "state", &rest)) {
+            // state "description" as id  |  state id <<choice|fork|join>>
+            if (!rest.empty() && rest.front() == '"') {
+                size_t closeQuote = rest.find('"', 1);
+                if (closeQuote == std::string_view::npos) {
+                    result.error = "Unterminated state description";
+                    return result;
+                }
+                std::string_view description = rest.substr(1, closeQuote - 1);
+                std::string_view after = trimView(rest.substr(closeQuote + 1));
+                std::string_view id;
+                if (startsWithWord(after, "as", &id)) {
+                    ensureState(trimView(id), description);
+                } else {
+                    ensureState(description, description);
+                }
+            } else {
+                size_t marker = rest.find("<<");
+                if (marker != std::string_view::npos) {
+                    std::string_view id = trimView(rest.substr(0, marker));
+                    std::string_view kind = rest.substr(marker + 2);
+                    size_t close = kind.find(">>");
+                    if (close != std::string_view::npos) {
+                        kind = kind.substr(0, close);
+                    }
+                    size_t node = ensureState(id, {});
+                    if (kind == "choice") {
+                        kinds[node] = StateKind::Choice;
+                    } else if (kind == "fork" || kind == "join") {
+                        kinds[node] = StateKind::Fork;
+                        graph.diagram.nodes[node].label.clear();
+                    }
+                } else {
+                    ensureState(trimView(rest), {});
+                }
+            }
+            continue;
+        }
+
+        // Transition: A --> B [: label], with [*] as start/end
+        size_t arrow = line.find("-->");
+        if (arrow != std::string_view::npos) {
+            std::string_view fromId = trimView(line.substr(0, arrow));
+            std::string_view afterArrow = line.substr(arrow + 3);
+            std::string_view toId = afterArrow;
+            std::string label;
+            size_t colon = afterArrow.find(':');
+            if (colon != std::string_view::npos) {
+                toId = trimView(afterArrow.substr(0, colon));
+                label = cleanLabel(trimView(afterArrow.substr(colon + 1)));
+            } else {
+                toId = trimView(afterArrow);
+            }
+            if (fromId.empty() || toId.empty()) {
+                result.error = "Transition needs two states";
+                return result;
+            }
+            size_t from = fromId == "[*]" ? ensureEndpoint(true)
+                                          : ensureState(fromId, {});
+            size_t to = toId == "[*]" ? ensureEndpoint(false)
+                                      : ensureState(toId, {});
+            mermaid::Edge edge;
+            edge.from = from;
+            edge.to = to;
+            edge.label = label;
+            graph.diagram.edges.push_back(std::move(edge));
+            EdgeDecor decor;
+            decor.atTo = Marker::FilledArrow;
+            decors.push_back(std::move(decor));
+            continue;
+        }
+
+        // Description: id : text
+        size_t colon = line.find(':');
+        if (colon != std::string_view::npos && colon > 0) {
+            size_t node = ensureState(trimView(line.substr(0, colon)), {});
+            descriptions[node].push_back(
+                cleanLabel(trimView(line.substr(colon + 1))));
+            continue;
+        }
+
+        result.error = "Unsupported state statement";
+        return result;
+    }
+
+    if (graph.diagram.nodes.empty()) {
+        result.error = "No states";
+        return result;
+    }
+
+    // --- measure nodes ---
+    TextStyle nameStyle;
+    nameStyle.bold = true;
+    TextStyle descStyle;
+    descStyle.scale = 0.9f;
+    bool vertical =
+        graph.diagram.direction == mermaid::Direction::TopToBottom ||
+        graph.diagram.direction == mermaid::Direction::BottomToTop;
+
+    std::vector<mermaid::Size> sizes(graph.diagram.nodes.size());
+    std::vector<Size> nameSizes(graph.diagram.nodes.size());
+    for (size_t i = 0; i < graph.diagram.nodes.size(); i++) {
+        switch (kinds[i]) {
+            case StateKind::Start:
+            case StateKind::End:
+                sizes[i] = {16.0f * scale, 16.0f * scale};
+                break;
+            case StateKind::Choice:
+                sizes[i] = {36.0f * scale, 36.0f * scale};
+                break;
+            case StateKind::Fork:
+                sizes[i] = vertical
+                               ? mermaid::Size{72.0f * scale, 9.0f * scale}
+                               : mermaid::Size{9.0f * scale, 72.0f * scale};
+                break;
+            case StateKind::Normal: {
+                Size nameSize =
+                    measure(graph.diagram.nodes[i].label, nameStyle, 0.0f);
+                nameSizes[i] = nameSize;
+                float width = nameSize.w;
+                float height = nameSize.h;
+                if (!descriptions[i].empty()) {
+                    for (const auto& description : descriptions[i]) {
+                        Size size = measure(description, descStyle, 0.0f);
+                        width = std::max(width, size.w);
+                        height += size.h;
+                    }
+                    height += 6.0f * scale;  // separator breathing room
+                }
+                sizes[i] = {std::max(56.0f * scale, width + 24.0f * scale),
+                            height + 16.0f * scale};
+                break;
+            }
+        }
+    }
+
+    mermaid::Layout layout = mermaid::layout(
+        acyclicForRanking(graph.diagram), sizes, kNodeGap * scale,
+        kRankGap * scale);
+    if (layout.nodes.size() != graph.diagram.nodes.size()) {
+        result.error = "Layout failed";
+        return result;
+    }
+
+    float maxRight = layout.width;
+    float maxBottom = layout.height;
+    auto routed =
+        routeEdges(graph.diagram, layout, scale, maxRight, maxBottom);
+    emitEdges(result.prims, graph.diagram, routed, decors, measure, scale);
+
+    // --- nodes ---
+    for (size_t i = 0; i < graph.diagram.nodes.size(); i++) {
+        const auto& rect = layout.nodes[i];
+        switch (kinds[i]) {
+            case StateKind::Start: {
+                Prim dot;
+                dot.type = PrimType::Ellipse;
+                dot.x1 = rect.left;
+                dot.y1 = rect.top;
+                dot.x2 = rect.right;
+                dot.y2 = rect.bottom;
+                dot.fill = Role::Accent;
+                result.prims.push_back(dot);
+                break;
+            }
+            case StateKind::End: {
+                Prim ring;
+                ring.type = PrimType::Ellipse;
+                ring.x1 = rect.left;
+                ring.y1 = rect.top;
+                ring.x2 = rect.right;
+                ring.y2 = rect.bottom;
+                ring.stroke = Role::Accent;
+                ring.strokeWidth = 1.6f * scale;
+                result.prims.push_back(ring);
+                Prim dot;
+                dot.type = PrimType::Ellipse;
+                float inset = 4.0f * scale;
+                dot.x1 = rect.left + inset;
+                dot.y1 = rect.top + inset;
+                dot.x2 = rect.right - inset;
+                dot.y2 = rect.bottom - inset;
+                dot.fill = Role::Accent;
+                result.prims.push_back(dot);
+                break;
+            }
+            case StateKind::Choice: {
+                Prim diamond;
+                diamond.type = PrimType::Polygon;
+                float cx = (rect.left + rect.right) * 0.5f;
+                float cy = (rect.top + rect.bottom) * 0.5f;
+                diamond.pts = {{cx, rect.top},
+                               {rect.right, cy},
+                               {cx, rect.bottom},
+                               {rect.left, cy}};
+                diamond.fill = Role::Fill;
+                diamond.stroke = Role::Stroke;
+                diamond.strokeWidth = 1.5f * scale;
+                result.prims.push_back(std::move(diamond));
+                break;
+            }
+            case StateKind::Fork: {
+                Prim bar;
+                bar.type = PrimType::RoundRect;
+                bar.radius = 3.0f * scale;
+                bar.x1 = rect.left;
+                bar.y1 = rect.top;
+                bar.x2 = rect.right;
+                bar.y2 = rect.bottom;
+                bar.fill = Role::Accent;
+                result.prims.push_back(bar);
+                break;
+            }
+            case StateKind::Normal: {
+                Prim box;
+                box.type = PrimType::RoundRect;
+                box.radius = 7.0f * scale;
+                box.x1 = rect.left;
+                box.y1 = rect.top;
+                box.x2 = rect.right;
+                box.y2 = rect.bottom;
+                box.fill = Role::Fill;
+                box.stroke = Role::Stroke;
+                box.strokeWidth = 1.5f * scale;
+                result.prims.push_back(box);
+                if (descriptions[i].empty()) {
+                    Prim name;
+                    name.type = PrimType::Text;
+                    name.text = graph.diagram.nodes[i].label;
+                    name.style = nameStyle;
+                    name.fill = Role::Text;
+                    name.x1 = rect.left;
+                    name.y1 = rect.top;
+                    name.x2 = rect.right;
+                    name.y2 = rect.bottom;
+                    result.prims.push_back(std::move(name));
+                } else {
+                    float nameHeight = nameSizes[i].h + 8.0f * scale;
+                    Prim name;
+                    name.type = PrimType::Text;
+                    name.text = graph.diagram.nodes[i].label;
+                    name.style = nameStyle;
+                    name.fill = Role::Text;
+                    name.x1 = rect.left;
+                    name.y1 = rect.top;
+                    name.x2 = rect.right;
+                    name.y2 = rect.top + nameHeight;
+                    result.prims.push_back(std::move(name));
+                    Prim separator;
+                    separator.type = PrimType::Line;
+                    separator.x1 = rect.left;
+                    separator.y1 = rect.top + nameHeight;
+                    separator.x2 = rect.right;
+                    separator.y2 = rect.top + nameHeight;
+                    separator.stroke = Role::Stroke;
+                    separator.strokeWidth = 1.0f * scale;
+                    result.prims.push_back(separator);
+                    std::string joined;
+                    for (const auto& description : descriptions[i]) {
+                        if (!joined.empty()) joined += '\n';
+                        joined += description;
+                    }
+                    Prim body;
+                    body.type = PrimType::Text;
+                    body.text = joined;
+                    body.style = descStyle;
+                    body.fill = Role::Text;
+                    body.alignH = -1;
+                    body.x1 = rect.left + 10.0f * scale;
+                    body.y1 = rect.top + nameHeight + 3.0f * scale;
+                    body.x2 = rect.right - 10.0f * scale;
+                    body.y2 = rect.bottom - 3.0f * scale;
+                    result.prims.push_back(std::move(body));
+                }
+                break;
+            }
+        }
+    }
+
+    // Inline notes beside their nodes
+    TextStyle noteStyle;
+    noteStyle.scale = 0.9f;
+    for (const auto& note : notes) {
+        const auto& rect = layout.nodes[note.node];
+        Size size = measure(note.text, noteStyle, 220.0f * scale);
+        float width = size.w + 16.0f * scale;
+        float height = size.h + 10.0f * scale;
+        float top = (rect.top + rect.bottom) * 0.5f - height * 0.5f;
+        float left = note.rightOf ? rect.right + 16.0f * scale
+                                  : rect.left - 16.0f * scale - width;
+        Prim box;
+        box.type = PrimType::Rect;
+        box.x1 = left;
+        box.y1 = top;
+        box.x2 = left + width;
+        box.y2 = top + height;
+        box.fill = Role::AccentSoft;
+        box.stroke = Role::Stroke;
+        box.strokeWidth = 1.0f * scale;
+        result.prims.push_back(box);
+        Prim text;
+        text.type = PrimType::Text;
+        text.text = note.text;
+        text.style = noteStyle;
+        text.fill = Role::Text;
+        text.x1 = left + 8.0f * scale;
+        text.y1 = top + 5.0f * scale;
+        text.x2 = left + width - 8.0f * scale;
+        text.y2 = top + height - 5.0f * scale;
+        result.prims.push_back(std::move(text));
+        Prim connectorLine;
+        connectorLine.type = PrimType::Line;
+        connectorLine.x1 = note.rightOf ? rect.right : rect.left;
+        connectorLine.y1 = (rect.top + rect.bottom) * 0.5f;
+        connectorLine.x2 = note.rightOf ? left : left + width;
+        connectorLine.y2 = top + height * 0.5f;
+        connectorLine.stroke = Role::Muted;
+        connectorLine.strokeWidth = 1.0f * scale;
+        connectorLine.dashed = true;
+        result.prims.push_back(connectorLine);
+        maxRight = std::max(maxRight, left + width);
+        maxBottom = std::max(maxBottom, top + height);
+    }
+
+    result.width = maxRight + 8.0f * scale;
+    result.height = maxBottom + 8.0f * scale;
+    normalizeLeft(result);
+    result.ok = true;
+    return result;
+}
+
+// --------------------------------------------------------------------------
+// Class diagrams
+// --------------------------------------------------------------------------
+
+namespace {
+
+struct ClassMembers {
+    std::string stereotype;
+    std::vector<std::string> attributes;
+    std::vector<std::string> methods;
+};
+
+// ~T~ generics display as <T>
+std::string displayGenerics(std::string value) {
+    bool open = true;
+    for (char& c : value) {
+        if (c == '~') {
+            c = open ? '<' : '>';
+            open = !open;
+        }
+    }
+    return value;
+}
+
+void addClassMember(ClassMembers& members, std::string_view raw) {
+    std::string_view trimmed = trimView(raw);
+    if (trimmed.empty()) return;
+    if (trimmed.size() >= 4 && trimmed.substr(0, 2) == "<<") {
+        size_t close = trimmed.find(">>");
+        if (close != std::string_view::npos) {
+            members.stereotype =
+                "<<" + std::string(trimView(trimmed.substr(2, close - 2))) +
+                ">>";
+            return;
+        }
+    }
+    std::string display = displayGenerics(cleanLabel(trimmed));
+    if (display.find('(') != std::string::npos) {
+        members.methods.push_back(std::move(display));
+    } else {
+        members.attributes.push_back(std::move(display));
+    }
+}
+
+struct RelationToken {
+    Marker marker = Marker::None;
+    size_t length = 0;
+};
+
+RelationToken leftRelationMarker(std::string_view text) {
+    if (text.size() >= 2 && text.substr(text.size() - 2) == "<|") {
+        return {Marker::HollowTriangle, 2};
+    }
+    if (!text.empty()) {
+        char last = text.back();
+        if (last == '*') return {Marker::FilledDiamond, 1};
+        if (last == 'o') return {Marker::HollowDiamond, 1};
+        if (last == '<') return {Marker::OpenArrow, 1};
+    }
+    return {};
+}
+
+RelationToken rightRelationMarker(std::string_view text) {
+    if (text.size() >= 2 && text.substr(0, 2) == "|>") {
+        return {Marker::HollowTriangle, 2};
+    }
+    if (!text.empty()) {
+        char first = text.front();
+        if (first == '*') return {Marker::FilledDiamond, 1};
+        if (first == 'o') return {Marker::HollowDiamond, 1};
+        if (first == '>') return {Marker::OpenArrow, 1};
+    }
+    return {};
+}
+
+// Strips one optional trailing quoted string ("1", "many") off the end
+std::string takeTrailingQuoted(std::string_view& text) {
+    text = trimView(text);
+    if (text.empty() || text.back() != '"') return {};
+    size_t open = text.rfind('"', text.size() - 2);
+    if (open == std::string_view::npos) return {};
+    std::string value(text.substr(open + 1, text.size() - open - 2));
+    text = trimView(text.substr(0, open));
+    return value;
+}
+
+std::string takeLeadingQuoted(std::string_view& text) {
+    text = trimView(text);
+    if (text.empty() || text.front() != '"') return {};
+    size_t close = text.find('"', 1);
+    if (close == std::string_view::npos) return {};
+    std::string value(text.substr(1, close - 1));
+    text = trimView(text.substr(close + 1));
+    return value;
+}
+
+}  // namespace
+
+Built buildClass(std::string_view source, const Measure& measure,
+                 float scale) {
+    Built result;
+    auto lines = diagramLines(source);
+    if (lines.empty()) {
+        result.error = "Empty diagram";
+        return result;
+    }
+
+    GraphNodes graph;
+    graph.diagram.direction = mermaid::Direction::TopToBottom;
+    std::map<size_t, ClassMembers> members;
+    std::vector<EdgeDecor> decors;
+    size_t openBlock = SIZE_MAX;  // class whose { } block is open
+
+    auto stripCss = [](std::string_view id) {
+        size_t css = id.find(":::");
+        return css == std::string_view::npos ? id : trimView(id.substr(0, css));
+    };
+    auto ensureClass = [&](std::string_view id) {
+        std::string display = displayGenerics(std::string(stripCss(id)));
+        return graph.ensure(display, display);
+    };
+
+    bool sawHeader = false;
+    for (std::string_view line : lines) {
+        if (!sawHeader) {
+            if (!startsWithWord(line, "classDiagram") &&
+                !startsWithWord(line, "classDiagram-v2")) {
+                result.error = "Expected classDiagram header";
+                return result;
+            }
+            sawHeader = true;
+            continue;
+        }
+        if (openBlock != SIZE_MAX) {
+            if (line == "}") {
+                openBlock = SIZE_MAX;
+            } else {
+                addClassMember(members[openBlock], line);
+            }
+            continue;
+        }
+        std::string_view rest;
+        if (startsWithWord(line, "direction", &rest)) {
+            if (rest == "LR") {
+                graph.diagram.direction = mermaid::Direction::LeftToRight;
+            } else if (rest == "RL") {
+                graph.diagram.direction = mermaid::Direction::RightToLeft;
+            } else if (rest == "BT") {
+                graph.diagram.direction = mermaid::Direction::BottomToTop;
+            } else {
+                graph.diagram.direction = mermaid::Direction::TopToBottom;
+            }
+            continue;
+        }
+        if (startsWithWord(line, "click", &rest) ||
+            startsWithWord(line, "callback", &rest) ||
+            startsWithWord(line, "link", &rest) ||
+            startsWithWord(line, "style", &rest) ||
+            startsWithWord(line, "classDef", &rest) ||
+            startsWithWord(line, "cssClass", &rest)) {
+            continue;  // interactivity/styling metadata, nothing to draw
+        }
+        if (startsWithWord(line, "note", &rest)) {
+            result.error = "Class notes are not supported";
+            return result;
+        }
+        if (startsWithWord(line, "namespace", &rest)) {
+            result.error = "Namespaces are not supported";
+            return result;
+        }
+        if (line.substr(0, 2) == "<<") {
+            size_t close = line.find(">>");
+            if (close != std::string_view::npos) {
+                std::string_view name = trimView(line.substr(close + 2));
+                if (!name.empty()) {
+                    size_t node = ensureClass(name);
+                    members[node].stereotype =
+                        "<<" +
+                        std::string(trimView(line.substr(2, close - 2))) +
+                        ">>";
+                    continue;
+                }
+            }
+            result.error = "Unsupported annotation";
+            return result;
+        }
+        if (startsWithWord(line, "class", &rest)) {
+            std::string_view spec = rest;
+            bool opensBlock = false;
+            if (!spec.empty() && spec.back() == '{') {
+                opensBlock = true;
+                spec = trimView(spec.substr(0, spec.size() - 1));
+            }
+            size_t node = ensureClass(spec);
+            if (opensBlock) openBlock = node;
+            continue;
+        }
+
+        // Relation: A [<|*o<] -- / .. [|>*o>] B, quoted multiplicities,
+        // optional : label
+        {
+            size_t linePos = std::string_view::npos;
+            bool dashed = false;
+            for (size_t i = 0; i + 1 < line.size(); i++) {
+                if (line[i] == '-' && line[i + 1] == '-') {
+                    linePos = i;
+                    dashed = false;
+                    break;
+                }
+                if (line[i] == '.' && line[i + 1] == '.') {
+                    linePos = i;
+                    dashed = true;
+                    break;
+                }
+            }
+            if (linePos != std::string_view::npos) {
+                std::string_view leftPart = line.substr(0, linePos);
+                std::string_view rightPart = line.substr(linePos + 2);
+                RelationToken leftMarker = leftRelationMarker(leftPart);
+                leftPart = leftPart.substr(0, leftPart.size() -
+                                                  leftMarker.length);
+                RelationToken rightMarker = rightRelationMarker(rightPart);
+                rightPart = rightPart.substr(rightMarker.length);
+
+                std::string label;
+                size_t colon = rightPart.find(':');
+                if (colon != std::string_view::npos) {
+                    label = cleanLabel(trimView(rightPart.substr(colon + 1)));
+                    rightPart = rightPart.substr(0, colon);
+                }
+                std::string leftMult = takeTrailingQuoted(leftPart);
+                std::string rightMult = takeLeadingQuoted(rightPart);
+                std::string_view leftId = trimView(leftPart);
+                std::string_view rightId = trimView(rightPart);
+                if (leftId.empty() || rightId.empty()) {
+                    result.error = "Relation needs two classes";
+                    return result;
+                }
+                mermaid::Edge edge;
+                edge.from = ensureClass(leftId);
+                edge.to = ensureClass(rightId);
+                edge.label = label;
+                graph.diagram.edges.push_back(std::move(edge));
+                EdgeDecor decor;
+                decor.atFrom = leftMarker.marker;
+                decor.atTo = rightMarker.marker;
+                decor.dashed = dashed;
+                decor.labelFrom = leftMult;
+                decor.labelTo = rightMult;
+                decors.push_back(std::move(decor));
+                continue;
+            }
+        }
+
+        // Member via colon: Name : +member
+        size_t colon = line.find(':');
+        if (colon != std::string_view::npos && colon > 0) {
+            size_t node = ensureClass(trimView(line.substr(0, colon)));
+            addClassMember(members[node], line.substr(colon + 1));
+            continue;
+        }
+
+        result.error = "Unsupported class statement";
+        return result;
+    }
+
+    if (graph.diagram.nodes.empty()) {
+        result.error = "No classes";
+        return result;
+    }
+
+    // --- measure ---
+    TextStyle nameStyle;
+    nameStyle.bold = true;
+    TextStyle stereoStyle;
+    stereoStyle.italic = true;
+    stereoStyle.scale = 0.85f;
+    TextStyle memberStyle;
+    memberStyle.scale = 0.9f;
+    float padX = 12.0f;
+    float memberLineGap = 3.0f;
+
+    struct MeasuredClass {
+        Size name;
+        Size stereotype;
+        float attrHeight = 0.0f;
+        float methodHeight = 0.0f;
+    };
+    std::vector<MeasuredClass> measured(graph.diagram.nodes.size());
+    std::vector<mermaid::Size> sizes(graph.diagram.nodes.size());
+    for (size_t i = 0; i < graph.diagram.nodes.size(); i++) {
+        const ClassMembers* classMembers = nullptr;
+        auto found = members.find(i);
+        if (found != members.end()) classMembers = &found->second;
+
+        MeasuredClass& node = measured[i];
+        node.name = measure(graph.diagram.nodes[i].label, nameStyle, 0.0f);
+        float width = node.name.w;
+        float height = node.name.h + 12.0f * scale;
+        if (classMembers && !classMembers->stereotype.empty()) {
+            node.stereotype =
+                measure(classMembers->stereotype, stereoStyle, 0.0f);
+            width = std::max(width, node.stereotype.w);
+            height += node.stereotype.h;
+        }
+        if (classMembers) {
+            for (const auto& attribute : classMembers->attributes) {
+                Size size = measure(attribute, memberStyle, 0.0f);
+                width = std::max(width, size.w);
+                node.attrHeight += size.h + memberLineGap * scale;
+            }
+            for (const auto& method : classMembers->methods) {
+                Size size = measure(method, memberStyle, 0.0f);
+                width = std::max(width, size.w);
+                node.methodHeight += size.h + memberLineGap * scale;
+            }
+            if (!classMembers->attributes.empty() ||
+                !classMembers->methods.empty()) {
+                // both compartments render (possibly thin) once any exist
+                height += node.attrHeight + node.methodHeight +
+                          16.0f * scale;
+            }
+        }
+        sizes[i] = {std::max(74.0f * scale, width + padX * 2.0f * scale),
+                    height};
+    }
+
+    mermaid::Layout layout = mermaid::layout(
+        acyclicForRanking(graph.diagram), sizes, kNodeGap * scale,
+        (kRankGap + 12.0f) * scale);
+    if (layout.nodes.size() != graph.diagram.nodes.size()) {
+        result.error = "Layout failed";
+        return result;
+    }
+
+    float maxRight = layout.width;
+    float maxBottom = layout.height;
+    auto routed =
+        routeEdges(graph.diagram, layout, scale, maxRight, maxBottom);
+    emitEdges(result.prims, graph.diagram, routed, decors, measure, scale);
+
+    for (size_t i = 0; i < graph.diagram.nodes.size(); i++) {
+        const auto& rect = layout.nodes[i];
+        const ClassMembers* classMembers = nullptr;
+        auto found = members.find(i);
+        if (found != members.end()) classMembers = &found->second;
+        const MeasuredClass& node = measured[i];
+
+        Prim box;
+        box.type = PrimType::RoundRect;
+        box.radius = 4.0f * scale;
+        box.x1 = rect.left;
+        box.y1 = rect.top;
+        box.x2 = rect.right;
+        box.y2 = rect.bottom;
+        box.fill = Role::Fill;
+        box.stroke = Role::Stroke;
+        box.strokeWidth = 1.5f * scale;
+        result.prims.push_back(box);
+
+        float y = rect.top + 6.0f * scale;
+        if (classMembers && !classMembers->stereotype.empty()) {
+            Prim stereo;
+            stereo.type = PrimType::Text;
+            stereo.text = classMembers->stereotype;
+            stereo.style = stereoStyle;
+            stereo.fill = Role::Muted;
+            stereo.x1 = rect.left;
+            stereo.y1 = y;
+            stereo.x2 = rect.right;
+            stereo.y2 = y + node.stereotype.h;
+            result.prims.push_back(std::move(stereo));
+            y += node.stereotype.h;
+        }
+        Prim name;
+        name.type = PrimType::Text;
+        name.text = graph.diagram.nodes[i].label;
+        name.style = nameStyle;
+        name.fill = Role::Text;
+        name.x1 = rect.left;
+        name.y1 = y;
+        name.x2 = rect.right;
+        name.y2 = y + node.name.h;
+        result.prims.push_back(std::move(name));
+        y += node.name.h + 6.0f * scale;
+
+        bool hasMembers =
+            classMembers && (!classMembers->attributes.empty() ||
+                             !classMembers->methods.empty());
+        if (hasMembers) {
+            auto compartment = [&](const std::vector<std::string>& entries,
+                                   float bodyHeight) {
+                Prim separator;
+                separator.type = PrimType::Line;
+                separator.x1 = rect.left;
+                separator.y1 = y;
+                separator.x2 = rect.right;
+                separator.y2 = y;
+                separator.stroke = Role::Stroke;
+                separator.strokeWidth = 1.0f * scale;
+                result.prims.push_back(separator);
+                y += 4.0f * scale;
+                if (!entries.empty()) {
+                    std::string joined;
+                    for (const auto& entry : entries) {
+                        if (!joined.empty()) joined += '\n';
+                        joined += entry;
+                    }
+                    Prim body;
+                    body.type = PrimType::Text;
+                    body.text = joined;
+                    body.style = memberStyle;
+                    body.fill = Role::Text;
+                    body.alignH = -1;
+                    body.alignV = -1;
+                    body.x1 = rect.left + padX * scale;
+                    body.y1 = y;
+                    body.x2 = rect.right - padX * scale;
+                    body.y2 = y + bodyHeight;
+                    result.prims.push_back(std::move(body));
+                }
+                y += bodyHeight + 4.0f * scale;
+            };
+            compartment(classMembers->attributes, node.attrHeight);
+            compartment(classMembers->methods, node.methodHeight);
+        }
+    }
+
+    result.width = maxRight + 8.0f * scale;
+    result.height = maxBottom + 8.0f * scale;
+    normalizeLeft(result);
+    result.ok = true;
+    return result;
+}
+
+}  // namespace detail
+}  // namespace mermaidext

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -324,7 +324,23 @@ void drawDocumentRange(App& app, ID2D1DeviceContext* dc,
         bool banded = applyBand(shape.rect.top, shape.rect.bottom);
         D2D1_RECT_F r = D2D1::RectF(shape.rect.left + dx, shape.rect.top + dy,
                                     shape.rect.right + dx, shape.rect.bottom + dy);
-        if (shape.type == App::LayoutShapeType::Diamond) {
+        if (shape.type == App::LayoutShapeType::Path) {
+            if (shape.geometry) {
+                D2D1_MATRIX_3X2_F previous;
+                dc->GetTransform(&previous);
+                dc->SetTransform(
+                    D2D1::Matrix3x2F::Translation(r.left, r.top) * previous);
+                if (shape.fill.a > 0.0f) {
+                    brush->SetColor(shape.fill);
+                    dc->FillGeometry(shape.geometry, brush);
+                }
+                if (shape.stroke.a > 0.0f && shape.strokeWidth > 0.0f) {
+                    brush->SetColor(shape.stroke);
+                    dc->DrawGeometry(shape.geometry, brush, shape.strokeWidth);
+                }
+                dc->SetTransform(previous);
+            }
+        } else if (shape.type == App::LayoutShapeType::Diamond) {
             float cx = (r.left + r.right) * 0.5f, cy = (r.top + r.bottom) * 0.5f;
             D2D1_POINT_2F pts[] = {{cx, r.top}, {r.right, cy}, {cx, r.bottom}, {r.left, cy}};
             fillStrokePolygon(pts, 4, shape);

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -1453,8 +1453,10 @@ static D2D1_COLOR_F diagramSeriesColor(const App& app, int index) {
     return D2D1::ColorF(r, g, b, 1.0f);
 }
 
-static D2D1_COLOR_F resolveDiagramRole(const App& app, mermaidext::Role role,
-                                       int seriesIndex) {
+static D2D1_COLOR_F resolveDiagramRole(const App& app,
+                                       const mermaidext::Prim& prim,
+                                       mermaidext::Role role) {
+    int seriesIndex = prim.seriesIndex;
     D2D1_COLOR_F color = app.theme.text;
     switch (role) {
         case mermaidext::Role::Text:
@@ -1486,6 +1488,9 @@ static D2D1_COLOR_F resolveDiagramRole(const App& app, mermaidext::Role role,
         case mermaidext::Role::SeriesSoft:
             color = diagramSeriesColor(app, seriesIndex);
             color.a = 0.30f;
+            break;
+        case mermaidext::Role::Custom:
+            color = D2D1::ColorF(prim.customR, prim.customG, prim.customB);
             break;
         case mermaidext::Role::None:
             color.a = 0.0f;
@@ -1683,10 +1688,8 @@ static bool layoutMermaidExtDiagram(App& app, mermaidext::Kind kind,
     for (const auto& prim : built.prims) {
         float x1 = baseX + prim.x1, y1 = baseY + prim.y1;
         float x2 = baseX + prim.x2, y2 = baseY + prim.y2;
-        D2D1_COLOR_F fill = resolveDiagramRole(app, prim.fill,
-                                               prim.seriesIndex);
-        D2D1_COLOR_F stroke = resolveDiagramRole(app, prim.stroke,
-                                                 prim.seriesIndex);
+        D2D1_COLOR_F fill = resolveDiagramRole(app, prim, prim.fill);
+        D2D1_COLOR_F stroke = resolveDiagramRole(app, prim, prim.stroke);
         switch (prim.type) {
             case mermaidext::PrimType::Rect:
             case mermaidext::PrimType::RoundRect:
@@ -1833,7 +1836,7 @@ static bool layoutMermaidExtDiagram(App& app, mermaidext::Kind kind,
         app.docText += wide;
         addTextRun(app, std::move(info),
                    D2D1::Point2F(rect.left, rect.top), rect,
-                   resolveDiagramRole(app, prim->fill, prim->seriesIndex),
+                   resolveDiagramRole(app, *prim, prim->fill),
                    docStart, wide.size(), true);
         app.docText += L"\n";
     }

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -4,6 +4,7 @@
 #include "syntax.h"
 #include "search.h"
 #include "mermaid.h"
+#include "mermaid_ext.h"
 #include "math_render.h"
 
 #include <algorithm>
@@ -11,6 +12,7 @@
 #include <cmath>
 #include <functional>
 #include <limits>
+#include <map>
 #include <string_view>
 #include <filesystem>
 #include <urlmon.h>
@@ -1393,6 +1395,462 @@ static bool layoutMermaidDiagram(App& app, const std::string& source,
     return true;
 }
 
+// --- extended Mermaid diagram families (sequence, pie, state, ...) ---
+
+static void rgbToHsl(float r, float g, float b, float& h, float& s, float& l) {
+    float maxC = std::max(r, std::max(g, b));
+    float minC = std::min(r, std::min(g, b));
+    l = (maxC + minC) * 0.5f;
+    if (maxC == minC) {
+        h = 0.0f;
+        s = 0.0f;
+        return;
+    }
+    float d = maxC - minC;
+    s = l > 0.5f ? d / (2.0f - maxC - minC) : d / (maxC + minC);
+    if (maxC == r) {
+        h = (g - b) / d + (g < b ? 6.0f : 0.0f);
+    } else if (maxC == g) {
+        h = (b - r) / d + 2.0f;
+    } else {
+        h = (r - g) / d + 4.0f;
+    }
+    h /= 6.0f;
+}
+
+static float hueChannel(float p, float q, float t) {
+    if (t < 0.0f) t += 1.0f;
+    if (t > 1.0f) t -= 1.0f;
+    if (t < 1.0f / 6.0f) return p + (q - p) * 6.0f * t;
+    if (t < 0.5f) return q;
+    if (t < 2.0f / 3.0f) return p + (q - p) * (2.0f / 3.0f - t) * 6.0f;
+    return p;
+}
+
+static void hslToRgb(float h, float s, float l, float& r, float& g, float& b) {
+    if (s == 0.0f) {
+        r = g = b = l;
+        return;
+    }
+    float q = l < 0.5f ? l * (1.0f + s) : l + s - l * s;
+    float p = 2.0f * l - q;
+    r = hueChannel(p, q, h + 1.0f / 3.0f);
+    g = hueChannel(p, q, h);
+    b = hueChannel(p, q, h - 1.0f / 3.0f);
+}
+
+// Categorical palette derived from the theme accent: golden-angle hue steps
+// keep neighboring series distinct in any theme
+static D2D1_COLOR_F diagramSeriesColor(const App& app, int index) {
+    float h, s, l;
+    rgbToHsl(app.theme.accent.r, app.theme.accent.g, app.theme.accent.b,
+             h, s, l);
+    h = std::fmod(h + index * 0.38197f, 1.0f);
+    s = app.theme.isDark ? 0.42f : 0.48f;
+    l = app.theme.isDark ? 0.60f : 0.52f;
+    float r, g, b;
+    hslToRgb(h, s, l, r, g, b);
+    return D2D1::ColorF(r, g, b, 1.0f);
+}
+
+static D2D1_COLOR_F resolveDiagramRole(const App& app, mermaidext::Role role,
+                                       int seriesIndex) {
+    D2D1_COLOR_F color = app.theme.text;
+    switch (role) {
+        case mermaidext::Role::Text:
+            color = app.theme.text;
+            break;
+        case mermaidext::Role::Muted:
+            color = app.theme.text;
+            color.a = app.theme.isDark ? 0.72f : 0.62f;
+            break;
+        case mermaidext::Role::Stroke:
+            color = app.theme.accent;
+            break;
+        case mermaidext::Role::Fill:
+            color = app.theme.codeBackground;
+            break;
+        case mermaidext::Role::Accent:
+            color = app.theme.accent;
+            break;
+        case mermaidext::Role::AccentSoft:
+            color = app.theme.accent;
+            color.a = app.theme.isDark ? 0.20f : 0.13f;
+            break;
+        case mermaidext::Role::Background:
+            color = app.theme.background;
+            break;
+        case mermaidext::Role::Series:
+            color = diagramSeriesColor(app, seriesIndex);
+            break;
+        case mermaidext::Role::SeriesSoft:
+            color = diagramSeriesColor(app, seriesIndex);
+            color.a = 0.30f;
+            break;
+        case mermaidext::Role::None:
+            color.a = 0.0f;
+            break;
+    }
+    return color;
+}
+
+// Per-layout-pass cache of text formats for the diagram text styles
+struct DiagramFormats {
+    App& app;
+    std::map<int, IDWriteTextFormat*> formats;
+
+    explicit DiagramFormats(App& application) : app(application) {}
+    DiagramFormats(const DiagramFormats&) = delete;
+    DiagramFormats& operator=(const DiagramFormats&) = delete;
+    ~DiagramFormats() {
+        for (auto& entry : formats) {
+            if (entry.second) entry.second->Release();
+        }
+    }
+
+    IDWriteTextFormat* get(const mermaidext::TextStyle& style, float scale) {
+        int key = (style.bold ? 1 : 0) | (style.italic ? 2 : 0) |
+                  (style.mono ? 4 : 0) |
+                  (static_cast<int>(style.scale * 100.0f + 0.5f) << 3);
+        auto found = formats.find(key);
+        if (found != formats.end()) return found->second;
+
+        const wchar_t* family =
+            style.mono ? app.theme.codeFontFamily : app.theme.fontFamily;
+        float size = (style.mono ? 13.0f : 14.0f) * scale * style.scale;
+        IDWriteTextFormat* format = nullptr;
+        app.dwriteFactory->CreateTextFormat(
+            family, nullptr,
+            style.bold ? DWRITE_FONT_WEIGHT_SEMI_BOLD
+                       : DWRITE_FONT_WEIGHT_NORMAL,
+            style.italic ? DWRITE_FONT_STYLE_ITALIC : DWRITE_FONT_STYLE_NORMAL,
+            DWRITE_FONT_STRETCH_NORMAL, size, L"en-us", &format);
+        formats[key] = format;
+        return format;
+    }
+};
+
+static IDWriteTextLayout* createDiagramTextLayout(
+        App& app, DiagramFormats& formats, const std::wstring& text,
+        const mermaidext::TextStyle& style, float scale, float width,
+        float height, int alignH, int alignV) {
+    IDWriteTextFormat* format = formats.get(style, scale);
+    if (!format || text.empty()) return nullptr;
+    IDWriteTextLayout* layout = nullptr;
+    app.dwriteFactory->CreateTextLayout(
+        text.data(), static_cast<UINT32>(text.size()), format,
+        std::max(width, 1.0f), std::max(height, 1.0f), &layout);
+    if (!layout) return nullptr;
+    layout->SetTextAlignment(alignH < 0 ? DWRITE_TEXT_ALIGNMENT_LEADING
+                             : alignH > 0 ? DWRITE_TEXT_ALIGNMENT_TRAILING
+                                          : DWRITE_TEXT_ALIGNMENT_CENTER);
+    layout->SetParagraphAlignment(alignV < 0
+                                      ? DWRITE_PARAGRAPH_ALIGNMENT_NEAR
+                                  : alignV > 0 ? DWRITE_PARAGRAPH_ALIGNMENT_FAR
+                                               : DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+    if (app.fontFallback) {
+        IDWriteTextLayout2* layout2 = nullptr;
+        if (SUCCEEDED(layout->QueryInterface(
+                __uuidof(IDWriteTextLayout2),
+                reinterpret_cast<void**>(&layout2)))) {
+            layout2->SetFontFallback(app.fontFallback);
+            layout2->Release();
+        }
+    }
+    return layout;
+}
+
+static ID2D1PathGeometry* buildPolygonGeometry(
+        App& app, const std::vector<mermaidext::Point>& points,
+        float originX, float originY) {
+    if (points.size() < 3) return nullptr;
+    ID2D1PathGeometry* geometry = nullptr;
+    if (FAILED(app.d2dFactory->CreatePathGeometry(&geometry)) || !geometry) {
+        return nullptr;
+    }
+    ID2D1GeometrySink* sink = nullptr;
+    if (FAILED(geometry->Open(&sink)) || !sink) {
+        geometry->Release();
+        return nullptr;
+    }
+    sink->BeginFigure(
+        D2D1::Point2F(points[0].x - originX, points[0].y - originY),
+        D2D1_FIGURE_BEGIN_FILLED);
+    for (size_t i = 1; i < points.size(); i++) {
+        sink->AddLine(
+            D2D1::Point2F(points[i].x - originX, points[i].y - originY));
+    }
+    sink->EndFigure(D2D1_FIGURE_END_CLOSED);
+    sink->Close();
+    sink->Release();
+    return geometry;
+}
+
+static ID2D1PathGeometry* buildSliceGeometry(App& app, float radius,
+                                             float a0, float a1) {
+    // Local space: circle center at (radius, radius)
+    ID2D1PathGeometry* geometry = nullptr;
+    if (FAILED(app.d2dFactory->CreatePathGeometry(&geometry)) || !geometry) {
+        return nullptr;
+    }
+    ID2D1GeometrySink* sink = nullptr;
+    if (FAILED(geometry->Open(&sink)) || !sink) {
+        geometry->Release();
+        return nullptr;
+    }
+    float cx = radius, cy = radius;
+    D2D1_POINT_2F start =
+        D2D1::Point2F(cx + radius * std::cos(a0), cy + radius * std::sin(a0));
+    D2D1_POINT_2F end =
+        D2D1::Point2F(cx + radius * std::cos(a1), cy + radius * std::sin(a1));
+    float sweep = a1 - a0;
+    if (sweep >= 6.28318f - 0.0001f) {
+        // Full circle: two half arcs
+        sink->BeginFigure(start, D2D1_FIGURE_BEGIN_FILLED);
+        D2D1_POINT_2F opposite = D2D1::Point2F(
+            cx + radius * std::cos(a0 + 3.14159f),
+            cy + radius * std::sin(a0 + 3.14159f));
+        D2D1_ARC_SEGMENT half1 = {
+            opposite, {radius, radius}, 0.0f,
+            D2D1_SWEEP_DIRECTION_CLOCKWISE, D2D1_ARC_SIZE_SMALL};
+        D2D1_ARC_SEGMENT half2 = {
+            start, {radius, radius}, 0.0f,
+            D2D1_SWEEP_DIRECTION_CLOCKWISE, D2D1_ARC_SIZE_SMALL};
+        sink->AddArc(half1);
+        sink->AddArc(half2);
+        sink->EndFigure(D2D1_FIGURE_END_CLOSED);
+    } else {
+        sink->BeginFigure(D2D1::Point2F(cx, cy), D2D1_FIGURE_BEGIN_FILLED);
+        sink->AddLine(start);
+        D2D1_ARC_SEGMENT arc = {
+            end, {radius, radius}, 0.0f, D2D1_SWEEP_DIRECTION_CLOCKWISE,
+            sweep > 3.14159f ? D2D1_ARC_SIZE_LARGE : D2D1_ARC_SIZE_SMALL};
+        sink->AddArc(arc);
+        sink->EndFigure(D2D1_FIGURE_END_CLOSED);
+    }
+    sink->Close();
+    sink->Release();
+    return geometry;
+}
+
+static bool layoutMermaidExtDiagram(App& app, mermaidext::Kind kind,
+                                    const std::string& source,
+                                    size_t sourceOffset, float& y,
+                                    float indent, float maxWidth,
+                                    D2D1_RECT_F* renderedBounds) {
+    float scale = app.contentScale * app.zoomFactor;
+    DiagramFormats formats(app);
+
+    auto measureFn = [&](const std::string& text,
+                         const mermaidext::TextStyle& style,
+                         float wrapWidth) -> mermaidext::Size {
+        if (text.empty()) return {};
+        std::wstring wide = toWide(text);
+        IDWriteTextLayout* layout = createDiagramTextLayout(
+            app, formats, wide, style, scale,
+            wrapWidth > 0.0f ? wrapWidth : kHugeWidth, kHugeWidth, -1, -1);
+        if (!layout) return {};
+        if (wrapWidth <= 0.0f) {
+            layout->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);
+        }
+        DWRITE_TEXT_METRICS metrics{};
+        layout->GetMetrics(&metrics);
+        layout->Release();
+        return {metrics.widthIncludingTrailingWhitespace, metrics.height};
+    };
+
+    mermaidext::Built built =
+        mermaidext::build(kind, source, measureFn, scale);
+    if (!built.ok || built.prims.empty()) return false;
+
+    float baseX = indent;
+    if (built.width < maxWidth) {
+        baseX += (maxWidth - built.width) * 0.5f;
+    }
+    float baseY = y + 10.0f * scale;
+
+    if (sourceOffset != SIZE_MAX) {
+        if (app.scrollAnchors.empty() ||
+            app.scrollAnchors.back().sourceOffset < sourceOffset) {
+            app.scrollAnchors.push_back({sourceOffset, baseY});
+        }
+    }
+
+    // Text prims are appended to docText in reading order so selection
+    // sweeps the diagram top-to-bottom
+    std::vector<const mermaidext::Prim*> textPrims;
+
+    for (const auto& prim : built.prims) {
+        float x1 = baseX + prim.x1, y1 = baseY + prim.y1;
+        float x2 = baseX + prim.x2, y2 = baseY + prim.y2;
+        D2D1_COLOR_F fill = resolveDiagramRole(app, prim.fill,
+                                               prim.seriesIndex);
+        D2D1_COLOR_F stroke = resolveDiagramRole(app, prim.stroke,
+                                                 prim.seriesIndex);
+        switch (prim.type) {
+            case mermaidext::PrimType::Rect:
+            case mermaidext::PrimType::RoundRect:
+            case mermaidext::PrimType::Ellipse: {
+                App::LayoutShape shape;
+                shape.type =
+                    prim.type == mermaidext::PrimType::Rect
+                        ? App::LayoutShapeType::Rectangle
+                    : prim.type == mermaidext::PrimType::RoundRect
+                        ? App::LayoutShapeType::RoundedRectangle
+                        : App::LayoutShapeType::Ellipse;
+                shape.rect = D2D1::RectF(x1, y1, x2, y2);
+                shape.fill = fill;
+                shape.stroke = stroke;
+                shape.strokeWidth = prim.strokeWidth;
+                shape.radius = prim.radius;
+                app.layoutShapes.push_back(shape);
+                break;
+            }
+            case mermaidext::PrimType::Line: {
+                App::LayoutConnector connector;
+                connector.color = stroke;
+                connector.stroke = prim.strokeWidth;
+                connector.dashed = prim.dashed;
+                connector.arrowSize = 8.0f * scale;
+                connector.directed = prim.openArrow;
+                float endX = x2, endY = y2;
+                if (prim.arrow) {
+                    // Filled triangle head: shorten the line, add a polygon
+                    float dx = x2 - x1, dy = y2 - y1;
+                    float length = std::sqrt(dx * dx + dy * dy);
+                    if (length > 0.01f) {
+                        dx /= length;
+                        dy /= length;
+                        float head = 9.0f * scale;
+                        float wing = 4.5f * scale;
+                        endX = x2 - dx * head * 0.7f;
+                        endY = y2 - dy * head * 0.7f;
+                        std::vector<mermaidext::Point> tri = {
+                            {x2, y2},
+                            {x2 - dx * head + dy * wing,
+                             y2 - dy * head - dx * wing},
+                            {x2 - dx * head - dy * wing,
+                             y2 - dy * head + dx * wing},
+                        };
+                        float minX = std::min({tri[0].x, tri[1].x, tri[2].x});
+                        float minY = std::min({tri[0].y, tri[1].y, tri[2].y});
+                        float maxX = std::max({tri[0].x, tri[1].x, tri[2].x});
+                        float maxY = std::max({tri[0].y, tri[1].y, tri[2].y});
+                        App::LayoutShape triangle;
+                        triangle.type = App::LayoutShapeType::Path;
+                        triangle.rect = D2D1::RectF(minX, minY, maxX, maxY);
+                        triangle.fill = stroke;
+                        triangle.stroke.a = 0.0f;
+                        triangle.geometry =
+                            buildPolygonGeometry(app, tri, minX, minY);
+                        app.layoutShapes.push_back(triangle);
+                    }
+                }
+                connector.points = {D2D1::Point2F(x1, y1),
+                                    D2D1::Point2F(endX, endY)};
+                connector.bounds = D2D1::RectF(
+                    std::min(x1, x2) - 10.0f * scale,
+                    std::min(y1, y2) - 10.0f * scale,
+                    std::max(x1, x2) + 10.0f * scale,
+                    std::max(y1, y2) + 10.0f * scale);
+                app.layoutConnectors.push_back(std::move(connector));
+                break;
+            }
+            case mermaidext::PrimType::Polygon: {
+                if (prim.pts.size() < 3) break;
+                std::vector<mermaidext::Point> shifted = prim.pts;
+                float minX = shifted[0].x, minY = shifted[0].y;
+                float maxX = minX, maxY = minY;
+                for (auto& point : shifted) {
+                    point.x += baseX;
+                    point.y += baseY;
+                }
+                minX = maxX = shifted[0].x;
+                minY = maxY = shifted[0].y;
+                for (const auto& point : shifted) {
+                    minX = std::min(minX, point.x);
+                    minY = std::min(minY, point.y);
+                    maxX = std::max(maxX, point.x);
+                    maxY = std::max(maxY, point.y);
+                }
+                App::LayoutShape shape;
+                shape.type = App::LayoutShapeType::Path;
+                shape.rect = D2D1::RectF(minX, minY, maxX, maxY);
+                shape.fill = fill;
+                shape.stroke = stroke;
+                shape.strokeWidth = prim.strokeWidth;
+                shape.geometry = buildPolygonGeometry(app, shifted, minX, minY);
+                app.layoutShapes.push_back(shape);
+                break;
+            }
+            case mermaidext::PrimType::Slice: {
+                App::LayoutShape shape;
+                shape.type = App::LayoutShapeType::Path;
+                shape.rect = D2D1::RectF(
+                    x1 - prim.radius, y1 - prim.radius,
+                    x1 + prim.radius, y1 + prim.radius);
+                shape.fill = fill;
+                shape.stroke = stroke;
+                shape.strokeWidth = prim.strokeWidth;
+                shape.geometry =
+                    buildSliceGeometry(app, prim.radius, prim.a0, prim.a1);
+                app.layoutShapes.push_back(shape);
+                break;
+            }
+            case mermaidext::PrimType::Text:
+                textPrims.push_back(&prim);
+                break;
+        }
+    }
+
+    std::stable_sort(textPrims.begin(), textPrims.end(),
+                     [](const mermaidext::Prim* a, const mermaidext::Prim* b) {
+                         if (std::abs(a->y1 - b->y1) > kLineBucketTolerance) {
+                             return a->y1 < b->y1;
+                         }
+                         return a->x1 < b->x1;
+                     });
+    for (const mermaidext::Prim* prim : textPrims) {
+        std::wstring wide = toWide(prim->text);
+        if (wide.empty()) continue;
+        D2D1_RECT_F rect = D2D1::RectF(baseX + prim->x1, baseY + prim->y1,
+                                       baseX + prim->x2, baseY + prim->y2);
+        // Slight width slack: boxes are sized from measured text, and
+        // re-wrapping at the exact measured width can push the last word
+        // (or a CJK character) onto a phantom second line
+        IDWriteTextLayout* layout = createDiagramTextLayout(
+            app, formats, wide, prim->style, scale,
+            rect.right - rect.left + 2.5f, rect.bottom - rect.top + 2.0f,
+            prim->alignH, prim->alignV);
+        if (!layout) continue;
+        LayoutInfo info;
+        info.layout = layout;
+        DWRITE_TEXT_METRICS metrics{};
+        layout->GetMetrics(&metrics);
+        info.width = metrics.widthIncludingTrailingWhitespace;
+        info.height = metrics.height;
+        size_t docStart = app.docText.size();
+        app.docText += wide;
+        addTextRun(app, std::move(info),
+                   D2D1::Point2F(rect.left, rect.top), rect,
+                   resolveDiagramRole(app, prim->fill, prim->seriesIndex),
+                   docStart, wide.size(), true);
+        app.docText += L"\n";
+    }
+    app.docText += L"\n";
+
+    float diagramRight = baseX + built.width;
+    float diagramBottom = baseY + built.height;
+    app.contentWidth = std::max(app.contentWidth,
+                                diagramRight + 40.0f * scale);
+    if (renderedBounds) {
+        *renderedBounds =
+            D2D1::RectF(baseX, baseY, diagramRight, diagramBottom);
+    }
+    y = diagramBottom + 24.0f * scale;
+    return true;
+}
+
 static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float indent, float maxWidth) {
     std::string code;
     for (const auto& child : elem->children) {
@@ -1407,9 +1865,18 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
         [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     if (languageName == "mermaid") {
         D2D1_RECT_F renderedBounds{};
-        if (layoutMermaidDiagram(
+        mermaidext::Kind kind = mermaidext::detectKind(code);
+        bool rendered = false;
+        if (kind == mermaidext::Kind::Flowchart) {
+            rendered = layoutMermaidDiagram(
                 app, code, elem->sourceOffset, y, indent, maxWidth,
-                &renderedBounds)) {
+                &renderedBounds);
+        } else if (kind != mermaidext::Kind::None) {
+            rendered = layoutMermaidExtDiagram(
+                app, kind, code, elem->sourceOffset, y, indent, maxWidth,
+                &renderedBounds);
+        }
+        if (rendered) {
             app.codeBlocks.push_back({renderedBounds, toWide(code)});
             return;
         }

--- a/tests/mermaid_tests.cpp
+++ b/tests/mermaid_tests.cpp
@@ -1,5 +1,7 @@
 #include "mermaid.h"
+#include "mermaid_ext.h"
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -209,6 +211,132 @@ A --> D
     }
 }
 
+// --- extended diagram families (mermaidext) ---
+
+// Character-cell measurer: 8px per column, 16px per line
+mermaidext::Size fakeMeasure(const std::string& text,
+                             const mermaidext::TextStyle&, float) {
+    size_t longest = 0, current = 0, lines = text.empty() ? 0 : 1;
+    for (char c : text) {
+        if (c == '\n') {
+            lines++;
+            current = 0;
+        } else {
+            current++;
+            longest = std::max(longest, current);
+        }
+    }
+    return {static_cast<float>(longest * 8),
+            static_cast<float>(lines * 16)};
+}
+
+void testDetectKind() {
+    using mermaidext::Kind;
+    using mermaidext::detectKind;
+    check(detectKind("graph TD\nA-->B") == Kind::Flowchart,
+          "graph detects as flowchart");
+    check(detectKind("%% comment\nflowchart LR\nA-->B") == Kind::Flowchart,
+          "leading comments are skipped in detection");
+    check(detectKind("sequenceDiagram\nA->>B: hi") == Kind::Sequence,
+          "sequenceDiagram detected");
+    check(detectKind("classDiagram\nA <|-- B") == Kind::Class,
+          "classDiagram detected");
+    check(detectKind("stateDiagram-v2\n[*] --> A") == Kind::State,
+          "stateDiagram-v2 detected");
+    check(detectKind("erDiagram\nA ||--o{ B : has") == Kind::Er,
+          "erDiagram detected");
+    check(detectKind("pie\n\"A\" : 1") == Kind::Pie, "pie detected");
+    check(detectKind("gitGraph\ncommit") == Kind::Git, "gitGraph detected");
+    check(detectKind("gantt\ntitle X") == Kind::Gantt, "gantt detected");
+    check(detectKind("mindmap\n  root") == Kind::Mindmap,
+          "mindmap detected");
+    check(detectKind("timeline\n2020 : x") == Kind::Timeline,
+          "timeline detected");
+    check(detectKind("journey\ntitle X") == Kind::Journey,
+          "journey detected");
+    check(detectKind("quadrantChart\ntitle X") == Kind::Quadrant,
+          "quadrantChart detected");
+    check(detectKind("xychart-beta\nbar [1]") == Kind::XyChart,
+          "xychart-beta detected");
+    check(detectKind("C4Context\n...") == Kind::None,
+          "unsupported kinds report None");
+}
+
+void testExtBuilders() {
+    using mermaidext::Kind;
+    struct Case {
+        Kind kind;
+        const char* name;
+        const char* source;
+    };
+    const Case kCases[] = {
+        {Kind::Sequence, "sequence",
+         "sequenceDiagram\n"
+         "    participant A as Service<br/>api\n"
+         "    A->>+B: request\n"
+         "    B-->>-A: reply\n"
+         "    Note over A,B: both\n"
+         "    loop retry\n        A-)B: ping\n    end\n"},
+        {Kind::Pie, "pie",
+         "pie showData title Share\n    \"A\" : 60\n    \"B\" : 40\n"},
+        {Kind::State, "state",
+         "stateDiagram-v2\n    [*] --> S1\n    S1 --> S2 : go\n"
+         "    S2 --> S1 : back\n    S2 --> [*]\n"},
+        {Kind::Class, "class",
+         "classDiagram\n    Animal <|-- Duck\n    Animal : +int age\n"
+         "    class Duck{\n        +swim()\n    }\n"},
+        {Kind::Er, "er",
+         "erDiagram\n    CUSTOMER ||--o{ ORDER : places\n"
+         "    CUSTOMER {\n        string name PK\n    }\n"},
+        {Kind::Git, "git",
+         "gitGraph\n   commit\n   branch dev\n   commit\n"
+         "   checkout main\n   merge dev tag: \"v1\"\n"},
+        {Kind::Gantt, "gantt",
+         "gantt\n    dateFormat YYYY-MM-DD\n    section S\n"
+         "        T1 :a1, 2026-01-01, 5d\n        T2 :after a1, 3d\n"},
+        {Kind::Mindmap, "mindmap",
+         "mindmap\n  root((center))\n    A\n      A1\n    B\n"},
+        {Kind::Timeline, "timeline",
+         "timeline\n    title T\n    2020 : one : two\n    2021 : three\n"},
+        {Kind::Journey, "journey",
+         "journey\n    title T\n    section S\n      Task: 5: Me\n"},
+        {Kind::Quadrant, "quadrant",
+         "quadrantChart\n    x-axis Low --> High\n    quadrant-1 Q\n"
+         "    A: [0.3, 0.6]\n"},
+        {Kind::XyChart, "xychart",
+         "xychart-beta\n    x-axis [a, b]\n    bar [1, 2]\n    line [2, 1]\n"},
+    };
+    for (const auto& testCase : kCases) {
+        auto built = mermaidext::build(testCase.kind, testCase.source,
+                                       fakeMeasure, 1.0f);
+        std::string label = std::string(testCase.name) + " builds";
+        check(built.ok, label.c_str());
+        if (!built.ok) {
+            std::cerr << "  (" << built.error << ")\n";
+            continue;
+        }
+        label = std::string(testCase.name) + " has extent";
+        check(built.width > 0.0f && built.height > 0.0f, label.c_str());
+        label = std::string(testCase.name) + " emits primitives";
+        check(!built.prims.empty(), label.c_str());
+    }
+}
+
+void testExtFallbacks() {
+    auto sequence = mermaidext::build(
+        mermaidext::Kind::Sequence,
+        "sequenceDiagram\n    createParticipant A\n", fakeMeasure, 1.0f);
+    check(!sequence.ok, "unknown sequence statement falls back");
+    auto composite = mermaidext::build(
+        mermaidext::Kind::State,
+        "stateDiagram-v2\n    state Outer {\n        [*] --> A\n    }\n",
+        fakeMeasure, 1.0f);
+    check(!composite.ok, "composite states fall back");
+    auto pie = mermaidext::build(mermaidext::Kind::Pie,
+                                 "pie\n    \"A\" : -3\n", fakeMeasure, 1.0f);
+    check(!pie.ok, "negative pie values fall back");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -221,6 +349,9 @@ int main(int argc, char** argv) {
     testBackslashNLineBreak();
     testAttributeSyntaxRejected();
     testLayoutExposesRanks();
+    testDetectKind();
+    testExtBuilders();
+    testExtFallbacks();
     testFiles(argc, argv);
 
     if (failures != 0) {


### PR DESCRIPTION
Tinta now natively renders **thirteen Mermaid diagram families** (previously: flowcharts only). No web engine involved, everything drawn with Direct2D, themed, printable via Ctrl+P, with selectable/searchable text.

New: **sequence diagrams** (#108 - the reporter's 2PC diagram was the development corpus), **class**, **state**, **ER**, **pie**, **gitGraph**, **gantt**, **mindmap**, **timeline**, **journey**, **quadrantChart**, **xychart-beta**.

Architecture: a new `mermaidext` library parses each family into flat theme-neutral drawing primitives (rects, lines, polygons, pie slices, text) with text measurement injected via callback, so the parsers stay unit-testable. `render.cpp` translates primitives into the existing layout structures; a new `Path` layout shape carries eager local-space geometry (arrowheads, pie slices, crow's feet) through both the screen and print pipelines. State/class/ER reuse the flowchart rank layout through a back-edge-reversing cycle breaker. Categorical colors derive from the theme accent via golden-angle hue rotation, so every theme gets a coherent palette.

Each family was screenshot-verified against the mermaid docs examples (feature-tests/mermaid/ in the campaign workspace) plus the corpus files; parser unit tests cover kind detection, one build per family, and fallback behavior. Anything unsupported still falls back to readable source - never silently dropped content.

Closes #108.