### PR TITLE
Bump version to 3.2.0, refresh release notes and README claims

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,14 +45,36 @@ jobs:
           body: |
             ## Tinta v${{ steps.version.outputs.VERSION }}
 
-            **Markdown, distilled.**
-
-            A fast, lightweight Markdown and Mermaid reader for Windows.
+            **Markdown, distilled.** The review release: annotations, file references, and a dozen quality-of-life touches for reading (and reviewing) agent-written Markdown.
 
             ### Installation
             - Easiest: `winget install "Tinta Markdown Viewer" -s msstore` (Store-signed, no security prompts, auto-updates), or the [Microsoft Store page](https://apps.microsoft.com/detail/9MZ5MZ3L9RKF)
             - Portable: download `tinta.exe` below and run it (SmartScreen may ask: "More info", then "Run anyway")
             - Optionally run `tinta.exe /register` to register Markdown and Mermaid files
+
+            ### Review annotations (#126)
+            - Select text and press `A` (or right-click, Annotate) to attach a note; annotated text gets a soft tint and a square on a rail beside the scrollbar, with a line pointing at the passage
+            - Notes are stored as invisible HTML comments in the file itself, so nothing else renders them and the file stays the only source of truth
+            - Hover a square for a preview beside the section; click it (or the tinted text) to edit or delete; off-screen annotations park at the rail's edges and clicking a parked square jumps to its text
+            - The copy-for-agent button puts the file path, a task instruction, and every remark with line numbers on the clipboard: paste it into any coding agent, and as the agent fixes items and deletes the comments, the squares vanish live
+
+            ### File references (#127)
+            - Plain-text paths like `docs/plan.md` in agent-written notes become real links: existing targets show the link color with a dashed underline and open as a tab on click; missing targets render as faded, inert ghosts
+            - `[text](target.md)` links to local files get the same live/missing treatment and open as tabs instead of shelling out
+            - Mouse back/forward (or Alt+Left / Alt+Right) walks your link jumps with exact scroll restore, and reopens the document if its tab was closed
+
+            ### Link peek
+            - Rest the pointer on a local `.md` or wiki link for half a second and the target opens fully rendered in a panel beside the link - headings, tables, diagrams, your theme - without opening a tab
+
+            ### Quality of life
+            - Pin on top: a pushpin in the title bar keeps the window above every other app
+            - Image lightbox: click any inline image to view it full size - wheel zooms, drag pans, Esc closes
+            - Table of contents follows your reading position, and typing while it is open filters the headings (Enter jumps to the first match)
+            - Find-in-page paints every match as a tick on the scrollbar, the current match brighter
+            - Tables grow a Copy TSV button on hover: paste straight into Excel or Sheets as a grid
+            - Diagrams grow an Image button: a crisp 2x PNG lands on the clipboard for slides and chats
+            - Paste a screenshot in edit mode and it saves as a PNG beside the document with the Markdown link inserted
+            - The Annotate key is rebindable like every other shortcut, in both keymap profiles
 
             ### What's included
             - Export as HTML, DOCX, or PDF from the context menu
@@ -60,7 +82,7 @@ jobs:
             - Tabbed interface with drag, session restore, and a tab context menu
             - 10 beautiful themes (5 light, 5 dark) plus custom themes
             - Hardware-accelerated rendering via Direct2D
-            - Single portable executable about 1.8 MB, no dependencies
+            - Single portable executable about 1.9 MB, no dependencies
           files: build/Release/tinta.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(tinta VERSION 3.1.0 LANGUAGES C CXX)
+project(tinta VERSION 3.2.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <br>
 
-Tinta is a **fast, lightweight Markdown and Mermaid viewer for Windows**, built with Direct2D and DirectWrite for hardware-accelerated rendering. A single native executable of about 1.8 MB that opens instantly — no Electron, no web engine, no installer.
+Tinta is a **fast, lightweight Markdown and Mermaid viewer for Windows**, built with Direct2D and DirectWrite for hardware-accelerated rendering. A single native executable of about 1.9 MB that opens instantly — no Electron, no web engine, no installer.
 
 <p align="center">
   <img src="https://tinta.cc/img/screenshots/paper.png" width="49%" alt="Tinta markdown viewer on Windows — Paper light theme">
@@ -56,7 +56,7 @@ Most markdown apps ship an entire browser to render text. Tinta uses the GPU-acc
 |  | Tinta | Typora | Obsidian | VS Code |
 |---|---|---|---|---|
 | Startup | **<100 ms** | ~1.5 s | ~3 s | ~2 s |
-| Install size | **~1.8 MB** | ~90 MB | ~250 MB | ~350 MB |
+| Install size | **~1.9 MB** | ~90 MB | ~250 MB | ~350 MB |
 | Runtime | **Native Direct2D** | Electron | Electron | Electron |
 
 It's a viewer first: perfect as the double-click default for `.md` and `.mmd` files, for reading documentation and diagrams — with an edit mode when you need it.
@@ -71,12 +71,20 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 - **Focused editing** - Hide the preview pane while writing (Ctrl+E)
 - **Native Mermaid diagrams** - 22 diagram families, from flowcharts with subgraphs through sequence, class, state, ER, gantt, and pie to C4, sankey, kanban, and radar - rendered without a web engine
 - **Export as HTML, DOCX, or PDF** - Right-click and pick "Export as..." for a self-contained web page, a Word document that opens natively, or a vector PDF; diagrams and math come along in every format
+- **Review annotations** - Select text and press `A` to attach a note, stored as an invisible HTML comment in the file itself. Annotated passages get a tint and a marker rail beside the scrollbar; hover previews, click edits, and a copy-for-agent button turns the whole review into a paste-ready task list for any coding agent - as the agent fixes items and deletes the comments, the marks vanish live
+- **File references** - Plain-text paths like `docs/plan.md` become real links: live targets open as tabs, missing ones render as faded ghosts. Mouse back/forward (or Alt+arrows) walks your jumps with exact scroll restore
+- **Link peek** - Rest the pointer on a local `.md` or wiki link and the target appears fully rendered in a panel beside it, no tab opened
+- **Image lightbox** - Click any inline image to view it full size: wheel zooms, drag pans, Esc closes
+- **Copy tables as TSV** - Hover a table for a copy button that pastes into Excel or Sheets as a real grid
+- **Copy diagrams as images** - Hover a diagram for an Image button that puts a crisp 2x PNG on the clipboard
+- **Paste screenshots** - Ctrl+V a bitmap in edit mode and it saves as a PNG beside the document with the link inserted
+- **Pin on top** - A pushpin in the title bar keeps the window above every other app
 - **Rich tables** - Tables with bold, italic, code, and clickable links in cells
 - **Tabs** - Win11 Notepad-style tabs in the title bar: files opened from Explorer join the window as tabs, Ctrl+Tab cycles, Ctrl+W closes, middle-click closes, Ctrl+T opens the file browser into a new tab, unsaved buffers show a dot, and dragging reorders tabs. Right-click a tab for close operations (close, close all but this, close all to the left/right) plus copy path and reveal in Explorer. Pulling a tab out of the strip floats it as a card: drop it on open space for a new window (which keeps the tab row), or onto another Tinta window to move it there — and dropping a single-file window onto a tab strip merges it back. Single-file windows stay tabless; turn the Explorer behavior off with the "Open files in tabs" setting
 - **Folder browser** - Press B to browse and open Markdown or Mermaid files (Ctrl+click a file to open it in a new tab)
-- **Table of contents** - Press Tab to see document headings, click to jump
+- **Table of contents** - Press Tab to see document headings, click to jump; the panel follows your reading position, and typing filters the headings
 - **Edit mode** - Press `:` to edit markdown with live preview, search works in editor too
-- **Search** - Find text with F or Ctrl+F, cycle through matches with Enter
+- **Search** - Find text with F or Ctrl+F, cycle through matches with Enter; every match shows as a tick on the scrollbar
 - **Persistent settings** - Remembers your theme, zoom level, and window position
 - **Localized interface** - English, Simplified Chinese, Japanese, Korean, German, French, and Italian UI; follows Windows or a chosen language
 - **Text selection & copy** - Select text and copy to clipboard
@@ -89,7 +97,8 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 | Key | Action |
 |-----|--------|
 | `B` | Toggle folder browser |
-| `Tab` | Toggle table of contents |
+| `Tab` | Toggle table of contents (type to filter, Enter jumps) |
+| `A` | Annotate the selected text |
 | `F` / `Ctrl+F` | Open search |
 | `Enter` | Next search match |
 | `ESC` | Close overlay / Quit |
@@ -99,6 +108,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 | `Ctrl+A` | Select all text |
 | `Ctrl+Scroll` | Zoom in/out |
 | `Arrow keys` / `J/K` | Scroll |
+| `Mouse back/forward` / `Alt+←/→` | Walk link jumps with scroll restore |
 | `Page Up/Down` | Page scroll |
 | `Home/End` | Jump to start/end |
 | `:` | Enter edit mode |


### PR DESCRIPTION
Release prep for v3.2.0, the review release.

- CMake version 3.1.0 -> 3.2.0
- Release notes in the build workflow rewritten to cover everything since 3.1.0: review annotations (#126), file references + mouse back/forward (#127), rendered link peek, pin on top, search marks on the scrollbar, table copy as TSV, diagram copy as image, TOC scroll-spy with typed filtering, image lightbox, and screenshot paste in edit mode
- README: new feature bullets, `A` and mouse/Alt navigation shortcut rows, size claims refreshed to ~1.9 MB (current exe: 2,020,864 bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)