### PR TITLE
Obsidian-style .md references and mouse back/forward navigation

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -546,6 +546,16 @@ struct App {
     // contentHeight, so applying immediately would clamp to a partial height)
     float pendingScrollRestore = -1.0f;
 
+    // Mouse back/forward navigation: link jumps push where they came from;
+    // XBUTTON1/Alt+Left walks back, XBUTTON2/Alt+Right forward, each entry
+    // restoring its document and scroll position
+    struct NavEntry {
+        std::string path;
+        float scrollY = 0.0f;
+    };
+    std::vector<NavEntry> navBack;
+    std::vector<NavEntry> navForward;
+
     // Print preview overlay. While it is open the document is held in print
     // layout — width, theme, zoom and scroll are hijacked by enterPrintLayout —
     // and the real screen state lives in printSaved. Screen dimensions and UI

--- a/include/inline_style.h
+++ b/include/inline_style.h
@@ -25,7 +25,6 @@ struct InlineStyle {
     bool bold = false;
     bool italic = false;
     bool fixedSize = false;  // ^sup^/~sub~ own their font size
-    int fileRefBadge = 0;    // local .md reference: 1 = live, 2 = broken (#127)
 };
 
 struct StyledRun {

--- a/include/input.h
+++ b/include/input.h
@@ -16,6 +16,9 @@ void handleDropFiles(App& app, HWND hwnd, WPARAM wParam);
 // Load a document into the viewer, saving the outgoing reading position
 // and restoring the incoming one (shared with tabs.cpp)
 bool openDocumentInViewer(App& app, const std::wstring& fullPath);
+// Mouse XBUTTON / Alt+arrow navigation across link jumps (viewer)
+void navigateBack(App& app, HWND hwnd);
+void navigateForward(App& app, HWND hwnd);
 // First clipboard line as text (shared by the search and path inputs)
 std::wstring clipboardLine(HWND hwnd);
 void handleFileWatchTimer(App& app, HWND hwnd);

--- a/src/inline_style.cpp
+++ b/src/inline_style.cpp
@@ -165,14 +165,11 @@ void flattenInline(App& app, const std::vector<ElementPtr>& elements,
                 if (!target.empty()) {
                     std::string resolved;
                     if (resolveFileRef(app, target, resolved)) {
-                        st.fileRefBadge = 1;
                         st.linkUrl = "fileref-ok:" + resolved;
                     } else {
-                        // Broken reference: muted, badged, inert
-                        st.fileRefBadge = 2;
+                        // Missing target: a ghost of the link color, inert
                         st.linkUrl = "fileref-missing:" + resolved;
-                        st.color = app.theme.text;
-                        st.color.a *= 0.62f;
+                        st.color.a *= 0.45f;
                     }
                 }
                 break;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1786,8 +1786,8 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 // Resolves an Obsidian [[wiki link]] target against the current file's
 // folder and opens it: the name as written, then with .md / .markdown
 // appended, then a case-insensitive scan of the directory listing.
-static void openWikiLink(App& app, const std::string& target) {
-    if (app.editMode || app.currentFile.empty()) return;
+static bool openWikiLink(App& app, const std::string& target) {
+    if (app.editMode || app.currentFile.empty()) return false;
     namespace fs = std::filesystem;
     std::error_code ec;
     std::wstring wideTarget = toWide(target);
@@ -1797,9 +1797,9 @@ static void openWikiLink(App& app, const std::string& target) {
         return fs::exists(p, ec) && !fs::is_directory(p, ec) &&
                openDocumentInViewer(app, p.wstring());
     };
-    if (tryOpen(dir / wideTarget)) return;
-    if (tryOpen(dir / (wideTarget + L".md"))) return;
-    if (tryOpen(dir / (wideTarget + L".markdown"))) return;
+    if (tryOpen(dir / wideTarget)) return true;
+    if (tryOpen(dir / (wideTarget + L".md"))) return true;
+    if (tryOpen(dir / (wideTarget + L".markdown"))) return true;
 
     auto lower = [](std::wstring s) {
         for (auto& c : s) c = (wchar_t)std::towlower(c);
@@ -1811,11 +1811,80 @@ static void openWikiLink(App& app, const std::string& target) {
         std::wstring stem = lower(entry.path().stem().wstring());
         std::wstring name = lower(entry.path().filename().wstring());
         if (stem == want || name == want) {
-            if (openDocumentInViewer(app, entry.path().wstring())) return;
+            if (openDocumentInViewer(app, entry.path().wstring())) return true;
         }
     }
     // Target doesn't exist: leave the document as-is (a viewer doesn't
     // create notes the way Obsidian would)
+    return false;
+}
+
+// Link jumps remember where they came from so mouse-back (XBUTTON1) can
+// return to the same document and position
+static void navRecordJump(App& app, const std::string& fromPath,
+                          float fromScroll) {
+    if (fromPath.empty()) return;
+    app.navBack.push_back({fromPath, fromScroll});
+    if (app.navBack.size() > 64) app.navBack.erase(app.navBack.begin());
+    app.navForward.clear();
+}
+
+// A live .md reference joins the window as a tab (#127)
+static void openFileRefTarget(App& app, HWND hwnd, const std::string& path) {
+    if (_stricmp(app.currentFile.c_str(), path.c_str()) != 0) {
+        navRecordJump(app, app.currentFile, app.scrollY);
+    }
+    tabOpenPath(app, hwnd, path, true);
+}
+
+// Lands on entry.path with the least motion: the same document is scroll
+// only, an open tab is activated, anything else replaces the current
+// document; the scroll position rides the #77 deferred restore
+static bool navOpenEntry(App& app, HWND hwnd, const App::NavEntry& entry) {
+    if (_stricmp(app.currentFile.c_str(), entry.path.c_str()) != 0) {
+        bool found = false;
+        for (size_t i = 0; i < app.tabs.size(); i++) {
+            const std::string& existing =
+                (int)i == app.activeTab ? app.currentFile : app.tabs[i].path;
+            if (_stricmp(existing.c_str(), entry.path.c_str()) == 0) {
+                tabActivate(app, hwnd, (int)i);
+                found = true;
+                break;
+            }
+        }
+        if (!found && !openDocumentInViewer(app, toWide(entry.path))) {
+            return false;  // deleted since the jump: caller tries older entries
+        }
+    }
+    app.pendingScrollRestore = entry.scrollY;
+    InvalidateRect(hwnd, nullptr, FALSE);
+    return true;
+}
+
+void navigateBack(App& app, HWND hwnd) {
+    if (app.editMode) return;
+    while (!app.navBack.empty()) {
+        App::NavEntry entry = app.navBack.back();
+        app.navBack.pop_back();
+        App::NavEntry here{app.currentFile, app.scrollY};
+        if (navOpenEntry(app, hwnd, entry)) {
+            if (!here.path.empty()) app.navForward.push_back(here);
+            return;
+        }
+    }
+}
+
+void navigateForward(App& app, HWND hwnd) {
+    if (app.editMode) return;
+    while (!app.navForward.empty()) {
+        App::NavEntry entry = app.navForward.back();
+        app.navForward.pop_back();
+        App::NavEntry here{app.currentFile, app.scrollY};
+        if (navOpenEntry(app, hwnd, entry)) {
+            if (!here.path.empty()) app.navBack.push_back(here);
+            return;
+        }
+    }
 }
 
 // Task checkbox under the mouse, or nullptr (viewer mode only)
@@ -2337,10 +2406,14 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             } else if (!app.hoveredLink.empty()) {
                 // It was just a click on a link
                 if (app.hoveredLink.rfind("wiki:", 0) == 0) {
-                    openWikiLink(app, app.hoveredLink.substr(5));
+                    std::string fromPath = app.currentFile;
+                    float fromScroll = app.scrollY;
+                    if (openWikiLink(app, app.hoveredLink.substr(5))) {
+                        navRecordJump(app, fromPath, fromScroll);
+                    }
                 } else if (app.hoveredLink.rfind("fileref-ok:", 0) == 0) {
                     // Live .md reference (#127): join as a tab
-                    tabOpenPath(app, hwnd, app.hoveredLink.substr(11), true);
+                    openFileRefTarget(app, hwnd, app.hoveredLink.substr(11));
                 } else {
                     handleLinkClick(app);
                 }
@@ -2353,7 +2426,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     } else if (!app.hoveredLink.empty()) {
         // Click on link
         if (app.hoveredLink.rfind("fileref-ok:", 0) == 0) {
-            tabOpenPath(app, hwnd, app.hoveredLink.substr(11), true);
+            openFileRefTarget(app, hwnd, app.hoveredLink.substr(11));
         } else {
             handleLinkClick(app);
         }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1190,6 +1190,27 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (app) handleKeyDown(*app, hwnd, wParam);
             return 0;
 
+        case WM_XBUTTONUP:
+            // Mouse side buttons walk back/forward across link jumps
+            if (app) {
+                if (GET_XBUTTON_WPARAM(wParam) == XBUTTON1) {
+                    navigateBack(*app, hwnd);
+                } else if (GET_XBUTTON_WPARAM(wParam) == XBUTTON2) {
+                    navigateForward(*app, hwnd);
+                }
+            }
+            return TRUE;
+
+        case WM_SYSKEYDOWN:
+            // Alt+Left / Alt+Right mirror the mouse side buttons
+            if (app && (lParam & (1 << 29)) &&
+                (wParam == VK_LEFT || wParam == VK_RIGHT)) {
+                if (wParam == VK_LEFT) navigateBack(*app, hwnd);
+                else navigateForward(*app, hwnd);
+                return 0;
+            }
+            break;
+
         case WM_CHAR:
             if (app) handleCharInput(*app, hwnd, wParam);
             return 0;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -385,12 +385,28 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
     auto addLinkSegment = [&](float lineStartX, float lineEndX, float lineY,
                               const std::string& linkUrl, D2D1_COLOR_F color) {
         if (lineEndX <= lineStartX) return;
-        // Broken .md references stay inert: no underline, no click (#127)
-        if (linkUrl.rfind("fileref-missing:", 0) == 0) return;
+        bool refLive = linkUrl.rfind("fileref-ok:", 0) == 0;
+        bool refMissing = linkUrl.rfind("fileref-missing:", 0) == 0;
         float underlineY = lineY + lineHeight - 2;
-        app.layoutLines.push_back({D2D1::Point2F(lineStartX, underlineY),
-                                   D2D1::Point2F(lineEndX, underlineY),
-                                   color, 1.0f});
+        if (refLive || refMissing) {
+            // .md references underline dashed; a missing target keeps a
+            // faint ghost of the same treatment and no click surface (#127)
+            D2D1_COLOR_F dashColor = color;
+            dashColor.a *= 0.55f;
+            float dash = lineHeight * 0.16f;
+            float gap = lineHeight * 0.12f;
+            for (float sx = lineStartX; sx < lineEndX; sx += dash + gap) {
+                float ex = std::min(sx + dash, lineEndX);
+                app.layoutLines.push_back({D2D1::Point2F(sx, underlineY),
+                                           D2D1::Point2F(ex, underlineY),
+                                           dashColor, 1.0f});
+            }
+        } else {
+            app.layoutLines.push_back({D2D1::Point2F(lineStartX, underlineY),
+                                       D2D1::Point2F(lineEndX, underlineY),
+                                       color, 1.0f});
+        }
+        if (refMissing) return;
         App::LinkRect lr;
         lr.bounds = D2D1::RectF(lineStartX, lineY, lineEndX, lineY + lineHeight);
         lr.url = linkUrl;
@@ -405,52 +421,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
     std::vector<StyledRun> runs;
     flattenInline(app, elements, rootStyle, lineHeight, runs);
 
-    // Live/broken badge after the last run of a .md reference (#127): a
-    // small arrow that opens the file in a tab, or a cross for a target
-    // the disk does not have
-    auto badgeDue = [&](size_t index) -> int {
-        const InlineStyle& style = runs[index].style;
-        if (!style.fileRefBadge) return 0;
-        if (index + 1 < runs.size() &&
-            runs[index + 1].style.fileRefBadge == style.fileRefBadge &&
-            runs[index + 1].style.linkUrl == style.linkUrl) {
-            return 0;
-        }
-        return style.fileRefBadge;
-    };
-    auto emitFileRefBadge = [&](int badge, const std::string& linkUrl) {
-        std::wstring glyph = badge == 1 ? L"\u2197" : L"\u2715";
-        D2D1_COLOR_F badgeColor =
-            badge == 1 ? app.theme.accent
-            : app.theme.isDark ? D2D1::ColorF(0.95f, 0.45f, 0.42f)
-                               : D2D1::ColorF(0.78f, 0.20f, 0.16f);
-        IDWriteTextFormat* badgeFormat =
-            app.supSubFormat ? app.supSubFormat : baseFormat;
-        LayoutInfo info =
-            createLayout(app, glyph, badgeFormat, lineHeight, app.bodyTypography);
-        if (x + info.width > maxX && x > startX) {
-            x = startX;
-            y += lineHeight;
-        }
-        D2D1_RECT_F bounds = D2D1::RectF(x, y, x + info.width, y + lineHeight);
-        addTextRun(app, std::move(info), D2D1::Point2F(x + 1, y), bounds,
-                   badgeColor, app.docText.size(), 0, false);
-        if (badge == 1) {
-            App::LinkRect lr;
-            lr.bounds = bounds;
-            lr.url = linkUrl;
-            app.linkRects.push_back(lr);
-        }
-        x += info.width + 2;
-    };
-
     for (size_t runIndex = 0; runIndex < runs.size(); runIndex++) {
-        if (runIndex > 0) {
-            int badge = badgeDue(runIndex - 1);
-            if (badge) {
-                emitFileRefBadge(badge, runs[runIndex - 1].style.linkUrl);
-            }
-        }
         const auto& run = runs[runIndex];
         const ElementPtr& elem = run.elem;
         IDWriteTextFormat* format = run.style.format;
@@ -852,10 +823,6 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
         if (isLink && lastWordEndX > linkLineStartX) {
             addLinkSegment(linkLineStartX, lastWordEndX, linkLineY, linkUrl, color);
         }
-    }
-    if (!runs.empty()) {
-        int badge = badgeDue(runs.size() - 1);
-        if (badge) emitFileRefBadge(badge, runs.back().style.linkUrl);
     }
 
     y += lineHeight;


### PR DESCRIPTION
Follow-up to #128 after feedback on #127.

## Quieter reference styling
The arrow/cross badges are gone. Plain-text `.md` references now use the Obsidian visual language:

- **Live**: link color with a dashed underline; click opens the file as a tab, cursor is the link hand
- **Missing**: the same hue faded to a ghost with a faint dashed underline, inert (no click surface, text cursor)

No icons, no red, nothing shouting; unresolved references read as ghost links.

## Mouse back/forward
Link jumps (plain references and wiki links) push a navigation entry, so:

- **XBUTTON1** (mouse back) or **Alt+Left** returns to the prior document at the exact scroll position
- **XBUTTON2** (mouse forward) or **Alt+Right** walks forward again
- Back activates the tab if it is still open, and reopens the document in place when its tab was closed; the scroll restore rides the #77 deferred mechanism so chunked layout cannot clamp it early

Verified interactively: dashed/ghost rendering in both states, hand cursor on every clickable link (plain refs, `[text](x.md)` links, URLs), back/forward round-trips with pixel-exact scroll restore, and reopen-after-close. All test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)