### PR TITLE
Fix copied-toast centering and stats overlay zoom scaling

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -317,6 +317,9 @@ struct App {
     IDWriteTextFormat* tocFormat = nullptr;
     IDWriteTextFormat* tocFormatBold = nullptr;
 
+    // Stats overlay: UI chrome, so it must not follow the document zoom
+    IDWriteTextFormat* statsFormat = nullptr;
+
     // Markdown
     MarkdownParser parser;
     ElementPtr root;
@@ -852,6 +855,7 @@ struct App {
         if (folderBrowserFormat) { folderBrowserFormat->Release(); folderBrowserFormat = nullptr; }
         if (tocFormat) { tocFormat->Release(); tocFormat = nullptr; }
         if (tocFormatBold) { tocFormatBold->Release(); tocFormatBold = nullptr; }
+        if (statsFormat) { statsFormat->Release(); statsFormat = nullptr; }
         if (supSubFormat) { supSubFormat->Release(); supSubFormat = nullptr; }
         if (editorTextFormat) { editorTextFormat->Release(); editorTextFormat = nullptr; }
         for (auto& fmt : themePreviewFormats) {

--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -321,6 +321,12 @@ void updateOverlayFormats(App& app) {
     // releaseOverlayFormats() above already cleared them; they rebuild at the
     // current scale on next use.
 
+    // Stats overlay format: fixed UI size so zooming the document cannot
+    // overflow the fixed stats box
+    app.dwriteFactory->CreateTextFormat(app.theme.codeFontFamily, nullptr,
+        DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
+        13.0f * scale, L"en-us", &app.statsFormat);
+
     // Folder browser format
     app.dwriteFactory->CreateTextFormat(L"Segoe UI", nullptr,
         DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -790,9 +790,19 @@ render_document:
                 D2D1_COLOR_F textColor = app.theme.background;
                 textColor.a = alpha;
                 app.brush->SetColor(textColor);
-                app.renderTarget->DrawText(copied, (UINT32)wcslen(copied), app.textFormat,
-                    D2D1::RectF(pillX, pillY + dpi(app, 4.0f),
-                                pillX + copyWidth, pillY + copyHeight), app.brush);
+                // A dedicated layout centers both axes; the shared textFormat
+                // is leading/near-aligned and must not be mutated here
+                IDWriteTextLayout* toastLayout = nullptr;
+                app.dwriteFactory->CreateTextLayout(
+                    copied, (UINT32)wcslen(copied), app.textFormat,
+                    copyWidth, copyHeight, &toastLayout);
+                if (toastLayout) {
+                    toastLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+                    toastLayout->SetParagraphAlignment(DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+                    app.renderTarget->DrawTextLayout(
+                        D2D1::Point2F(pillX, pillY), toastLayout, app.brush);
+                    toastLayout->Release();
+                }
             }
             app.drawCalls++;
         } else {
@@ -827,7 +837,8 @@ render_document:
             app.brush);
 
         app.brush->SetColor(D2D1::ColorF(0.7f, 0.9f, 0.7f));
-        app.renderTarget->DrawText(stats, (UINT32)wcslen(stats), app.codeFormat,
+        app.renderTarget->DrawText(stats, (UINT32)wcslen(stats),
+            app.statsFormat ? app.statsFormat : app.codeFormat,
             D2D1::RectF(app.width - statsWidth - dpi(app, 5.0f), app.height - statsHeight - dpi(app, 5.0f),
                        app.width - dpi(app, 15.0f), app.height - dpi(app, 15.0f)),
             app.brush);


### PR DESCRIPTION
Two overlay fixes found in live testing after #110: the copied toast now centers its label on both axes (it drew with the leading-aligned shared textFormat), and the stats overlay gets a zoom-independent text format so document zoom cannot overflow its fixed box.