### PR TITLE
README: lead installs with the Microsoft Store and winget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,9 +50,9 @@ jobs:
             A fast, lightweight Markdown and Mermaid reader for Windows.
 
             ### Installation
-            1. Download `tinta.exe` below
-            2. Run it (you may need to click "More info" → "Run anyway" on SmartScreen)
-            3. Optionally run `tinta.exe /register` to register Markdown and Mermaid files
+            - Easiest: `winget install "Tinta Markdown Viewer" -s msstore` (Store-signed, no security prompts, auto-updates), or the [Microsoft Store page](https://apps.microsoft.com/detail/9MZ5MZ3L9RKF)
+            - Portable: download `tinta.exe` below and run it (SmartScreen may ask: "More info", then "Run anyway")
+            - Optionally run `tinta.exe /register` to register Markdown and Mermaid files
 
             ### What's included
             - Tabbed interface with drag, session restore, and a tab context menu

--- a/README.md
+++ b/README.md
@@ -4,8 +4,14 @@
   <p><em>Markdown, distilled.</em></p>
   <p>A fast, lightweight Markdown and Mermaid viewer for Windows</p>
 
+  <p>
+    <a href="https://apps.microsoft.com/detail/9MZ5MZ3L9RKF">
+      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" alt="Get Tinta from the Microsoft Store">
+    </a>
+  </p>
+
   <a href="https://github.com/oipoistar/tinta/releases/latest">
-    <img src="https://img.shields.io/github/v/release/oipoistar/tinta?label=Download&style=for-the-badge&color=1a1a2e" alt="Download">
+    <img src="https://img.shields.io/github/v/release/oipoistar/tinta?label=Portable&style=for-the-badge&color=1a1a2e" alt="Portable download">
   </a>
   <a href="https://tinta.cc">
     <img src="https://img.shields.io/badge/website-tinta.cc-8b4513?style=for-the-badge" alt="Website">
@@ -13,12 +19,6 @@
   <a href="LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-blue?style=for-the-badge" alt="MIT License">
   </a>
-
-  <p>
-    <a href="https://apps.microsoft.com/detail/9MZ5MZ3L9RKF">
-      <img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200" alt="Get Tinta from the Microsoft Store">
-    </a>
-  </p>
 </div>
 
 <br>
@@ -30,17 +30,19 @@ Tinta is a **fast, lightweight Markdown and Mermaid viewer for Windows**, built 
   <img src="https://tinta.cc/img/screenshots/midnight.png" width="49%" alt="Tinta markdown viewer on Windows — Midnight dark theme">
 </p>
 
-## Download
+## Install
 
-Grab [the latest release](https://github.com/oipoistar/tinta/releases/latest) — a single portable `tinta.exe`, no installation required. Run it and open a Markdown or Mermaid file.
-
-Or install from the [Microsoft Store](https://apps.microsoft.com/detail/9MZ5MZ3L9RKF) (automatic updates, Store-signed):
+The recommended way is the [Microsoft Store](https://apps.microsoft.com/detail/9MZ5MZ3L9RKF): the build is signed by the Store, trusted by Windows out of the box (no security prompts, works with Smart App Control), and updates automatically. The same signed build installs from the command line:
 
 ```pwsh
 winget install "Tinta Markdown Viewer" -s msstore
 ```
 
-Or install with [Scoop](https://scoop.sh):
+### Portable and other options
+
+Prefer a single file? Grab [the latest release](https://github.com/oipoistar/tinta/releases/latest): a portable `tinta.exe`, no installation required. Because a freshly released exe is not yet code-signed, Windows may show a SmartScreen prompt on first run ("More info", then "Run anyway") until the new version builds up download reputation.
+
+[Scoop](https://scoop.sh) users can install from the bucket:
 
 ```pwsh
 scoop bucket add tinta https://github.com/oipoistar/scoop-bucket


### PR DESCRIPTION
Refocuses installation guidance on the trusted channels:

- The Store badge moves to the top of the header; the release badge is relabeled to Portable
- Download becomes **Install**, opening with the Store-signed build (no security prompts, works with Smart App Control, auto-updates) and the winget command that installs the same build
- The portable exe and Scoop live under **Portable and other options**, with a factual note that a freshly released unsigned exe can prompt SmartScreen until its reputation builds
- The CI release-notes template mirrors the same ordering

Motivated by #119: every unsigned release restarts SmartScreen/Smart App Control reputation from zero, while the Store build is trusted immediately.