### PR TITLE
Detect plain-text Markdown paths and badge them live or broken

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -802,6 +802,10 @@ struct App {
     float layoutMaxWidth = 0.0f;
     size_t layoutTimeUs = 0;      // total layout time for the current cycle
 
+    // Plain-text .md reference existence per resolved path (#127); cleared
+    // with the layout so reload and file changes re-check the disk
+    std::unordered_map<std::string, bool> fileRefCache;
+
     // Scroll sync anchors: source byte offset → rendered Y position
     struct ScrollAnchor {
         size_t sourceOffset;
@@ -949,6 +953,7 @@ struct App {
         docTextLower.clear();
         headings.clear();
         headingSlugCounts.clear();
+        fileRefCache.clear();
     }
 
     void releaseOverlayFormats() {

--- a/include/inline_style.h
+++ b/include/inline_style.h
@@ -25,6 +25,7 @@ struct InlineStyle {
     bool bold = false;
     bool italic = false;
     bool fixedSize = false;  // ^sup^/~sub~ own their font size
+    int fileRefBadge = 0;    // local .md reference: 1 = live, 2 = broken (#127)
 };
 
 struct StyledRun {

--- a/src/export_docx.cpp
+++ b/src/export_docx.cpp
@@ -790,7 +790,12 @@ void walkInline(DocxCtx& ctx, const ElementPtr& elem, RunProps props,
         }
         case ElementType::Link: {
             bool wiki = elem->url.rfind("wiki:", 0) == 0;
-            if (wiki) {
+            if (elem->url.rfind("fileref:", 0) == 0) {
+                // Detected plain-text .md reference (#127): stays plain
+                for (const auto& child : elem->children) {
+                    walkInline(ctx, child, props, out);
+                }
+            } else if (wiki) {
                 RunProps wikiProps = props;
                 wikiProps.color = ctx.linkHex;
                 for (const auto& child : elem->children) {

--- a/src/export_html.cpp
+++ b/src/export_html.cpp
@@ -1255,7 +1255,12 @@ void walk(ExportCtx& ctx, const ElementPtr& elem) {
             break;
         case ElementType::Link: {
             bool wiki = elem->url.rfind("wiki:", 0) == 0;
-            if (wiki) {
+            bool fileRef = elem->url.rfind("fileref:", 0) == 0;
+            if (fileRef) {
+                // Detected plain-text .md reference (#127): it was plain
+                // text in the source, it stays plain text in the export
+                walkChildren(ctx, elem);
+            } else if (wiki) {
                 // Single-file export: wiki targets stay as styled text
                 ctx.out += "<span class=\"wikilink\">";
                 walkChildren(ctx, elem);

--- a/src/inline_style.cpp
+++ b/src/inline_style.cpp
@@ -1,5 +1,95 @@
 #include "inline_style.h"
 
+#include <cctype>
+#include <filesystem>
+
+namespace {
+
+// Local converters keep this file free of editor.cpp for the test target
+std::wstring refToWide(const std::string& str) {
+    if (str.empty()) return {};
+    int length = MultiByteToWideChar(CP_UTF8, 0, str.c_str(),
+                                     (int)str.size(), nullptr, 0);
+    std::wstring out(length, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, str.c_str(), (int)str.size(), &out[0],
+                        length);
+    return out;
+}
+
+std::string refToUtf8(const std::wstring& wide) {
+    if (wide.empty()) return {};
+    int length = WideCharToMultiByte(CP_UTF8, 0, wide.c_str(),
+                                     (int)wide.size(), nullptr, 0, nullptr,
+                                     nullptr);
+    std::string out(length, '\0');
+    WideCharToMultiByte(CP_UTF8, 0, wide.c_str(), (int)wide.size(), &out[0],
+                        length, nullptr, nullptr);
+    return out;
+}
+
+// %20 and friends, for [text](my%20notes.md) targets
+std::string percentDecode(const std::string& value) {
+    std::string out;
+    out.reserve(value.size());
+    for (size_t i = 0; i < value.size(); i++) {
+        if (value[i] == '%' && i + 2 < value.size() &&
+            std::isxdigit(static_cast<unsigned char>(value[i + 1])) &&
+            std::isxdigit(static_cast<unsigned char>(value[i + 2]))) {
+            out += static_cast<char>(
+                std::stoi(value.substr(i + 1, 2), nullptr, 16));
+            i += 2;
+        } else {
+            out += value[i];
+        }
+    }
+    return out;
+}
+
+// A real [text](target) whose target is a local markdown path gets the
+// same live/broken treatment as a plain-text reference
+bool isLocalMarkdownUrl(const std::string& url) {
+    if (url.empty() || url[0] == '#') return false;
+    if (url.find("://") != std::string::npos) return false;
+    if (url.rfind("//", 0) == 0 || url.rfind("\\\\", 0) == 0) return false;
+    for (size_t i = 0; i < url.size(); i++) {
+        if (url[i] == ':' &&
+            !(i == 1 && std::isalpha(static_cast<unsigned char>(url[0])))) {
+            return false;  // wiki:, mailto:, and other schemes
+        }
+    }
+    std::string lower = url;
+    for (char& c : lower) c = (char)std::tolower((unsigned char)c);
+    return lower.size() > 3 &&
+           (lower.rfind(".md") == lower.size() - 3 ||
+            (lower.size() > 4 && lower.rfind(".mmd") == lower.size() - 4) ||
+            (lower.size() > 9 &&
+             lower.rfind(".markdown") == lower.size() - 9));
+}
+
+// Resolves against the current file's folder and checks the disk, cached
+// per resolved path until the next full relayout
+bool resolveFileRef(App& app, const std::string& raw, std::string& absOut) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::path path(refToWide(percentDecode(raw)));
+    if (path.is_relative()) {
+        if (app.currentFile.empty()) {
+            absOut = raw;
+            return false;  // unsaved buffer: nothing to resolve against
+        }
+        path = fs::path(refToWide(app.currentFile)).parent_path() / path;
+    }
+    path = path.lexically_normal();
+    absOut = refToUtf8(path.wstring());
+    auto found = app.fileRefCache.find(absOut);
+    if (found != app.fileRefCache.end()) return found->second;
+    bool exists = fs::exists(path, ec) && !fs::is_directory(path, ec);
+    app.fileRefCache[absOut] = exists;
+    return exists;
+}
+
+}  // namespace
+
 IDWriteTextFormat* emphasisFormat(App& app, IDWriteTextFormat* base, bool bold, bool italic) {
     IDWriteTextFormat* fmt = nullptr;
     if (bold && italic) fmt = app.boldItalicFormat ? app.boldItalicFormat : app.boldFormat;
@@ -62,11 +152,31 @@ void flattenInline(App& app, const std::vector<ElementPtr>& elements,
                 if (elem->type == ElementType::Subscript) st.drawYOffset = lineHeight * 0.38f;
                 break;
 
-            case ElementType::Link:
+            case ElementType::Link: {
                 st.color = app.theme.link;
                 st.linkUrl = elem->url;
                 st.isLink = true;
+                std::string target;
+                if (elem->url.rfind("fileref:", 0) == 0) {
+                    target = elem->url.substr(8);
+                } else if (isLocalMarkdownUrl(elem->url)) {
+                    target = elem->url;
+                }
+                if (!target.empty()) {
+                    std::string resolved;
+                    if (resolveFileRef(app, target, resolved)) {
+                        st.fileRefBadge = 1;
+                        st.linkUrl = "fileref-ok:" + resolved;
+                    } else {
+                        // Broken reference: muted, badged, inert
+                        st.fileRefBadge = 2;
+                        st.linkUrl = "fileref-missing:" + resolved;
+                        st.color = app.theme.text;
+                        st.color.a *= 0.62f;
+                    }
+                }
                 break;
+            }
 
             default:
                 break;  // unknown wrapper: keep the style and descend

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -2338,6 +2338,9 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 // It was just a click on a link
                 if (app.hoveredLink.rfind("wiki:", 0) == 0) {
                     openWikiLink(app, app.hoveredLink.substr(5));
+                } else if (app.hoveredLink.rfind("fileref-ok:", 0) == 0) {
+                    // Live .md reference (#127): join as a tab
+                    tabOpenPath(app, hwnd, app.hoveredLink.substr(11), true);
                 } else {
                     handleLinkClick(app);
                 }
@@ -2349,7 +2352,11 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         InvalidateRect(hwnd, nullptr, FALSE);
     } else if (!app.hoveredLink.empty()) {
         // Click on link
-        handleLinkClick(app);
+        if (app.hoveredLink.rfind("fileref-ok:", 0) == 0) {
+            tabOpenPath(app, hwnd, app.hoveredLink.substr(11), true);
+        } else {
+            handleLinkClick(app);
+        }
     }
 
     app.mouseDown = false;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -580,6 +580,133 @@ static void splitWikiLinks(const ElementPtr& parent) {
     if (changed) parent->children = std::move(rebuilt);
 }
 
+// Plain-text references to local Markdown files ("docs/auth.md",
+// "./setup.md") become fileref: Link elements; layout resolves the target
+// against the current file's folder and badges it live or broken (#127).
+// Agent-written notes drop these in constantly without wrapping them as
+// links. Runs after the wiki pass, skipping code the same way.
+
+static bool isFileRefChar(char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) != 0 || c == '_' ||
+           c == '-' || c == '.' || c == '/' || c == '\\' || c == '~' ||
+           c == ':';
+}
+
+// The extension ends at `end` (exclusive): the next character must not
+// extend the file name (".mdx", "setup.md.bak" are different files; a
+// sentence-ending ".md." is fine)
+static bool fileRefBoundary(const std::string& text, size_t end) {
+    if (end >= text.size()) return true;
+    char next = text[end];
+    if (std::isalnum(static_cast<unsigned char>(next)) || next == '_' ||
+        next == '-') {
+        return false;
+    }
+    if (next == '.' && end + 1 < text.size() &&
+        std::isalnum(static_cast<unsigned char>(text[end + 1]))) {
+        return false;
+    }
+    return true;
+}
+
+// Token shape check: a plausible local path, not a URL, not UNC (a dead
+// server would stall the existence check), drive colon only as "C:"
+static bool isFileRefToken(const std::string& token, size_t extLength) {
+    if (token.size() <= extLength) return false;  // bare ".md"
+    if (token.find("://") != std::string::npos) return false;
+    if (token.rfind("//", 0) == 0 || token.rfind("\\\\", 0) == 0) {
+        return false;
+    }
+    char beforeExt = token[token.size() - extLength - 1];
+    if (beforeExt == '/' || beforeExt == '\\') return false;  // "docs/.md"
+    for (size_t i = 0; i < token.size(); i++) {
+        if (token[i] == ':' &&
+            !(i == 1 && std::isalpha(static_cast<unsigned char>(token[0])))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void splitFileRefs(const ElementPtr& parent) {
+    if (parent->type == ElementType::Code ||
+        parent->type == ElementType::CodeBlock ||
+        parent->type == ElementType::MermaidDiagram ||
+        parent->type == ElementType::Link) {
+        return;
+    }
+
+    static const char* kExtensions[] = {".markdown", ".mmd", ".md"};
+
+    std::vector<ElementPtr> rebuilt;
+    bool changed = false;
+    for (auto& child : parent->children) {
+        if (child->type != ElementType::Text) {
+            splitFileRefs(child);
+            rebuilt.push_back(child);
+            continue;
+        }
+
+        const std::string& text = child->text;
+        size_t cursor = 0;
+        bool any = false;
+        size_t scan = 0;
+        while (scan < text.size()) {
+            size_t dot = text.find('.', scan);
+            if (dot == std::string::npos) break;
+            size_t extLength = 0;
+            for (const char* extension : kExtensions) {
+                size_t length = strlen(extension);
+                if (dot + length <= text.size() &&
+                    _strnicmp(text.c_str() + dot, extension, length) == 0 &&
+                    fileRefBoundary(text, dot + length)) {
+                    extLength = length;
+                    break;
+                }
+            }
+            if (extLength == 0) {
+                scan = dot + 1;
+                continue;
+            }
+            size_t end = dot + extLength;
+            size_t start = dot;
+            while (start > 0 && isFileRefChar(text[start - 1])) start--;
+            // ':' and '-' cannot open a path
+            while (start < dot &&
+                   (text[start] == ':' || text[start] == '-')) {
+                start++;
+            }
+            std::string token = text.substr(start, end - start);
+            if (start < cursor || !isFileRefToken(token, extLength)) {
+                scan = end;
+                continue;
+            }
+            any = true;
+            if (start > cursor) {
+                rebuilt.push_back(makeTextElement(
+                    text.substr(cursor, start - cursor), parent.get()));
+            }
+            auto link = std::make_shared<Element>(ElementType::Link);
+            link->parent = parent.get();
+            link->url = "fileref:" + token;
+            link->children.push_back(makeTextElement(token, link.get()));
+            rebuilt.push_back(std::move(link));
+            cursor = end;
+            scan = end;
+        }
+        if (!any) {
+            rebuilt.push_back(child);
+            continue;
+        }
+        changed = true;
+        if (cursor < text.size()) {
+            rebuilt.push_back(
+                makeTextElement(text.substr(cursor), parent.get()));
+        }
+    }
+    if (changed) parent->children = std::move(rebuilt);
+}
+
 } // namespace
 
 MarkdownParser::MarkdownParser() = default;
@@ -633,6 +760,7 @@ ParseResult MarkdownParser::parse(const std::string& markdown) {
     ctx.flushText();
     splitInlineExtensions(ctx.root);
     splitWikiLinks(ctx.root);
+    splitFileRefs(ctx.root);
     detectGitHubAlerts(ctx.root);
     result.root = ctx.root;
     result.success = true;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -385,6 +385,8 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
     auto addLinkSegment = [&](float lineStartX, float lineEndX, float lineY,
                               const std::string& linkUrl, D2D1_COLOR_F color) {
         if (lineEndX <= lineStartX) return;
+        // Broken .md references stay inert: no underline, no click (#127)
+        if (linkUrl.rfind("fileref-missing:", 0) == 0) return;
         float underlineY = lineY + lineHeight - 2;
         app.layoutLines.push_back({D2D1::Point2F(lineStartX, underlineY),
                                    D2D1::Point2F(lineEndX, underlineY),
@@ -403,7 +405,53 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
     std::vector<StyledRun> runs;
     flattenInline(app, elements, rootStyle, lineHeight, runs);
 
-    for (const auto& run : runs) {
+    // Live/broken badge after the last run of a .md reference (#127): a
+    // small arrow that opens the file in a tab, or a cross for a target
+    // the disk does not have
+    auto badgeDue = [&](size_t index) -> int {
+        const InlineStyle& style = runs[index].style;
+        if (!style.fileRefBadge) return 0;
+        if (index + 1 < runs.size() &&
+            runs[index + 1].style.fileRefBadge == style.fileRefBadge &&
+            runs[index + 1].style.linkUrl == style.linkUrl) {
+            return 0;
+        }
+        return style.fileRefBadge;
+    };
+    auto emitFileRefBadge = [&](int badge, const std::string& linkUrl) {
+        std::wstring glyph = badge == 1 ? L"\u2197" : L"\u2715";
+        D2D1_COLOR_F badgeColor =
+            badge == 1 ? app.theme.accent
+            : app.theme.isDark ? D2D1::ColorF(0.95f, 0.45f, 0.42f)
+                               : D2D1::ColorF(0.78f, 0.20f, 0.16f);
+        IDWriteTextFormat* badgeFormat =
+            app.supSubFormat ? app.supSubFormat : baseFormat;
+        LayoutInfo info =
+            createLayout(app, glyph, badgeFormat, lineHeight, app.bodyTypography);
+        if (x + info.width > maxX && x > startX) {
+            x = startX;
+            y += lineHeight;
+        }
+        D2D1_RECT_F bounds = D2D1::RectF(x, y, x + info.width, y + lineHeight);
+        addTextRun(app, std::move(info), D2D1::Point2F(x + 1, y), bounds,
+                   badgeColor, app.docText.size(), 0, false);
+        if (badge == 1) {
+            App::LinkRect lr;
+            lr.bounds = bounds;
+            lr.url = linkUrl;
+            app.linkRects.push_back(lr);
+        }
+        x += info.width + 2;
+    };
+
+    for (size_t runIndex = 0; runIndex < runs.size(); runIndex++) {
+        if (runIndex > 0) {
+            int badge = badgeDue(runIndex - 1);
+            if (badge) {
+                emitFileRefBadge(badge, runs[runIndex - 1].style.linkUrl);
+            }
+        }
+        const auto& run = runs[runIndex];
         const ElementPtr& elem = run.elem;
         IDWriteTextFormat* format = run.style.format;
         D2D1_COLOR_F color = run.style.color;
@@ -804,6 +852,10 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
         if (isLink && lastWordEndX > linkLineStartX) {
             addLinkSegment(linkLineStartX, lastWordEndX, linkLineY, linkUrl, color);
         }
+    }
+    if (!runs.empty()) {
+        int badge = badgeDue(runs.size() - 1);
+        if (badge) emitFileRefBadge(badge, runs.back().style.linkUrl);
     }
 
     y += lineHeight;

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -153,6 +153,46 @@ int main() {
           markdown.root->children[0]->type == qmd::ElementType::Heading,
           ".md content keeps Markdown parsing");
 
+    // Plain-text .md references become fileref: links (#127)
+    {
+        auto refs = parseDocument(parser,
+            "See docs/auth.md and ./setup.md plus C:\\notes\\a.md here.\n"
+            "Not these: `code.md` or https://x.com/y.md or file.mdx or "
+            "bare .md or v2.md.bak\n"
+            "Sentence ends with index.md.\n",
+            "notes.md");
+        check(refs.success, "fileref test parses");
+        std::vector<std::string> found;
+        std::function<void(const qmd::ElementPtr&)> walk =
+            [&](const qmd::ElementPtr& node) {
+            if (node->type == qmd::ElementType::Link &&
+                node->url.rfind("fileref:", 0) == 0) {
+                found.push_back(node->url.substr(8));
+            }
+            if (node->type != qmd::ElementType::Code &&
+                node->type != qmd::ElementType::CodeBlock) {
+                for (const auto& child : node->children) walk(child);
+            }
+        };
+        if (refs.root) walk(refs.root);
+        check(found.size() == 4, "exactly the four real references detected");
+        auto has = [&](const char* token) {
+            for (const auto& item : found) {
+                if (item == token) return true;
+            }
+            return false;
+        };
+        check(has("docs/auth.md"), "bare relative path detected");
+        check(has("./setup.md"), "dot-relative path detected");
+        check(has("C:\\notes\\a.md"), "absolute path detected");
+        check(has("index.md"), "sentence-ending path detected sans period");
+        check(!has("code.md"), "code spans are left alone");
+        check(!has("y.md"), "URLs are left alone");
+        check(!has("file.mdx"), "longer extensions are not references");
+        check(!has(".md"), "a bare extension is not a reference");
+        check(!has("v2.md"), "dotted archive names are not references");
+    }
+
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";
         return 1;


### PR DESCRIPTION
Closes #127.

Agent-written notes reference other files as bare text (`docs/auth.md`, `./setup.md`) instead of real links. Tinta now notices those, checks the disk, and badges each one:

- **Live**: link styling plus a small arrow badge; clicking the path or the badge opens the file as a tab in the current window
- **Broken**: muted text plus a cross badge, no underline, no click

## How
- A parse pass (mirroring the wiki-link splitter) wraps path-shaped tokens ending in `.md`/`.markdown`/`.mmd` as `fileref:` links. It skips code spans, code blocks, existing links, URLs, UNC paths (a dead server would stall the check), longer extensions (`.mdx`, `.md.bak`), and bare extensions.
- Layout resolves each target against the current file's folder (absolute paths as-is, `%20` decoded) and stats it, cached per relayout so reloads and file changes re-check the disk. Local stats are microseconds, so first paint is unaffected.
- Real `[text](target.md)` links to local files get the same live/broken treatment; clicking a live one now opens a tab instead of shelling out.
- HTML and DOCX export render detected references as the plain text they were.

Covered by new document_tests cases (detection, boundaries, code/URL exclusions) and verified interactively: live refs open as tabs, broken refs have no click surface at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)