### PR TITLE
QoL batch: pin on top, search marks on the scrollbar, table copy as TSV

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -395,6 +395,9 @@ struct App {
         bool hasClose = false;
     };
     std::vector<TabHit> tabHits;       // refreshed by renderTabStrip
+    // Pin button in the title bar: keeps this window above every other
+    // (per-window, not persisted)
+    bool alwaysOnTop = false;
     std::vector<std::pair<D2D1_RECT_F, int>> tabSwitcherHits;
     // Closing a dirty tab routes through the unsaved-changes dialog; the
     // close completes from confirmExitAction once the user decides
@@ -677,6 +680,14 @@ struct App {
     };
     std::vector<CodeBlockInfo> codeBlocks;
     int hoveredCodeBlock = -1;
+
+    // Tables - tracked for the copy-as-TSV button
+    struct TableInfo {
+        D2D1_RECT_F bounds{};  // document coordinates
+        std::wstring tsv;      // cells joined by tabs, rows by newlines
+    };
+    std::vector<TableInfo> tableRects;
+    int hoveredTable = -1;
 
     // Text bounds - tracked for cursor changes and selection (document coordinates)
     struct TextRect {
@@ -993,6 +1004,7 @@ struct App {
         taskRects.clear();
         linkRects.clear();
         codeBlocks.clear();
+        tableRects.clear();
         textRects.clear();
         lineBuckets.clear();
         docText.clear();

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -190,6 +190,8 @@ const Entry kEntries[] = {
     { "annot.note_hint", L"Note (markdown)", L"\u6279\u6CE8\uFF08Markdown\uFF09", L"\u30E1\u30E2\uFF08Markdown\uFF09", L"\uBA54\uBAA8 (Markdown)" },
     { "annot.nolocate", L"Couldn't locate selection", L"\u65E0\u6CD5\u5B9A\u4F4D\u6240\u9009\u5185\u5BB9", L"\u9078\u629E\u7BC4\u56F2\u3092\u7279\u5B9A\u3067\u304D\u307E\u305B\u3093", L"\uC120\uD0DD \uC601\uC5ED\uC744 \uCC3E\uC744 \uC218 \uC5C6\uC74C" },
     { "toast.agent_copied", L"Copied for agent", L"\u5DF2\u590D\u5236\u7ED9\u667A\u80FD\u4F53", L"\u30A8\u30FC\u30B8\u30A7\u30F3\u30C8\u7528\u306B\u30B3\u30D4\u30FC", L"\uC5D0\uC774\uC804\uD2B8\uC6A9\uC73C\uB85C \uBCF5\uC0AC\uB428" },
+    { "table.copy", L"Copy TSV", L"\u590D\u5236TSV", L"TSV\u3092\u30B3\u30D4\u30FC", L"TSV \uBCF5\uC0AC" },
+    { "table.copied", L"Table copied", L"\u5DF2\u590D\u5236\u8868\u683C", L"\u8868\u3092\u30B3\u30D4\u30FC\u3057\u307E\u3057\u305F", L"\uD45C \uBCF5\uC0AC\uB428" },
     { "ctx.new", L"New File", L"\u65B0\u5EFA\u6587\u4EF6", L"\u65B0\u898F\u30D5\u30A1\u30A4\u30EB", L"\uC0C8 \uD30C\uC77C" },
     { "ctx.print", L"Print / PDF", L"\u6253\u5370 / PDF", L"\u5370\u5237 / PDF", L"\uCD9C\uB825 / PDF" },
     { "ctx.edit", L"Edit", L"\u7F16\u8F91", L"\u7DE8\u96C6", L"\uD3B8\uC9D1" },

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -31,6 +31,7 @@ static HCURSOR cursorIBeam = LoadCursor(nullptr, IDC_IBEAM);
 static HCURSOR cursorSizeWE = LoadCursor(nullptr, IDC_SIZEWE);
 
 static const App::TaskRect* taskRectAt(const App& app);
+static bool tableCopyButtonAt(const App& app, int mouseX, int mouseY);
 
 static bool cursorPointInRect(float x, float y, const D2D1_RECT_F& rect) {
     return x >= rect.left && x <= rect.right &&
@@ -1251,6 +1252,18 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         }
     }
 
+    // Table hover (shows the copy-as-TSV button)
+    int prevHoveredTable = app.hoveredTable;
+    app.hoveredTable = -1;
+    for (int i = 0; i < (int)app.tableRects.size(); i++) {
+        const auto& tb = app.tableRects[i];
+        if (docX >= tb.bounds.left && docX <= tb.bounds.right &&
+            docY >= tb.bounds.top && docY <= tb.bounds.bottom) {
+            app.hoveredTable = i;
+            break;
+        }
+    }
+
     // Annotation hover: rail squares first, then tinted text (#126)
     int prevHoveredAnnotation = app.hoveredAnnotation;
     app.hoveredAnnotation = -1;
@@ -1314,6 +1327,9 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         } else {
             SetCursor(cursorArrow);
         }
+    } else if (app.hoveredTable >= 0 &&
+               tableCopyButtonAt(app, app.mouseX, app.mouseY)) {
+        SetCursor(cursorHand);
     } else if (!app.hoveredLink.empty()) {
         SetCursor(cursorHand);
     } else if (app.overText) {
@@ -1326,6 +1342,7 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         wasHHovered != app.hScrollbarHovered ||
         prevHoveredLink != app.hoveredLink ||
         prevHoveredCodeBlock != app.hoveredCodeBlock ||
+        prevHoveredTable != app.hoveredTable ||
         prevHoveredAnnotation != app.hoveredAnnotation) {
         InvalidateRect(hwnd, nullptr, FALSE);
     }
