### PR TITLE
Folder browser: hit-test clicks instead of trusting hover

### DIFF
--- a/include/overlays.h
+++ b/include/overlays.h
@@ -5,6 +5,9 @@
 
 void renderSearchOverlay(App& app);
 void renderFolderBrowser(App& app);
+// Folder-browser item under a client point (-1 = none); shares the
+// renderer's geometry so click handling never trusts stale hover state
+int folderItemIndexAt(const App& app, float x, float y);
 void renderToc(App& app);
 void renderThemeChooser(App& app);
 // Chooser grid geometry, shared between render and hit-testing: rows in the

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1974,9 +1974,12 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 return;
             }
 
-            // Hit-test items
-            if (app.hoveredFolderIndex >= 0 && app.hoveredFolderIndex < (int)app.folderItems.size()) {
-                const auto& item = app.folderItems[app.hoveredFolderIndex];
+            // Hit-test items at the CLICK position: the render-time hover
+            // index lags a paint behind the mouse, so trusting it here
+            // opened the previously highlighted row on fast move-and-click
+            int clickedItem = folderItemIndexAt(app, (float)clickX, (float)clickY);
+            if (clickedItem >= 0 && clickedItem < (int)app.folderItems.size()) {
+                const auto& item = app.folderItems[clickedItem];
 
                 if (item.isDirectory) {
                     // Navigate into folder

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -139,6 +139,33 @@ void renderSearchOverlay(App& app) {
     }
 }
 
+// Item index at a client point, sharing renderFolderBrowser's geometry.
+// Clicks must hit-test their own coordinates: the render-time hover index
+// lags one paint behind the mouse, so a fast move-and-click would act on
+// the previously highlighted row.
+int folderItemIndexAt(const App& app, float x, float y) {
+    float panelWidth = folderBrowserPanelWidth(app);
+    float panelX = -panelWidth * (1.0f - app.folderBrowserAnimation);
+    float padding = dpi(app, 12.0f);
+    float itemHeight = dpi(app, 28.0f);
+    float headerHeight = dpi(app, 40.0f);
+    float listStartY = padding + headerHeight + dpi(app, 8.0f);
+    float panelHeight = (float)app.height;
+    float namingOffset =
+        app.folderBrowserNaming != 0 ? itemHeight : 0.0f;
+
+    float itemX = panelX + padding;
+    float itemW = panelWidth - padding * 2.0f;
+    if (x < itemX || x > itemX + itemW) return -1;
+    if (y < listStartY || y > panelHeight - padding) return -1;
+    float offset =
+        y - (listStartY + namingOffset - app.folderBrowserScroll);
+    if (offset < 0.0f) return -1;
+    int index = (int)(offset / itemHeight);
+    if (index < 0 || index >= (int)app.folderItems.size()) return -1;
+    return index;
+}
+
 void renderFolderBrowser(App& app) {
     // Animate in (slide from left) - only invalidate while progressing
     if (app.folderBrowserAnimation < 1.0f) {


### PR DESCRIPTION
User-reported: with one folder row highlighted, clicking a different row opened the highlighted one. The click handler trusted `hoveredFolderIndex`, which the renderer computes from the previous paint's mouse position, so it lagged fast move-and-click. Clicks now hit-test their own coordinates via a helper that shares the renderer's geometry.

Verified: a click with no preceding mousemove (hover = -1, would previously do nothing) now opens exactly the row under the cursor.