### PR TITLE
Paste images into notes; rendered link peek

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -35,6 +35,7 @@ inline int64_t usElapsed(Clock::time_point start) {
 #define TIMER_IMAGE_REFLOW 6
 #define TIMER_FOLDER_SEARCH 7
 #define TIMER_SELECT_SCROLL 8
+#define TIMER_LINK_PEEK 9
 
 // Posted to continue an incomplete document layout in time-budgeted chunks
 #define WM_APP_LAYOUT_CHUNK (WM_APP + 1)
@@ -593,6 +594,15 @@ struct App {
     std::string sourceText;       // raw markdown of currentFile (viewer)
     int hoveredAnnotation = -1;
     bool annotEditorOpen = false;
+
+    // Link peek: dwelling on a local .md link previews the target, fully
+    // rendered at the live theme beside the link
+    std::string linkPeekUrl;    // hoveredLink value the dwell timer armed for
+    std::wstring linkPeekTitle;
+    bool linkPeekActive = false;
+    ID2D1Bitmap* linkPeekBitmap = nullptr;  // owned while active
+    D2D1_RECT_F linkPeekAnchorDoc{};        // hovered link rect (doc coords)
+    D2D1_RECT_F linkPeekPanel{};            // placed panel (screen coords)
     int annotEditorIndex = -1;    // -1 = creating a new annotation
     std::wstring annotEditorText;
     size_t annotEditorCaret = 0;
@@ -1070,6 +1080,10 @@ struct App {
         if (lightboxBitmap) {
             lightboxBitmap->Release();
             lightboxBitmap = nullptr;
+        }
+        if (linkPeekBitmap) {
+            linkPeekBitmap->Release();
+            linkPeekBitmap = nullptr;
         }
         clearLayoutCache();
         releaseOverlayFormats();

--- a/include/export.h
+++ b/include/export.h
@@ -35,4 +35,7 @@ mermaidext::Built buildFlowchartPrims(App& app, const std::string& sourceUtf8,
 // a PNG stream, for pasting into slides/chats/documents (export_docx.cpp)
 bool copyDiagramImage(App& app, HWND hwnd, const std::string& sourceUtf8);
 
+// Clipboard bitmap -> PNG file (editor image paste; export_docx.cpp)
+bool clipboardImageToPngFile(App& app, HWND hwnd, const std::wstring& path);
+
 #endif  // TINTA_EXPORT_H

--- a/include/input.h
+++ b/include/input.h
@@ -23,5 +23,7 @@ void navigateForward(App& app, HWND hwnd);
 std::wstring clipboardLine(HWND hwnd);
 void handleFileWatchTimer(App& app, HWND hwnd);
 void handleSelectScrollTimer(App& app, HWND hwnd);
+// Dwell timer fired over a local .md link: load the peek preview
+void handleLinkPeekTimer(App& app, HWND hwnd);
 
 #endif // TINTA_INPUT_H

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -81,6 +81,9 @@ enum ContextMenuItem {
 };
 void renderContextMenu(App& app);
 
+// Hovering a local .md link for a beat previews the target's first lines
+void renderLinkPeek(App& app);
+
 // Image lightbox (click an inline image)
 void openLightbox(App& app, ID2D1Bitmap* bitmap);
 void closeLightbox(App& app);

--- a/include/print.h
+++ b/include/print.h
@@ -40,4 +40,10 @@ void printPreviewSetFormat(App& app, int paper, bool landscape);
 // the same layout and pagination as printing. Returns the page count.
 int printDebugPages(App& app, const std::wstring& outDir);
 
+// Link peek: renders the top of another markdown file at the live theme
+// into a 2x bitmap (caller releases). heightDips shrinks to the target's
+// content height when the document is shorter than the request.
+ID2D1Bitmap* renderPeekBitmap(App& app, const std::wstring& path,
+                              float widthDips, float& heightDips);
+
 #endif // TINTA_PRINT_H

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -10,6 +10,9 @@
 #include "i18n.h"
 #include "input.h"
 
+#include "export.h"
+
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <algorithm>
@@ -1506,6 +1509,41 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 return;
             case 'V': {
                 std::wstring paste = editorGetClipboard(hwnd);
+                // A bitmap without text (a screenshot) saves as PNG beside
+                // the document and pastes as its markdown link
+                if (paste.empty() && !app.currentFile.empty() &&
+                    IsClipboardFormatAvailable(CF_BITMAP)) {
+                    namespace fs = std::filesystem;
+                    fs::path doc(toWide(app.currentFile));
+                    std::wstring stem = doc.stem().wstring();
+                    std::wstring name;
+                    fs::path target;
+                    for (int i = 1; i < 100; i++) {
+                        wchar_t suffix[24];
+                        swprintf_s(suffix, _countof(suffix),
+                                   L"-img-%02d.png", i);
+                        std::wstring candidate = stem + suffix;
+                        fs::path p = doc.parent_path() / candidate;
+                        std::error_code ec;
+                        if (!fs::exists(p, ec)) {
+                            name = candidate;
+                            target = p;
+                            break;
+                        }
+                    }
+                    if (!name.empty() &&
+                        clipboardImageToPngFile(app, hwnd,
+                                                target.wstring())) {
+                        std::wstring linkName = name;
+                        size_t sp = 0;  // spaces break the link target
+                        while ((sp = linkName.find(L' ', sp)) !=
+                               std::wstring::npos) {
+                            linkName.replace(sp, 1, L"%20");
+                            sp += 3;
+                        }
+                        paste = L"![image](" + linkName + L")";
+                    }
+                }
                 if (!paste.empty()) {
                     if (app.editorHasSelection) editorDeleteSelection(app);
                     size_t before = app.editorCursorPos;

--- a/src/export_docx.cpp
+++ b/src/export_docx.cpp
@@ -1509,3 +1509,32 @@ bool copyDiagramImage(App& app, HWND hwnd, const std::string& sourceUtf8) {
     CloseClipboard();
     return ok;
 }
+
+// Ctrl+V in the editor with a bitmap on the clipboard: encode it as PNG
+// into the given file (screenshots land beside the document)
+bool clipboardImageToPngFile(App& app, HWND hwnd, const std::wstring& path) {
+    if (!IsClipboardFormatAvailable(CF_BITMAP) || !app.wicFactory) {
+        return false;
+    }
+    if (!OpenClipboard(hwnd)) return false;
+    bool ok = false;
+    if (HBITMAP hbm = (HBITMAP)GetClipboardData(CF_BITMAP)) {
+        IWICBitmap* bitmap = nullptr;
+        if (SUCCEEDED(app.wicFactory->CreateBitmapFromHBITMAP(
+                hbm, nullptr, WICBitmapIgnoreAlpha, &bitmap))) {
+            UINT w = 0, h = 0;
+            bitmap->GetSize(&w, &h);
+            std::string png = encodeWicPng(app, bitmap, w, h);
+            bitmap->Release();
+            if (!png.empty()) {
+                std::ofstream out(path, std::ios::binary | std::ios::trunc);
+                if (out) {
+                    out.write(png.data(), (std::streamsize)png.size());
+                    ok = out.good();
+                }
+            }
+        }
+    }
+    CloseClipboard();
+    return ok;
+}

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -34,6 +34,16 @@ static const App::TaskRect* taskRectAt(const App& app);
 static bool tableCopyButtonAt(const App& app, int mouseX, int mouseY);
 static bool diagramPngButtonAt(const App& app, int mouseX, int mouseY);
 
+// Drops the link-peek popup and its rendered bitmap
+static void clearLinkPeek(App& app) {
+    app.linkPeekActive = false;
+    app.linkPeekUrl.clear();
+    if (app.linkPeekBitmap) {
+        app.linkPeekBitmap->Release();
+        app.linkPeekBitmap = nullptr;
+    }
+}
+
 // Inline image under the document point, or nullptr (viewer lightbox)
 static const App::LayoutBitmap* layoutBitmapAt(const App& app, float docX,
                                                float docY) {
@@ -275,6 +285,7 @@ bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
     annotationsParseSource(app);
     if (app.annotEditorOpen) annotationEditorCancel(app);
     if (app.showLightbox) closeLightbox(app);
+    clearLinkPeek(app);
 
     // Reading position memory (#77): keep the old document's position,
     // resume the new one's
@@ -762,6 +773,13 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             std::max(0.2f, std::min(app.lightboxZoom * factor, 10.0f));
         InvalidateRect(hwnd, nullptr, FALSE);
         return;
+    }
+
+    // Scrolling moves the document under a stationary cursor: drop any
+    // link peek so it cannot go stale
+    if (app.linkPeekActive || !app.linkPeekUrl.empty()) {
+        clearLinkPeek(app);
+        KillTimer(hwnd, TIMER_LINK_PEEK);
     }
 
     // Theme editor: wheel scrolls the font list
@@ -1271,12 +1289,29 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
 
     // Check link hover
     std::string prevHoveredLink = app.hoveredLink;
+    D2D1_RECT_F hoveredLinkBounds{};
     app.hoveredLink.clear();
     for (const auto& lr : app.linkRects) {
         if (docX >= lr.bounds.left && docX <= lr.bounds.right &&
             docY >= lr.bounds.top && docY <= lr.bounds.bottom) {
             app.hoveredLink = lr.url;
+            hoveredLinkBounds = lr.bounds;
             break;
+        }
+    }
+
+    // Link peek: dwelling on a local .md link arms the preview timer
+    if (app.hoveredLink != prevHoveredLink) {
+        clearLinkPeek(app);
+        bool peekable = !app.editMode &&
+                        (app.hoveredLink.rfind("fileref-ok:", 0) == 0 ||
+                         app.hoveredLink.rfind("wiki:", 0) == 0);
+        if (peekable) {
+            app.linkPeekUrl = app.hoveredLink;
+            app.linkPeekAnchorDoc = hoveredLinkBounds;
+            SetTimer(hwnd, TIMER_LINK_PEEK, 450, nullptr);
+        } else {
+            KillTimer(hwnd, TIMER_LINK_PEEK);
         }
     }
 
@@ -3523,6 +3558,67 @@ void handleDropFiles(App& app, HWND hwnd, WPARAM wParam) {
     }
     if (activated) InvalidateRect(hwnd, nullptr, FALSE);
     DragFinish(hDrop);
+}
+
+void handleLinkPeekTimer(App& app, HWND hwnd) {
+    KillTimer(hwnd, TIMER_LINK_PEEK);
+    if (app.linkPeekUrl.empty() || app.hoveredLink != app.linkPeekUrl) return;
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    fs::path target;
+    if (app.linkPeekUrl.rfind("fileref-ok:", 0) == 0) {
+        target = toWide(app.linkPeekUrl.substr(11));
+    } else if (app.linkPeekUrl.rfind("wiki:", 0) == 0 &&
+               !app.currentFile.empty()) {
+        std::wstring t = toWide(app.linkPeekUrl.substr(5));
+        fs::path dir = fs::path(toWide(app.currentFile)).parent_path();
+        if (fs::exists(dir / t, ec)) {
+            target = dir / t;
+        } else if (fs::exists(dir / (t + L".md"), ec)) {
+            target = dir / (t + L".md");
+        } else if (fs::exists(dir / (t + L".markdown"), ec)) {
+            target = dir / (t + L".markdown");
+        }
+    }
+    if (target.empty() || !fs::exists(target, ec)) return;
+
+    // Place the panel to the right of the link, never past the right
+    // edge; when the link leaves no room there, right-align it instead
+    float viewX = documentViewportX(app);
+    float chrome = chromeTopHeight(app);
+    float rightLimit = viewX + documentViewportWidth(app) - dpi(app, 22.0f);
+    float anchorRight =
+        app.linkPeekAnchorDoc.right - app.scrollX + viewX + dpi(app, 14.0f);
+    float anchorTop = app.linkPeekAnchorDoc.top - app.scrollY;
+    float maxW = dpi(app, 520.0f);
+    float h = std::min(dpi(app, 460.0f),
+                       (float)app.height - chrome - dpi(app, 24.0f));
+    float w = rightLimit - anchorRight;
+    float px;
+    if (w >= dpi(app, 300.0f)) {
+        w = std::min(w, maxW);
+        px = anchorRight;
+    } else {
+        w = std::min(maxW, rightLimit - viewX - dpi(app, 22.0f));
+        px = rightLimit - w;
+    }
+    float py = std::max(chrome + dpi(app, 10.0f),
+                        std::min(anchorTop - dpi(app, 30.0f),
+                                 (float)app.height - h - dpi(app, 12.0f)));
+    app.linkPeekPanel = D2D1::RectF(px, py, px + w, py + h);
+
+    float titleH = dpi(app, 22.0f);
+    float contentH = h - titleH - 2.0f;
+    ID2D1Bitmap* bitmap =
+        renderPeekBitmap(app, target.wstring(), w - 2.0f, contentH);
+    if (!bitmap) return;
+    // The render may have shrunk to the target's real height
+    app.linkPeekPanel.bottom = py + titleH + contentH + 2.0f;
+    if (app.linkPeekBitmap) app.linkPeekBitmap->Release();
+    app.linkPeekBitmap = bitmap;
+    app.linkPeekTitle = target.filename().wstring();
+    app.linkPeekActive = true;
+    InvalidateRect(hwnd, nullptr, FALSE);
 }
 
 void handleFileWatchTimer(App& app, HWND hwnd) {

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -892,6 +892,9 @@ render_document:
     // Review annotations: text tint, marker rail, hover preview (#126)
     renderAnnotations(app);
 
+    // Link peek popup (dwell over a local .md link)
+    renderLinkPeek(app);
+
     // Localized copy notification with fade out.
     if (app.showCopiedNotification) {
         auto now = std::chrono::steady_clock::now();
@@ -1358,6 +1361,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             return 0;
 
         case WM_TIMER:
+            if (wParam == TIMER_LINK_PEEK && app) handleLinkPeekTimer(*app, hwnd);
             if (wParam == TIMER_FILE_WATCH && app) handleFileWatchTimer(*app, hwnd);
             if (wParam == 2 && app) editorReparse(*app); // TIMER_EDITOR_REPARSE
             if (wParam == TIMER_CURSOR_BLINK && app) {

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -898,6 +898,53 @@ void renderToc(App& app) {
     }
 }
 
+// --- Link peek ---
+
+void renderLinkPeek(App& app) {
+    if (!app.linkPeekActive || !app.linkPeekBitmap ||
+        app.hoveredLink != app.linkPeekUrl || !app.folderBrowserFormat) {
+        return;
+    }
+    const D2D1_RECT_F& p = app.linkPeekPanel;
+    float titleH = dpi(app, 22.0f);
+
+    // Soft drop shadow so the page reads as floating above the document
+    D2D1_COLOR_F shadow = D2D1::ColorF(0.0f, 0.0f, 0.0f, 0.28f);
+    app.brush->SetColor(shadow);
+    app.renderTarget->FillRoundedRectangle(
+        D2D1::RoundedRect(D2D1::RectF(p.left + 4, p.top + 5, p.right + 4,
+                                      p.bottom + 5),
+                          4, 4),
+        app.brush);
+
+    D2D1_COLOR_F bg = app.theme.isDark ? hexColor(0x1E1E1E, 1.0f)
+                                       : hexColor(0xFCFCFA, 1.0f);
+    app.brush->SetColor(bg);
+    app.renderTarget->FillRectangle(p, app.brush);
+
+    // Title strip: the target's file name
+    D2D1_COLOR_F titleColor = app.theme.accent;
+    app.brush->SetColor(titleColor);
+    app.renderTarget->DrawText(
+        app.linkPeekTitle.c_str(), (UINT32)app.linkPeekTitle.size(),
+        app.folderBrowserFormat,
+        D2D1::RectF(p.left + dpi(app, 10.0f), p.top + dpi(app, 3.0f),
+                    p.right - dpi(app, 10.0f), p.top + titleH),
+        app.brush);
+
+    // The rendered page
+    app.renderTarget->DrawBitmap(
+        app.linkPeekBitmap,
+        D2D1::RectF(p.left + 1.0f, p.top + titleH, p.right - 1.0f,
+                    p.bottom - 1.0f),
+        1.0f, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, nullptr);
+
+    D2D1_COLOR_F border = app.theme.accent;
+    border.a = 0.55f;
+    app.brush->SetColor(border);
+    app.renderTarget->DrawRectangle(p, app.brush, 1.0f);
+}
+
 // --- Image lightbox ---
 
 void openLightbox(App& app, ID2D1Bitmap* bitmap) {

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -1,8 +1,12 @@
 #include "print.h"
 #include "render.h"
 #include "d2d_init.h"
+#include "document.h"
 #include "editor.h"
 #include "utils.h"
+
+#include <fstream>
+#include <sstream>
 
 #include <commdlg.h>
 #include <documenttarget.h>
@@ -905,4 +909,71 @@ bool exportPdfFile(App& app, const std::wstring& path) {
     fileStream->Commit(STGC_DEFAULT);
     fileStream->Release();
     return ok;
+}
+
+// Link peek: renders the top of another markdown file at the live theme
+// into a 2x bitmap. The document swap rides the print-layout save/restore
+// (the palette switch is undone so the peek matches the screen).
+ID2D1Bitmap* renderPeekBitmap(App& app, const std::wstring& path,
+                              float widthDips, float& heightDips) {
+    if (!app.deviceContext || !app.root) return nullptr;
+    std::ifstream file(path);
+    if (!file) return nullptr;
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    auto parsed = parseDocument(app.parser, buffer.str(), path);
+    if (!parsed.success || !parsed.root) return nullptr;
+
+    qmd::ElementPtr savedRoot = app.root;
+    std::string savedFile = app.currentFile;
+    SavedView saved{};
+    enterPrintLayout(app, saved);
+    app.theme = saved.theme;  // keep the screen palette, not print white
+    updateTextFormats(app);
+    app.root = parsed.root;
+    app.currentFile = toUtf8(path);  // relative images resolve at the target
+    layoutAtPrintWidth(app, widthDips);
+    // Short targets shrink the peek to their real height
+    heightDips = std::max(dpi(app, 60.0f),
+                          std::min(heightDips, app.contentHeight + 6.0f));
+
+    ID2D1Device* device = nullptr;
+    app.deviceContext->GetDevice(&device);
+    ID2D1DeviceContext* dc = nullptr;
+    ID2D1Bitmap1* bitmap = nullptr;
+    ID2D1Bitmap* result = nullptr;
+    if (device && SUCCEEDED(device->CreateDeviceContext(
+                      D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &dc))) {
+        D2D1_BITMAP_PROPERTIES1 props = D2D1::BitmapProperties1(
+            D2D1_BITMAP_OPTIONS_TARGET,
+            D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM,
+                              D2D1_ALPHA_MODE_PREMULTIPLIED),
+            192.0f, 192.0f);
+        D2D1_SIZE_U px = D2D1::SizeU((UINT32)(widthDips * 2.0f),
+                                     (UINT32)(heightDips * 2.0f));
+        if (SUCCEEDED(dc->CreateBitmap(px, nullptr, 0, &props, &bitmap))) {
+            dc->SetTarget(bitmap);
+            dc->BeginDraw();
+            dc->Clear(app.theme.background);
+            ID2D1SolidColorBrush* brush = nullptr;
+            dc->CreateSolidColorBrush(D2D1::ColorF(0, 0, 0), &brush);
+            if (brush) {
+                drawDocumentRange(app, dc, brush, 0.0f, heightDips, 0.0f,
+                                  0.0f);
+                brush->Release();
+            }
+            if (SUCCEEDED(dc->EndDraw())) {
+                result = bitmap;
+                bitmap = nullptr;
+            }
+        }
+    }
+    if (bitmap) bitmap->Release();
+    if (dc) dc->Release();
+    if (device) device->Release();
+
+    app.root = savedRoot;
+    app.currentFile = savedFile;
+    leavePrintLayout(app, saved);
+    return result;
 }

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -928,14 +928,24 @@ ID2D1Bitmap* renderPeekBitmap(App& app, const std::wstring& path,
     std::string savedFile = app.currentFile;
     SavedView saved{};
     enterPrintLayout(app, saved);
-    app.theme = saved.theme;  // keep the screen palette, not print white
+    // The peek must look exactly like the screen: keep the palette, the
+    // DPI scale, and the zoom instead of the print defaults; the reading
+    // column stays full width inside the small panel
+    app.theme = saved.theme;
+    app.contentScale = saved.contentScale;
+    app.zoomFactor = saved.zoomFactor;
+    int savedPct = app.readingWidthPct;
+    app.readingWidthPct = 100;
     updateTextFormats(app);
     app.root = parsed.root;
     app.currentFile = toUtf8(path);  // relative images resolve at the target
     layoutAtPrintWidth(app, widthDips);
-    // Short targets shrink the peek to their real height
+    // The layout starts below the (invisible) title strip; the peek slice
+    // begins there and shrinks to short targets
+    float topPad = chromeTopHeight(app);
     heightDips = std::max(dpi(app, 60.0f),
-                          std::min(heightDips, app.contentHeight + 6.0f));
+                          std::min(heightDips,
+                                   app.contentHeight - topPad + dpi(app, 8.0f)));
 
     ID2D1Device* device = nullptr;
     app.deviceContext->GetDevice(&device);
@@ -953,13 +963,14 @@ ID2D1Bitmap* renderPeekBitmap(App& app, const std::wstring& path,
                                      (UINT32)(heightDips * 2.0f));
         if (SUCCEEDED(dc->CreateBitmap(px, nullptr, 0, &props, &bitmap))) {
             dc->SetTarget(bitmap);
+            dc->SetDpi(192.0f, 192.0f);  // 1 DIP = 2px: the 2x crispness
             dc->BeginDraw();
             dc->Clear(app.theme.background);
             ID2D1SolidColorBrush* brush = nullptr;
             dc->CreateSolidColorBrush(D2D1::ColorF(0, 0, 0), &brush);
             if (brush) {
-                drawDocumentRange(app, dc, brush, 0.0f, heightDips, 0.0f,
-                                  0.0f);
+                drawDocumentRange(app, dc, brush, topPad, topPad + heightDips,
+                                  0.0f, 0.0f);
                 brush->Release();
             }
             if (SUCCEEDED(dc->EndDraw())) {
@@ -974,6 +985,7 @@ ID2D1Bitmap* renderPeekBitmap(App& app, const std::wstring& path,
 
     app.root = savedRoot;
     app.currentFile = savedFile;
+    app.readingWidthPct = savedPct;
     leavePrintLayout(app, saved);
     return result;
 }


### PR DESCRIPTION
The last two from the QoL list.

## Paste images into notes
Ctrl+V in the editor with a bitmap on the clipboard (a screenshot) saves it as `<stem>-img-NN.png` beside the document and inserts the markdown link. Clipboard text still takes priority; spaces in the generated name are percent-encoded so the link parses.

## Link peek, fully rendered
Dwell on a live `.md` reference or wiki link for half a second and a large preview of the target opens beside it - not extracted text, the actual page: parsed and laid out at the current theme through the print-layout machinery (`drawDocumentRange` into a 2x bitmap, palette switch undone so it matches the screen). The panel sits to the right of the link and never crosses the right edge; when the link leaves no room it right-aligns instead, and short targets shrink the panel to their real height. Scrolling, leaving the link, or switching documents dismisses it.

Verified interactively across short and long targets, plus placement clamping. All test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)