### PR TITLE
README: startup claim to <100 ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Most markdown apps ship an entire browser to render text. Tinta uses the GPU-acc
 
 |  | Tinta | Typora | Obsidian | VS Code |
 |---|---|---|---|---|
-| Startup | **~200 ms** | ~1.5 s | ~3 s | ~2 s |
+| Startup | **<100 ms** | ~1.5 s | ~3 s | ~2 s |
 | Install size | **~1.4 MB** | ~90 MB | ~250 MB | ~350 MB |
 | Runtime | **Native Direct2D** | Electron | Electron | Electron |
 


### PR DESCRIPTION
Comparison table startup figure updated from ~200 ms to **<100 ms** - interleaved app-reported measurements on the current build come in at 43-45 ms. The tinta.cc meta descriptions and stat chips carry the same updated claim.