### PR TITLE
Copy diagrams as images

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -676,7 +676,8 @@ struct App {
     // Code block info - tracked for copy button
     struct CodeBlockInfo {
         D2D1_RECT_F bounds;       // Full background rect in document coordinates
-        std::wstring codeText;    // The code content
+        std::wstring codeText;    // The code content (diagram source for diagrams)
+        bool isDiagram = false;   // adds the copy-as-image button
     };
     std::vector<CodeBlockInfo> codeBlocks;
     int hoveredCodeBlock = -1;

--- a/include/export.h
+++ b/include/export.h
@@ -31,4 +31,8 @@ mermaidext::Built buildDiagramPrims(App& app, const std::string& sourceUtf8,
 mermaidext::Built buildFlowchartPrims(App& app, const std::string& sourceUtf8,
                                       float scale);
 
+// Rasterizes a diagram at 2x and puts it on the clipboard as CF_DIB plus
+// a PNG stream, for pasting into slides/chats/documents (export_docx.cpp)
+bool copyDiagramImage(App& app, HWND hwnd, const std::string& sourceUtf8);
+
 #endif  // TINTA_EXPORT_H

--- a/src/export_docx.cpp
+++ b/src/export_docx.cpp
@@ -1430,3 +1430,82 @@ bool exportDocxFile(App& app, const std::wstring& path) {
     out.write(package.data(), package.size());
     return out.good();
 }
+
+// Rasterizes the diagram exactly like the DOCX path, then hands the pixels
+// to the clipboard as CF_DIB (universal) plus a "PNG" stream (kept by apps
+// that prefer lossless with metadata)
+bool copyDiagramImage(App& app, HWND hwnd, const std::string& sourceUtf8) {
+    mermaidext::Built built = buildDiagramPrims(app, sourceUtf8, kRasterScale);
+    if (!built.ok || built.prims.empty()) return false;
+    RasterTarget rt;
+    if (!rt.open(app, built.width, built.height)) return false;
+    rt.target->BeginDraw();
+    rt.target->Clear(app.theme.background);
+    drawPrims(app, rt, built, kRasterScale);
+    if (FAILED(rt.target->EndDraw())) return false;
+
+    UINT stride = rt.width * 4;
+    std::vector<BYTE> pixels((size_t)stride * rt.height);
+    if (FAILED(rt.bitmap->CopyPixels(nullptr, stride, (UINT)pixels.size(),
+                                     pixels.data()))) {
+        return false;
+    }
+
+    // CF_DIB: header plus bottom-up 32bpp rows (background is opaque, so
+    // the ignored alpha byte is 255 everywhere)
+    HGLOBAL dib = GlobalAlloc(GMEM_MOVEABLE,
+                              sizeof(BITMAPINFOHEADER) + pixels.size());
+    if (!dib) return false;
+    if (BYTE* out = (BYTE*)GlobalLock(dib)) {
+        BITMAPINFOHEADER hdr{};
+        hdr.biSize = sizeof(hdr);
+        hdr.biWidth = (LONG)rt.width;
+        hdr.biHeight = (LONG)rt.height;
+        hdr.biPlanes = 1;
+        hdr.biBitCount = 32;
+        hdr.biCompression = BI_RGB;
+        hdr.biSizeImage = (DWORD)pixels.size();
+        memcpy(out, &hdr, sizeof(hdr));
+        for (UINT row = 0; row < rt.height; row++) {
+            memcpy(out + sizeof(hdr) + (size_t)row * stride,
+                   pixels.data() + (size_t)(rt.height - 1 - row) * stride,
+                   stride);
+        }
+        GlobalUnlock(dib);
+    } else {
+        GlobalFree(dib);
+        return false;
+    }
+
+    std::string png = encodeWicPng(app, rt.bitmap, rt.width, rt.height);
+    HGLOBAL pngGlobal = nullptr;
+    if (!png.empty()) {
+        pngGlobal = GlobalAlloc(GMEM_MOVEABLE, png.size());
+        if (pngGlobal) {
+            if (void* bits = GlobalLock(pngGlobal)) {
+                memcpy(bits, png.data(), png.size());
+                GlobalUnlock(pngGlobal);
+            } else {
+                GlobalFree(pngGlobal);
+                pngGlobal = nullptr;
+            }
+        }
+    }
+
+    if (!OpenClipboard(hwnd)) {
+        GlobalFree(dib);
+        if (pngGlobal) GlobalFree(pngGlobal);
+        return false;
+    }
+    EmptyClipboard();
+    bool ok = SetClipboardData(CF_DIB, dib) != nullptr;
+    if (!ok) GlobalFree(dib);
+    if (pngGlobal) {
+        UINT pngFormat = RegisterClipboardFormatW(L"PNG");
+        if (!pngFormat || !SetClipboardData(pngFormat, pngGlobal)) {
+            GlobalFree(pngGlobal);
+        }
+    }
+    CloseClipboard();
+    return ok;
+}

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -192,6 +192,8 @@ const Entry kEntries[] = {
     { "toast.agent_copied", L"Copied for agent", L"\u5DF2\u590D\u5236\u7ED9\u667A\u80FD\u4F53", L"\u30A8\u30FC\u30B8\u30A7\u30F3\u30C8\u7528\u306B\u30B3\u30D4\u30FC", L"\uC5D0\uC774\uC804\uD2B8\uC6A9\uC73C\uB85C \uBCF5\uC0AC\uB428" },
     { "table.copy", L"Copy TSV", L"\u590D\u5236TSV", L"TSV\u3092\u30B3\u30D4\u30FC", L"TSV \uBCF5\uC0AC" },
     { "table.copied", L"Table copied", L"\u5DF2\u590D\u5236\u8868\u683C", L"\u8868\u3092\u30B3\u30D4\u30FC\u3057\u307E\u3057\u305F", L"\uD45C \uBCF5\uC0AC\uB428" },
+    { "diagram.png", L"Image", L"\u56FE\u7247", L"\u753B\u50CF", L"\uC774\uBBF8\uC9C0" },
+    { "diagram.copied", L"Image copied", L"\u5DF2\u590D\u5236\u56FE\u7247", L"\u753B\u50CF\u3092\u30B3\u30D4\u30FC\u3057\u307E\u3057\u305F", L"\uC774\uBBF8\uC9C0 \uBCF5\uC0AC\uB428" },
     { "ctx.new", L"New File", L"\u65B0\u5EFA\u6587\u4EF6", L"\u65B0\u898F\u30D5\u30A1\u30A4\u30EB", L"\uC0C8 \uD30C\uC77C" },
     { "ctx.print", L"Print / PDF", L"\u6253\u5370 / PDF", L"\u5370\u5237 / PDF", L"\uCD9C\uB825 / PDF" },
     { "ctx.edit", L"Edit", L"\u7F16\u8F91", L"\u7DE8\u96C6", L"\uD3B8\uC9D1" },

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -32,6 +32,7 @@ static HCURSOR cursorSizeWE = LoadCursor(nullptr, IDC_SIZEWE);
 
 static const App::TaskRect* taskRectAt(const App& app);
 static bool tableCopyButtonAt(const App& app, int mouseX, int mouseY);
+static bool diagramPngButtonAt(const App& app, int mouseX, int mouseY);
 
 static bool cursorPointInRect(float x, float y, const D2D1_RECT_F& rect) {
     return x >= rect.left && x <= rect.right &&
@@ -1319,8 +1320,9 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         float btnPad = 8.0f * app.contentScale * app.zoomFactor;
         float btnX = cb.bounds.right - btnW - btnPad;
         float btnY = cb.bounds.top + btnPad;
-        if (docX >= btnX && docX <= btnX + btnW &&
-            docY >= btnY && docY <= btnY + btnH) {
+        if ((docX >= btnX && docX <= btnX + btnW &&
+             docY >= btnY && docY <= btnY + btnH) ||
+            diagramPngButtonAt(app, app.mouseX, app.mouseY)) {
             SetCursor(cursorHand);
         } else if (app.overText) {
             SetCursor(cursorIBeam);
@@ -2069,6 +2071,29 @@ static bool codeCopyButtonAt(const App& app, int mouseX, int mouseY) {
            docY >= btnY && docY <= btnY + btnH;
 }
 
+// True when (mouseX, mouseY) is on the hovered diagram's copy-as-image
+// button (drawn left of the source copy button)
+static bool diagramPngButtonAt(const App& app, int mouseX, int mouseY) {
+    if (app.hoveredCodeBlock < 0 ||
+        app.hoveredCodeBlock >= (int)app.codeBlocks.size()) {
+        return false;
+    }
+    const auto& cb = app.codeBlocks[app.hoveredCodeBlock];
+    if (!cb.isDiagram) return false;
+    float previewOffsetX = documentViewportX(app);
+    float docX = (mouseX - previewOffsetX) + app.scrollX;
+    float docY = mouseY + app.scrollY;
+    float btnW = dpi(app, 72.0f);
+    float btnH = dpi(app, 26.0f);
+    float btnPad = 8.0f * app.contentScale * app.zoomFactor;
+    float copyX = cb.bounds.right - btnW - btnPad;
+    float pngW = dpi(app, 52.0f);
+    float pngX = copyX - pngW - dpi(app, 6.0f);
+    float btnY = cb.bounds.top + btnPad;
+    return docX >= pngX && docX <= pngX + pngW &&
+           docY >= btnY && docY <= btnY + btnH;
+}
+
 // True when (mouseX, mouseY) is on the hovered table's copy-as-TSV button
 static bool tableCopyButtonAt(const App& app, int mouseX, int mouseY) {
     if (app.hoveredTable < 0 ||
@@ -2508,6 +2533,19 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         app.showCopiedNotification = true;
         app.copiedNotificationStart = std::chrono::steady_clock::now();
         startNotificationTimer(app);
+        app.hoveredCodeBlock = -1;
+        app.selecting = false;
+        InvalidateRect(hwnd, nullptr, FALSE);
+    } else if (diagramPngButtonAt(app, app.mouseX, app.mouseY)) {
+        // Diagram image button: 2x raster to the clipboard
+        if (copyDiagramImage(
+                app, hwnd,
+                toUtf8(app.codeBlocks[app.hoveredCodeBlock].codeText))) {
+            app.copiedNotificationKey = "diagram.copied";
+            app.showCopiedNotification = true;
+            app.copiedNotificationStart = std::chrono::steady_clock::now();
+            startNotificationTimer(app);
+        }
         app.hoveredCodeBlock = -1;
         app.selecting = false;
         InvalidateRect(hwnd, nullptr, FALSE);

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -600,6 +600,39 @@ render_document:
                     D2D1::Point2F(btnX, btnY), btnLayout, app.brush);
                 btnLayout->Release();
             }
+
+            // Diagrams add a copy-as-image button beside the source copy
+            if (cb.isDiagram) {
+                float pngW = dpi(app, 52.0f);
+                float pngX = btnX - pngW - dpi(app, 6.0f);
+                app.brush->SetColor(D2D1::ColorF(
+                    app.theme.isDark ? 0.3f : 0.85f,
+                    app.theme.isDark ? 0.3f : 0.85f,
+                    app.theme.isDark ? 0.3f : 0.85f,
+                    0.9f));
+                app.renderTarget->FillRoundedRectangle(
+                    D2D1::RoundedRect(
+                        D2D1::RectF(pngX, btnY, pngX + pngW, btnY + btnH), 4, 4),
+                    app.brush);
+                app.brush->SetColor(D2D1::ColorF(
+                    app.theme.isDark ? 0.9f : 0.15f,
+                    app.theme.isDark ? 0.9f : 0.15f,
+                    app.theme.isDark ? 0.9f : 0.15f,
+                    1.0f));
+                IDWriteTextLayout* pngLayout = nullptr;
+                const wchar_t* pngLabel = tr(app, "diagram.png");
+                app.dwriteFactory->CreateTextLayout(
+                    pngLabel, (UINT32)wcslen(pngLabel), app.codeFormat, pngW,
+                    btnH, &pngLayout);
+                if (pngLayout) {
+                    pngLayout->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
+                    pngLayout->SetParagraphAlignment(
+                        DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+                    app.renderTarget->DrawTextLayout(
+                        D2D1::Point2F(pngX, btnY), pngLayout, app.brush);
+                    pngLayout->Release();
+                }
+            }
             app.drawCalls++;
         }
     }

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2003,7 +2003,7 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
                 &renderedBounds);
         }
         if (rendered) {
-            app.codeBlocks.push_back({renderedBounds, toWide(code)});
+            app.codeBlocks.push_back({renderedBounds, toWide(code), true});
             return;
         }
     }


### PR DESCRIPTION
Hovering a rendered mermaid diagram now shows an **Image** button beside the existing source **Copy**. One click rasterizes the diagram at 2x through the DOCX export pipeline (same prims, same WIC target, all 22 families) and puts it on the clipboard as CF_DIB plus a PNG stream, so it pastes crisply into slides, chats, tickets, and documents.

Verified: clipboard carries DeviceIndependentBitmap + PNG, 2x resolution confirmed (1908x272 for a viewport-width flowchart). All test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)