@@ -2052,6 +2069,27 @@ static bool codeCopyButtonAt(const App& app, int mouseX, int mouseY) {
            docY >= btnY && docY <= btnY + btnH;
 }
 
+// True when (mouseX, mouseY) is on the hovered table's copy-as-TSV button
+static bool tableCopyButtonAt(const App& app, int mouseX, int mouseY) {
+    if (app.hoveredTable < 0 ||
+        app.hoveredTable >= (int)app.tableRects.size()) {
+        return false;
+    }
+    const auto& tb = app.tableRects[app.hoveredTable];
+    float previewOffsetX = documentViewportX(app);
+    float docX = (mouseX - previewOffsetX) + app.scrollX;
+    float docY = mouseY + app.scrollY;
+    float btnW = dpi(app, 88.0f);
+    float btnH = dpi(app, 26.0f);
+    float btnPad = 8.0f * app.contentScale * app.zoomFactor;
+    float rightEdge =
+        std::min(tb.bounds.right, app.scrollX + documentViewportWidth(app));
+    float btnX = rightEdge - btnW - btnPad;
+    float btnY = tb.bounds.top + btnPad;
+    return docX >= btnX && docX <= btnX + btnW &&
+           docY >= btnY && docY <= btnY + btnH;
+}
+
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     // A tab drag ends on release (its press already consumed the click)
     if (app.tabDragIndex >= 0) {
@@ -2471,6 +2509,17 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         app.copiedNotificationStart = std::chrono::steady_clock::now();
         startNotificationTimer(app);
         app.hoveredCodeBlock = -1;
+        app.selecting = false;
+        InvalidateRect(hwnd, nullptr, FALSE);
+    } else if (tableCopyButtonAt(app, app.mouseX, app.mouseY)) {
+        // Table copy button: cells joined by tabs paste into a
+        // spreadsheet as a grid
+        copyToClipboard(hwnd, app.tableRects[app.hoveredTable].tsv);
+        app.copiedNotificationKey = "table.copied";
+        app.showCopiedNotification = true;
+        app.copiedNotificationStart = std::chrono::steady_clock::now();
+        startNotificationTimer(app);
+        app.hoveredTable = -1;
         app.selecting = false;
         InvalidateRect(hwnd, nullptr, FALSE);
     } else if (app.selecting) {

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -604,6 +604,52 @@ render_document:
         }
     }
 
