### PR TITLE
TOC scroll-spy with typed filtering; image lightbox

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -284,6 +284,20 @@ struct App {
     };
     std::vector<LayoutBitmap> layoutBitmaps;
 
+    // Image lightbox: clicking an inline image views it full size over a
+    // dimmed backdrop; wheel zooms, drag pans, Esc or a click closes
+    bool showLightbox = false;
+    ID2D1Bitmap* lightboxBitmap = nullptr;  // AddRef'd while open
+    float lightboxZoom = 1.0f;              // multiplier over fit-to-view
+    float lightboxPanX = 0.0f;
+    float lightboxPanY = 0.0f;
+    bool lightboxDragging = false;
+    int lightboxDragStartX = 0;
+    int lightboxDragStartY = 0;
+    float lightboxDragPanX = 0.0f;
+    float lightboxDragPanY = 0.0f;
+    bool lightboxDragMoved = false;
+
     // DirectWrite
     IDWriteFactory* dwriteFactory = nullptr;
     IDWriteFontFallback* fontFallback = nullptr;  // For emoji font fallback
@@ -645,6 +659,8 @@ struct App {
     std::unordered_map<std::string, int> headingSlugCounts;
     int hoveredTocIndex = -1;
     float tocScroll = 0.0f;
+    // Typed while the panel is open: case-insensitive substring filter
+    std::wstring tocFilter;
 
     // Mouse
     bool mouseDown = false;
@@ -1051,6 +1067,10 @@ struct App {
     }
 
     void shutdown() {
+        if (lightboxBitmap) {
+            lightboxBitmap->Release();
+            lightboxBitmap = nullptr;
+        }
         clearLayoutCache();
         releaseOverlayFormats();
         releaseImageCache();

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -81,6 +81,13 @@ enum ContextMenuItem {
 };
 void renderContextMenu(App& app);
 
+// Image lightbox (click an inline image)
+void openLightbox(App& app, ID2D1Bitmap* bitmap);
+void closeLightbox(App& app);
+void renderLightbox(App& app);
+// Where the image currently draws, in screen coordinates
+D2D1_RECT_F lightboxImageRect(const App& app);
+
 // Folder-wide search results beside the search bar; the toggle button sits
 // at the bar's right edge (geometry shared with input hit-testing)
 void renderFolderSearchResults(App& app);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -34,6 +34,19 @@ static const App::TaskRect* taskRectAt(const App& app);
 static bool tableCopyButtonAt(const App& app, int mouseX, int mouseY);
 static bool diagramPngButtonAt(const App& app, int mouseX, int mouseY);
 
+// Inline image under the document point, or nullptr (viewer lightbox)
+static const App::LayoutBitmap* layoutBitmapAt(const App& app, float docX,
+                                               float docY) {
+    for (const auto& lb : app.layoutBitmaps) {
+        if (lb.bitmap && docX >= lb.destRect.left &&
+            docX <= lb.destRect.right && docY >= lb.destRect.top &&
+            docY <= lb.destRect.bottom) {
+            return &lb;
+        }
+    }
+    return nullptr;
+}
+
 static bool cursorPointInRect(float x, float y, const D2D1_RECT_F& rect) {
     return x >= rect.left && x <= rect.right &&
            y >= rect.top && y <= rect.bottom;
@@ -261,6 +274,7 @@ bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
     app.sourceText = buffer.str();
     annotationsParseSource(app);
     if (app.annotEditorOpen) annotationEditorCancel(app);
+    if (app.showLightbox) closeLightbox(app);
 
     // Reading position memory (#77): keep the old document's position,
     // resume the new one's
@@ -740,6 +754,16 @@ static WPARAM translateActionKey(App& app, WPARAM key, bool isChar) {
 }
 
 void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    // Lightbox: the wheel zooms the image
+    if (app.showLightbox) {
+        float delta = (float)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
+        float factor = delta > 0 ? 1.15f : 1.0f / 1.15f;
+        app.lightboxZoom =
+            std::max(0.2f, std::min(app.lightboxZoom * factor, 10.0f));
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     // Theme editor: wheel scrolls the font list
     if (app.showThemeEditor) {
         float delta = (float)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
@@ -885,6 +909,25 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     // An armed tab drag owns the mouse until release (capture held)
     if (app.tabDragIndex >= 0) {
         tabDragMove(app, hwnd, app.mouseX, app.mouseY);
+        return;
+    }
+
+    // Lightbox: drag pans the image
+    if (app.showLightbox) {
+        if (app.lightboxDragging) {
+            int dx = app.mouseX - app.lightboxDragStartX;
+            int dy = app.mouseY - app.lightboxDragStartY;
+            if (abs(dx) > 3 || abs(dy) > 3) app.lightboxDragMoved = true;
+            app.lightboxPanX = app.lightboxDragPanX + (float)dx;
+            app.lightboxPanY = app.lightboxDragPanY + (float)dy;
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
+        D2D1_RECT_F img = lightboxImageRect(app);
+        bool over = (float)app.mouseX >= img.left &&
+                    (float)app.mouseX <= img.right &&
+                    (float)app.mouseY >= img.top &&
+                    (float)app.mouseY <= img.bottom;
+        SetCursor(over || app.lightboxDragging ? cursorHand : cursorArrow);
         return;
     }
 
@@ -1334,6 +1377,8 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         SetCursor(cursorHand);
     } else if (!app.hoveredLink.empty()) {
         SetCursor(cursorHand);
+    } else if (!app.editMode && layoutBitmapAt(app, docX, docY) != nullptr) {
+        SetCursor(cursorHand);
     } else if (app.overText) {
         SetCursor(cursorIBeam);
     } else {
@@ -1438,6 +1483,7 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
             app.showToc = true;
             app.tocAnimation = 0;
             app.tocScroll = 0;
+            app.tocFilter.clear();
             app.hoveredTocIndex = -1;
             break;
         case CTX_BROWSE:
@@ -1541,6 +1587,27 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             return;
         }
     }
+    // Lightbox: press on the image arms a pan, elsewhere closes
+    if (app.showLightbox) {
+        int mx = GET_X_LPARAM(lParam);
+        int my = GET_Y_LPARAM(lParam);
+        D2D1_RECT_F img = lightboxImageRect(app);
+        if ((float)mx >= img.left && (float)mx <= img.right &&
+            (float)my >= img.top && (float)my <= img.bottom) {
+            app.lightboxDragging = true;
+            app.lightboxDragMoved = false;
+            app.lightboxDragStartX = mx;
+            app.lightboxDragStartY = my;
+            app.lightboxDragPanX = app.lightboxPanX;
+            app.lightboxDragPanY = app.lightboxPanY;
+            SetCapture(hwnd);
+        } else {
+            closeLightbox(app);
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     // Theme and shortcut editors: everything acts on the release
     if (app.showThemeEditor || app.showShortcutEditor) return;
     // Unsaved-changes dialog is modal: buttons act on the release
@@ -2126,6 +2193,17 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         return;
     }
 
+    // Lightbox: a plain click closes, a pan drag just ends
+    if (app.showLightbox) {
+        if (app.lightboxDragging) {
+            app.lightboxDragging = false;
+            if (GetCapture() == hwnd) ReleaseCapture();
+            if (!app.lightboxDragMoved) closeLightbox(app);
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
+        return;
+    }
+
     // Unsaved-changes dialog: resolve its buttons; clicks elsewhere keep
     // the dialog up (it is modal, and dismissal must be deliberate)
     if (app.editMode && app.confirmExitPending) {
@@ -2315,11 +2393,13 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 // Close TOC
                 app.showToc = false;
                 app.tocAnimation = 0;
+                app.tocFilter.clear();
             }
         } else {
             // Click outside panel = close TOC
             app.showToc = false;
             app.tocAnimation = 0;
+            app.tocFilter.clear();
         }
 
         InvalidateRect(hwnd, nullptr, FALSE);
@@ -2607,6 +2687,11 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 // A click on annotated text opens its note editor (#126)
                 annotationOpenEditor(app, annotationAtDocPoint(app, docX, docY));
                 app.hasSelection = false;
+            } else if (const App::LayoutBitmap* img =
+                           layoutBitmapAt(app, docX, docY)) {
+                // Inline image: view it full size
+                openLightbox(app, img->bitmap);
+                app.hasSelection = false;
             } else {
                 app.hasSelection = false;
             }
@@ -2619,12 +2704,18 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         } else {
             handleLinkClick(app);
         }
-    } else if (!app.editMode && !app.annotations.empty()) {
-        // A click on annotated text opens its note editor (#126)
+    } else if (!app.editMode) {
+        // A click on annotated text opens its note editor (#126); a
+        // click on an inline image opens the lightbox
         float docX = (app.mouseX - documentViewportX(app)) + app.scrollX;
         float docY = app.mouseY + app.scrollY;
         int annotHit = annotationAtDocPoint(app, docX, docY);
-        if (annotHit >= 0) annotationOpenEditor(app, annotHit);
+        if (annotHit >= 0) {
+            annotationOpenEditor(app, annotHit);
+        } else if (const App::LayoutBitmap* img =
+                       layoutBitmapAt(app, docX, docY)) {
+            openLightbox(app, img->bitmap);
+        }
     }
 
     app.mouseDown = false;
@@ -2662,6 +2753,16 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     float pageSize = app.height * 0.8f;
     float maxScroll = std::max(0.0f, app.contentHeight - app.height);
     bool ctrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
+
+    // Lightbox: dismiss keys close it, everything else is swallowed
+    if (app.showLightbox) {
+        if (wParam == VK_ESCAPE || wParam == VK_RETURN ||
+            wParam == VK_SPACE) {
+            closeLightbox(app);
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
+        return;
+    }
 
     // Annotation note editor owns the keyboard while open (#126)
     if (app.annotEditorOpen && !app.editMode) {
@@ -3021,6 +3122,37 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             }
             return;
         }
+        // TOC filter: printable keys narrow the heading list via WM_CHAR,
+        // Backspace edits, Enter jumps to the first match
+        if (app.showToc && !app.editMode) {
+            if (wParam == VK_BACK) {
+                if (!app.tocFilter.empty()) app.tocFilter.pop_back();
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+            if (wParam == VK_RETURN) {
+                std::wstring needle = toLower(app.tocFilter);
+                for (const auto& heading : app.headings) {
+                    if (needle.empty() ||
+                        toLower(heading.text).find(needle) !=
+                            std::wstring::npos) {
+                        ensureLayoutComplete(app);
+                        scrollToHeadingY(app, heading.y);
+                        app.showToc = false;
+                        app.tocAnimation = 0;
+                        app.tocFilter.clear();
+                        break;
+                    }
+                }
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+            if ((wParam >= 'A' && wParam <= 'Z') ||
+                (wParam >= '0' && wParam <= '9') || wParam == VK_SPACE) {
+                return;  // swallowed here; WM_CHAR feeds the filter
+            }
+        }
+
         wParam = translateActionKey(app, wParam, false);
         switch (wParam) {
             case VK_ESCAPE:
@@ -3043,8 +3175,12 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                     app.showFolderBrowser = false;
                     app.folderBrowserAnimation = 0;
                 } else if (app.showToc) {
-                    app.showToc = false;
-                    app.tocAnimation = 0;
+                    if (!app.tocFilter.empty()) {
+                        app.tocFilter.clear();  // first Esc clears the filter
+                    } else {
+                        app.showToc = false;
+                        app.tocAnimation = 0;
+                    }
                 } else if (app.showThemeChooser) {
                     app.showThemeChooser = false;
                     app.themeChooserAnimation = 0;
@@ -3103,6 +3239,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             case VK_TAB:
                 if (!app.showSearch && !app.showThemeChooser && !app.showFolderBrowser) {
                     app.showToc = !app.showToc;
+                    app.tocFilter.clear();
                     if (app.showToc) {
                         ensureLayoutComplete(app);  // headings list is built during layout
                         app.tocAnimation = 0;
@@ -3253,6 +3390,17 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
     // Edit mode: ':' enters edit mode, otherwise route to editor
     if (app.editMode) {
         handleEditorCharInput(app, hwnd, wParam);
+        return;
+    }
+
+    // TOC filter: typing narrows the heading list
+    if (app.showToc && !app.showSearch) {
+        wchar_t ch = (wchar_t)wParam;
+        if (ch >= 0x20 && ch != 127) {
+            app.tocFilter += ch;
+            app.tocScroll = 0;
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
         return;
     }
 

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -992,6 +992,7 @@ render_document:
     if (app.showThemeChooser) renderThemeChooser(app);
     if (app.showHelp) renderHelpOverlay(app);
     if (app.showSettings) renderSettingsOverlay(app);
+    if (app.showLightbox) renderLightbox(app);
     if (app.showThemeEditor) renderThemeEditor(app);
     if (app.showShortcutEditor) renderShortcutEditor(app);
 

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -711,6 +711,26 @@ void renderToc(App& app) {
             D2D1::RectF(panelX + padding, headerY, panelX + panelWidth - padding, headerY + headerHeight),
             app.brush);
 
+        // Active filter, right-aligned in the header
+        if (!app.tocFilter.empty() && app.dwriteFactory) {
+            IDWriteTextLayout* filterLayout = nullptr;
+            app.dwriteFactory->CreateTextLayout(
+                app.tocFilter.c_str(), (UINT32)app.tocFilter.size(),
+                tocNormal, panelWidth, headerHeight, &filterLayout);
+            if (filterLayout) {
+                DWRITE_TEXT_METRICS fm{};
+                filterLayout->GetMetrics(&fm);
+                D2D1_COLOR_F filterColor = app.theme.accent;
+                filterColor.a = anim;
+                app.brush->SetColor(filterColor);
+                app.renderTarget->DrawTextLayout(
+                    D2D1::Point2F(panelX + panelWidth - padding - fm.width,
+                                  headerY + dpi(app, 2.0f)),
+                    filterLayout, app.brush);
+                filterLayout->Release();
+            }
+        }
+
         // Divider
         float dividerY = headerY + headerHeight;
         app.brush->SetColor(borderColor);
@@ -733,23 +753,71 @@ void renderToc(App& app) {
                 D2D1::RectF(panelX + padding, listStartY + dpi(app, 8.0f), panelX + panelWidth - padding, listStartY + dpi(app, 40.0f)),
                 app.brush);
         } else {
-            float totalItemsHeight = app.headings.size() * itemHeight;
+            // Typing filters the list; the section under the reading line
+            // stays highlighted and in view (scroll-spy)
+            std::vector<int> visible;
+            visible.reserve(app.headings.size());
+            std::wstring needle = toLower(app.tocFilter);
+            for (size_t i = 0; i < app.headings.size(); i++) {
+                if (needle.empty() ||
+                    toLower(app.headings[i].text).find(needle) !=
+                        std::wstring::npos) {
+                    visible.push_back((int)i);
+                }
+            }
 
-            // Clamp scroll
+            int currentIdx = -1;
+            float spyLine = app.scrollY + (float)app.height * 0.25f;
+            for (size_t i = 0; i < app.headings.size(); i++) {
+                if (app.headings[i].y <= spyLine) currentIdx = (int)i;
+            }
+            if (currentIdx < 0 && !app.headings.empty()) currentIdx = 0;
+
+            float totalItemsHeight = visible.size() * itemHeight;
             float maxScroll = std::max(0.0f, totalItemsHeight - listHeight);
+
+            // Follow the document: when the current section changes, keep
+            // its row inside the list viewport
+            static int lastSpyIndex = -1;
+            if (currentIdx != lastSpyIndex && app.tocFilter.empty()) {
+                lastSpyIndex = currentIdx;
+                for (size_t row = 0; row < visible.size(); row++) {
+                    if (visible[row] != currentIdx) continue;
+                    float rowTop = (float)row * itemHeight;
+                    if (rowTop < app.tocScroll ||
+                        rowTop + itemHeight > app.tocScroll + listHeight) {
+                        app.tocScroll = rowTop - listHeight * 0.4f;
+                    }
+                    break;
+                }
+            }
             app.tocScroll = std::max(0.0f, std::min(app.tocScroll, maxScroll));
 
             app.hoveredTocIndex = -1;
 
-            for (size_t i = 0; i < app.headings.size(); i++) {
-                float itemY = listStartY + i * itemHeight - app.tocScroll;
+            if (visible.empty()) {
+                D2D1_COLOR_F dimColor = app.theme.text;
+                dimColor.a = 0.5f * anim;
+                app.brush->SetColor(dimColor);
+                const wchar_t* tocEmpty = tr(app, "toc.empty");
+                app.renderTarget->DrawText(tocEmpty, (UINT32)wcslen(tocEmpty),
+                    tocNormal,
+                    D2D1::RectF(panelX + padding, listStartY + dpi(app, 8.0f),
+                                panelX + panelWidth - padding,
+                                listStartY + dpi(app, 40.0f)),
+                    app.brush);
+            }
+
+            for (size_t row = 0; row < visible.size(); row++) {
+                float itemY = listStartY + row * itemHeight - app.tocScroll;
 
                 // Skip items outside visible area
                 if (itemY + itemHeight < listStartY || itemY > panelHeight - padding) continue;
 
-                const auto& heading = app.headings[i];
+                const auto& heading = app.headings[visible[row]];
                 float indent = (heading.level - 1) * dpi(app, 16.0f);
                 float itemX = panelX + padding + indent;
+                bool isCurrent = visible[row] == currentIdx;
 
                 // Check hover (use full item width for hit area)
                 float hitX = panelX + padding;
@@ -759,7 +827,7 @@ void renderToc(App& app) {
                                   app.mouseY >= listStartY && app.mouseY <= panelHeight - padding);
 
                 if (isHovered) {
-                    app.hoveredTocIndex = (int)i;
+                    app.hoveredTocIndex = visible[row];
 
                     // Hover highlight
                     D2D1_COLOR_F hoverColor = app.theme.accent;
@@ -768,6 +836,28 @@ void renderToc(App& app) {
                     app.renderTarget->FillRoundedRectangle(
                         D2D1::RoundedRect(D2D1::RectF(panelX + padding - dpi(app, 4.0f), itemY,
                             panelX + panelWidth - padding + dpi(app, 4.0f), itemY + itemHeight), 4, 4),
+                        app.brush);
+                } else if (isCurrent) {
+                    // Scroll-spy highlight: softer than hover
+                    D2D1_COLOR_F spyColor = app.theme.accent;
+                    spyColor.a = 0.08f * anim;
+                    app.brush->SetColor(spyColor);
+                    app.renderTarget->FillRoundedRectangle(
+                        D2D1::RoundedRect(D2D1::RectF(panelX + padding - dpi(app, 4.0f), itemY,
+                            panelX + panelWidth - padding + dpi(app, 4.0f), itemY + itemHeight), 4, 4),
+                        app.brush);
+                }
+                if (isCurrent) {
+                    D2D1_COLOR_F barColor = app.theme.accent;
+                    barColor.a = anim;
+                    app.brush->SetColor(barColor);
+                    app.renderTarget->FillRoundedRectangle(
+                        D2D1::RoundedRect(
+                            D2D1::RectF(panelX + padding - dpi(app, 8.0f),
+                                        itemY + dpi(app, 5.0f),
+                                        panelX + padding - dpi(app, 5.0f),
+                                        itemY + itemHeight - dpi(app, 5.0f)),
+                            1.5f, 1.5f),
                         app.brush);
                 }
 
@@ -778,7 +868,7 @@ void renderToc(App& app) {
                     textColor = app.theme.heading;
                 } else if (heading.level == 3) {
                     textColor = app.theme.text;
-                    textColor.a = 0.7f * anim;
+                    textColor.a = (isCurrent ? 1.0f : 0.7f) * anim;
                 } else {
                     textColor = app.theme.text;
                     textColor.a = anim;
@@ -806,6 +896,61 @@ void renderToc(App& app) {
             }
         }
     }
+}
+
+// --- Image lightbox ---
+
+void openLightbox(App& app, ID2D1Bitmap* bitmap) {
+    if (!bitmap) return;
+    closeLightbox(app);
+    bitmap->AddRef();
+    app.lightboxBitmap = bitmap;
+    app.showLightbox = true;
+    app.lightboxZoom = 1.0f;
+    app.lightboxPanX = 0.0f;
+    app.lightboxPanY = 0.0f;
+    app.lightboxDragging = false;
+}
+
+void closeLightbox(App& app) {
+    if (app.lightboxBitmap) {
+        app.lightboxBitmap->Release();
+        app.lightboxBitmap = nullptr;
+    }
+    app.showLightbox = false;
+    app.lightboxDragging = false;
+}
+
+D2D1_RECT_F lightboxImageRect(const App& app) {
+    if (!app.lightboxBitmap) return D2D1_RECT_F{};
+    D2D1_SIZE_F size = app.lightboxBitmap->GetSize();
+    float availW = (float)app.width * 0.94f;
+    float availH = (float)app.height - chromeTopHeight(app) - dpi(app, 24.0f);
+    // Fit large images to the view, keep small ones at natural size
+    float fit = std::min(1.0f, std::min(availW / std::max(1.0f, size.width),
+                                        availH / std::max(1.0f, size.height)));
+    float scale = fit * app.lightboxZoom;
+    float w = size.width * scale;
+    float h = size.height * scale;
+    float cx = (float)app.width * 0.5f + app.lightboxPanX;
+    float cy = (chromeTopHeight(app) + (float)app.height) * 0.5f +
+               app.lightboxPanY;
+    return D2D1::RectF(cx - w * 0.5f, cy - h * 0.5f, cx + w * 0.5f,
+                       cy + h * 0.5f);
+}
+
+void renderLightbox(App& app) {
+    if (!app.lightboxBitmap || !app.renderTarget || !app.brush) return;
+    app.brush->SetColor(D2D1::ColorF(0.0f, 0.0f, 0.0f, 0.82f));
+    app.renderTarget->FillRectangle(
+        D2D1::RectF(0, 0, (float)app.width, (float)app.height), app.brush);
+    D2D1_RECT_F dest = lightboxImageRect(app);
+    app.renderTarget->DrawBitmap(
+        app.lightboxBitmap, dest, 1.0f,
+        D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, nullptr);
+    // Thin border so light images do not bleed into the backdrop
+    app.brush->SetColor(D2D1::ColorF(1.0f, 1.0f, 1.0f, 0.18f));
+    app.renderTarget->DrawRectangle(dest, app.brush, 1.0f);
 }
 
 float tocPanelX(const App& app, float panelWidth) {


### PR DESCRIPTION
Two more from the QoL list.

## TOC scroll-spy + filter
- The section currently under the reading line stays highlighted (accent bar + soft fill) and its row follows along as the document scrolls
- Typing while the panel is open filters headings by case-insensitive substring; the query shows in the header
- Backspace edits, Enter jumps to the first match and closes, Esc clears the filter first and closes second

## Image lightbox
- Click any inline image: it opens full size over a dimmed backdrop (large images fit the view, small ones stay 1:1)
- Wheel zooms 0.2x-10x, dragging pans, Esc/Enter/Space or a plain click closes
- The bitmap is AddRef'd while open, so image-cache eviction or a watcher reload cannot pull it out from under the overlay

Both verified interactively (spy highlight while paging, filter narrowing + Enter jump, open/zoom/pan/close cycle). All test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)