+    // Table copy-as-TSV button on hover (same pattern as code blocks;
+    // wide tables clamp the button into the visible viewport)
+    if (app.hoveredTable >= 0 && app.hoveredTable < (int)app.tableRects.size()) {
+        const auto& tb = app.tableRects[app.hoveredTable];
+        if (tb.bounds.bottom >= viewportTop - cullMargin &&
+            tb.bounds.top <= viewportBottom + cullMargin) {
+            float btnW = dpi(app, 88.0f);
+            float btnH = dpi(app, 26.0f);
+            float btnPad = 8.0f * app.contentScale * app.zoomFactor;
+            float rightEdge = std::min(
+                tb.bounds.right, app.scrollX + documentViewportWidth(app));
+            float btnX = rightEdge - btnW - btnPad - app.scrollX;
+            float btnY = tb.bounds.top + btnPad - app.scrollY;
+
+            app.brush->SetColor(D2D1::ColorF(
+                app.theme.isDark ? 0.3f : 0.85f,
+                app.theme.isDark ? 0.3f : 0.85f,
+                app.theme.isDark ? 0.3f : 0.85f,
+                0.9f));
+            app.renderTarget->FillRoundedRectangle(
+                D2D1::RoundedRect(
+                    D2D1::RectF(btnX, btnY, btnX + btnW, btnY + btnH), 4, 4),
+                app.brush);
+
+            app.brush->SetColor(D2D1::ColorF(
+                app.theme.isDark ? 0.9f : 0.15f,
+                app.theme.isDark ? 0.9f : 0.15f,
+                app.theme.isDark ? 0.9f : 0.15f,
+                1.0f));
+            IDWriteTextLayout* btnLayout = nullptr;
+            const wchar_t* copyLabel = tr(app, "table.copy");
+            app.dwriteFactory->CreateTextLayout(
+                copyLabel, (UINT32)wcslen(copyLabel), app.codeFormat, btnW,
+                btnH, &btnLayout);
+            if (btnLayout) {
+                btnLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+                btnLayout->SetParagraphAlignment(
+                    DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+                app.renderTarget->DrawTextLayout(
+                    D2D1::Point2F(btnX, btnY), btnLayout, app.brush);
+                btnLayout->Release();
+            }
+            app.drawCalls++;
+        }
+    }
+
     // Determine scrollbar visibility
     bool needsVScroll = app.verticalScrollbarVisible;
     bool needsHScroll = app.contentWidth > documentWidth;
@@ -633,6 +679,52 @@ render_document:
                                           documentWidth - dpi(app, 4.0f), sbY + sbHeight), 3, 3),
             app.brush);
         app.drawCalls++;
+
+        // Find-match ticks along the track: the document's match silhouette
+        // at a glance (overview-ruler pattern). Dense results thin out so a
+        // one-letter query cannot flood the frame with fills.
+        if (app.showSearch && !app.searchQuery.empty() &&
+            !app.searchMatches.empty() && !app.editMode) {
+            size_t step =
+                std::max<size_t>(1, app.searchMatches.size() / 400);
+            float tickLeft = documentWidth - dpi(app, 12.0f);
+            float tickRight = documentWidth - dpi(app, 2.0f);
+            auto tickY = [&](const App::SearchMatch& m, float& ty) {
+                float docY;
+                if (m.highlightRect.bottom > m.highlightRect.top) {
+                    docY = m.highlightRect.top;
+                } else if (!app.docText.empty()) {
+                    docY = (float)m.startPos / (float)app.docText.size() *
+                           scrollExtent;
+                } else {
+                    return false;
+                }
+                ty = trackTop + docY / scrollExtent * trackHeight;
+                ty = std::min(ty, trackTop + trackHeight - dpi(app, 2.0f));
+                return true;
+            };
+            app.brush->SetColor(D2D1::ColorF(1.0f, 0.82f, 0.0f, 0.55f));
+            for (size_t i = 0; i < app.searchMatches.size(); i += step) {
+                float ty;
+                if (!tickY(app.searchMatches[i], ty)) continue;
+                app.renderTarget->FillRectangle(
+                    D2D1::RectF(tickLeft, ty, tickRight, ty + dpi(app, 2.0f)),
+                    app.brush);
+            }
+            // The current match always gets its tick, stepping or not
+            if (app.searchCurrentIndex >= 0 &&
+                app.searchCurrentIndex < (int)app.searchMatches.size()) {
+                float ty;
+                if (tickY(app.searchMatches[app.searchCurrentIndex], ty)) {
+                    app.brush->SetColor(D2D1::ColorF(1.0f, 0.6f, 0.0f, 0.95f));
+                    app.renderTarget->FillRectangle(
+                        D2D1::RectF(tickLeft, ty - dpi(app, 0.5f), tickRight,
+                                    ty + dpi(app, 2.5f)),
+                        app.brush);
+                }
+            }
+            app.drawCalls++;
+        }
     }
 
     // Draw horizontal scrollbar

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2515,8 +2515,10 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
     std::vector<std::vector<float>> cellNatural(rows.size(), std::vector<float>(colCount, 0.0f));
     std::vector<std::vector<uint8_t>> cellSimple(rows.size(), std::vector<uint8_t>(colCount, 0));
 
+    std::wstring tsv;  // per-cell plain text doubles as the copy payload
     for (size_t r = 0; r < rows.size(); r++) {
         const auto& row = rows[r];
+        if (r > 0) tsv += L"\n";
         for (size_t c = 0; c < row->children.size() && c < (size_t)colCount; c++) {
             const auto& cell = row->children[c];
             cellAligns[r][c] = cell->align;
@@ -2529,6 +2531,13 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
                 else for (const auto& ch : e->children) extract(ch);
             };
             for (const auto& ch : cell->children) extract(ch);
+
+            if (c > 0) tsv += L"\t";
+            std::wstring tsvCell = text;
+            for (wchar_t& ch : tsvCell) {
+                if (ch == L'\t' || ch == L'\n' || ch == L'\r') ch = L' ';
+            }
+            tsv += tsvCell;
 
             // Measure natural width
             bool isHeader = (r == 0);
@@ -2716,6 +2725,13 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
                                        borderColor, borderStroke});
             if (c < colCount) vx += colWidths[c];
         }
+
+        // Copy-as-TSV hover button hit region
+        App::TableInfo info;
+        info.bounds =
+            D2D1::RectF(indent, tableStartY, indent + totalWidth, tableEndY);
+        info.tsv = std::move(tsv);
+        app.tableRects.push_back(std::move(info));
     }
 
     app.docText += L"\n";

--- a/src/tabs.cpp
+++ b/src/tabs.cpp
@@ -263,6 +263,13 @@ void tabOpenQuickNote(App& app, HWND hwnd) {
 namespace {
 
 float captionButtonWidth(const App& app) { return dpi(app, 46.0f); }
+// Always-on-top pin, left of the caption buttons
+float pinButtonWidth(const App& app) { return dpi(app, 34.0f); }
+D2D1_RECT_F pinButtonRect(const App& app) {
+    float right = (float)app.width - captionButtonWidth(app) * 3.0f;
+    return D2D1::RectF(right - pinButtonWidth(app), 0.0f, right,
+                       chromeTopHeight(app));
+}
 
 struct StripMetrics {
     float height = 0.0f;
@@ -278,7 +285,7 @@ StripMetrics stripMetrics(const App& app) {
     StripMetrics m;
     m.height = chromeTopHeight(app);
     m.tabsLeft = dpi(app, 40.0f);
-    float buttons = captionButtonWidth(app) * 3.0f;
+    float buttons = captionButtonWidth(app) * 3.0f + pinButtonWidth(app);
     float plusW = dpi(app, 30.0f);
     float chevronW = dpi(app, 32.0f);
     float gap = dpi(app, 2.0f);
@@ -460,7 +467,8 @@ void renderTabStrip(App& app) {
         }
         float textLeft = iconCell + dpi(app, 4.0f);
         float textRight = textLeft;
-        float maxRight = (float)app.width - captionButtonWidth(app) * 3;
+        float maxRight = (float)app.width - captionButtonWidth(app) * 3 -
+                         pinButtonWidth(app);
         if (app.folderBrowserFormat) {
             app.brush->SetColor(muted);
             app.renderTarget->DrawText(
@@ -687,6 +695,49 @@ void renderTabStrip(App& app) {
             drawCloseGlyph(app, cx, cy, dpi(app, 4.5f), glyph);
         }
     }
+
+    // Always-on-top pin: an upright pushpin, accent-filled while pinned
+    {
+        D2D1_RECT_F r = pinButtonRect(app);
+        bool hover = (float)app.mouseX >= r.left && (float)app.mouseX < r.right &&
+                     (float)app.mouseY >= r.top && (float)app.mouseY < r.bottom;
+        if (hover) {
+            D2D1_COLOR_F bg = text;
+            bg.a = 0.07f;
+            app.brush->SetColor(bg);
+            app.renderTarget->FillRectangle(r, app.brush);
+        }
+        float cx = (r.left + r.right) * 0.5f;
+        float cy = (r.top + r.bottom) * 0.5f - dpi(app, 1.0f);
+        D2D1_COLOR_F pin = app.alwaysOnTop ? app.theme.accent : text;
+        if (!app.alwaysOnTop && !hover) pin.a = 0.45f;
+        app.brush->SetColor(pin);
+        float bw = dpi(app, 3.0f);   // body half-width
+        float bh = dpi(app, 4.0f);   // body half-height
+        D2D1_RECT_F body = D2D1::RectF(cx - bw, cy - bh, cx + bw, cy + bh - 1);
+        if (app.alwaysOnTop) {
+            app.renderTarget->FillRectangle(body, app.brush);
+        } else {
+            app.renderTarget->DrawRectangle(body, app.brush, dpi(app, 1.0f));
+        }
+        // Head bar, flange, and needle
+        app.renderTarget->DrawLine(
+            D2D1::Point2F(cx - bw - dpi(app, 1.0f), cy - bh),
+            D2D1::Point2F(cx + bw + dpi(app, 1.0f), cy - bh), app.brush,
+            dpi(app, 1.2f));
+        app.renderTarget->DrawLine(
+            D2D1::Point2F(cx - bw - dpi(app, 2.0f), cy + bh - 1),
+            D2D1::Point2F(cx + bw + dpi(app, 2.0f), cy + bh - 1), app.brush,
+            dpi(app, 1.2f));
+        app.renderTarget->DrawLine(
+            D2D1::Point2F(cx, cy + bh - 1),
+            D2D1::Point2F(cx, cy + bh + dpi(app, 4.0f)), app.brush,
+            dpi(app, 1.2f));
+        App::TabHit pinHit;
+        pinHit.rect = r;
+        pinHit.index = -4;
+        app.tabHits.push_back(pinHit);
+    }
 }
 
 void renderTabSwitcher(App& app) {
@@ -834,6 +885,18 @@ bool tabStripMouseDown(App& app, HWND hwnd, int x, int y, bool middle) {
             if (!middle) {
                 app.showTabSwitcher = !app.showTabSwitcher;
                 app.tabSwitcherHover = -1;
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            return true;
+        }
+        if (hit.index == -4) {
+            // Pin: toggle always-on-top for this window
+            if (!middle) {
+                app.alwaysOnTop = !app.alwaysOnTop;
+                SetWindowPos(hwnd,
+                             app.alwaysOnTop ? HWND_TOPMOST : HWND_NOTOPMOST,
+                             0, 0, 0, 0,
+                             SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
                 InvalidateRect(hwnd, nullptr, FALSE);
             }
             return true;


### PR DESCRIPTION
First slice of the QoL backlog, smallest items first.

- **Pin on top**: a pushpin in the title bar (left of minimize) toggles always-on-top for that window; accent-filled while pinned. For following a runbook or notes while working in another app.
- **Search marks**: find-in-page draws every match as a tick along the scrollbar track, the current match brighter, so the document's match silhouette is visible at a glance. Dense results thin to ~400 draws.
- **Table copy as TSV**: hovering a table shows a Copy TSV button (same pattern as the code block copy button). Cells join with tabs, rows with newlines, and the paste lands in Excel or Sheets as a real grid. Inline formatting is stripped to plain text; the button clamps into the viewport on wide scrolling tables.

All test suites pass; each feature verified interactively (topmost style checked via WS_EX_TOPMOST, TSV round-trip checked from the clipboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)