### PR TITLE
Per-document zoom memory, emoji shortcodes, fit-to-width for tables and diagrams

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -163,8 +163,9 @@ struct Settings {
     // Last session's open tabs, restored on the next plain launch
     std::vector<std::string> sessionTabs;
     int sessionActive = 0;
-    // Reading positions: most-recent-first, capped (#77)
-    struct ReadingPosition { std::string path; float scrollY; };
+    // Reading positions: most-recent-first, capped (#77). zoom = 0 means
+    // "no per-document zoom": the document keeps the current zoom.
+    struct ReadingPosition { std::string path; float scrollY; float zoom = 0.0f; };
     std::vector<ReadingPosition> readingPositions;
     // [Keys] overrides from settings.ini: action name -> key name (#77)
     std::vector<std::pair<std::string, std::string>> keyOverrides;
@@ -727,6 +728,9 @@ struct App {
         D2D1_RECT_F bounds;       // Full background rect in document coordinates
         std::wstring codeText;    // The code content (diagram source for diagrams)
         bool isDiagram = false;   // adds the copy-as-image button
+        unsigned fitKey = 0;      // per-layout ordinal for the fit toggle
+        bool fitCandidate = false;
+        bool fitActive = false;
     };
     std::vector<CodeBlockInfo> codeBlocks;
     int hoveredCodeBlock = -1;
@@ -735,9 +739,18 @@ struct App {
     struct TableInfo {
         D2D1_RECT_F bounds{};  // document coordinates
         std::wstring tsv;      // cells joined by tabs, rows by newlines
+        unsigned fitKey = 0;   // per-layout ordinal for the fit toggle
+        bool fitCandidate = false;  // wider than the column at natural size
+        bool fitActive = false;
     };
     std::vector<TableInfo> tableRects;
     int hoveredTable = -1;
+
+    // Fit-to-width overrides for oversized tables/diagrams, keyed by their
+    // per-layout ordinal (cleared when the document changes)
+    std::vector<unsigned> fitBlocks;
+    unsigned layoutTableSeq = 0;
+    unsigned layoutDiagramSeq = 0;
 
     // Text bounds - tracked for cursor changes and selection (document coordinates)
     struct TextRect {

--- a/include/settings.h
+++ b/include/settings.h
@@ -9,9 +9,13 @@ Settings loadSettings();
 
 // Reading position memory (#77): most-recent-first list capped in remember.
 // The persist/lookup helpers load and save settings.ini themselves.
-void rememberReadingPosition(Settings& settings, const std::string& path, float scrollY);
-void persistReadingPosition(const std::string& path, float scrollY);
+void rememberReadingPosition(Settings& settings, const std::string& path,
+                             float scrollY, float zoom = 0.0f);
+void persistReadingPosition(const std::string& path, float scrollY,
+                            float zoom = 0.0f);
 float findReadingPosition(const Settings& settings, const std::string& path);
+// Per-document zoom, or 0 when the document has none stored
+float findReadingZoom(const Settings& settings, const std::string& path);
 
 // User-remappable single-key actions (#77), written to settings.ini as a
 // [Keys] section. Char actions trigger via WM_CHAR (edit ':', help '?');

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -33,6 +33,9 @@ static HCURSOR cursorSizeWE = LoadCursor(nullptr, IDC_SIZEWE);
 static const App::TaskRect* taskRectAt(const App& app);
 static bool tableCopyButtonAt(const App& app, int mouseX, int mouseY);
 static bool diagramPngButtonAt(const App& app, int mouseX, int mouseY);
+static bool tableFitButtonAt(const App& app, int mouseX, int mouseY);
+static bool diagramFitButtonAt(const App& app, int mouseX, int mouseY);
+static void toggleFitBlock(App& app, HWND hwnd, unsigned key);
 
 // Drops the link-peek popup and its rendered bitmap
 static void clearLinkPeek(App& app) {
@@ -286,11 +289,12 @@ bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
     if (app.annotEditorOpen) annotationEditorCancel(app);
     if (app.showLightbox) closeLightbox(app);
     clearLinkPeek(app);
+    app.fitBlocks.clear();
 
     // Reading position memory (#77): keep the old document's position,
     // resume the new one's
     if (!app.currentFile.empty()) {
-        persistReadingPosition(app.currentFile, app.scrollY);
+        persistReadingPosition(app.currentFile, app.scrollY, app.zoomFactor);
     }
 
     app.root = result.root;
@@ -302,7 +306,18 @@ bool openDocumentInViewer(App& app, const std::wstring& fullPath) {
     app.scrollX = 0;
     app.targetScrollY = 0;
     app.targetScrollX = 0;
-    app.pendingScrollRestore = findReadingPosition(loadSettings(), app.currentFile);
+    {
+        Settings stored = loadSettings();
+        app.pendingScrollRestore = findReadingPosition(stored, app.currentFile);
+        // Per-document zoom (#zoom-memory): a document remembered at a
+        // different zoom reopens there
+        float zoom = findReadingZoom(stored, app.currentFile);
+        if (zoom > 0.0f && fabsf(zoom - app.zoomFactor) > 0.01f) {
+            app.zoomFactor = zoom;
+            app.appliedZoomFactor = zoom;
+            updateTextFormats(app);
+        }
+    }
     app.focusMermaidOnNextLayout = isMermaidDocumentPath(fullPath);
     app.contentHeight = 0;
     app.verticalScrollbarVisible = false;
@@ -1400,11 +1415,14 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         float btnW = dpi(app, 72.0f);
         float btnH = dpi(app, 26.0f);
         float btnPad = 8.0f * app.contentScale * app.zoomFactor;
-        float btnX = cb.bounds.right - btnW - btnPad;
+        float rightEdge = std::min(cb.bounds.right,
+                                   app.scrollX + documentViewportWidth(app));
+        float btnX = rightEdge - btnW - btnPad;
         float btnY = cb.bounds.top + btnPad;
         if ((docX >= btnX && docX <= btnX + btnW &&
              docY >= btnY && docY <= btnY + btnH) ||
-            diagramPngButtonAt(app, app.mouseX, app.mouseY)) {
+            diagramPngButtonAt(app, app.mouseX, app.mouseY) ||
+            diagramFitButtonAt(app, app.mouseX, app.mouseY)) {
             SetCursor(cursorHand);
         } else if (app.overText) {
             SetCursor(cursorIBeam);
@@ -1412,7 +1430,8 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
             SetCursor(cursorArrow);
         }
     } else if (app.hoveredTable >= 0 &&
-               tableCopyButtonAt(app, app.mouseX, app.mouseY)) {
+               (tableCopyButtonAt(app, app.mouseX, app.mouseY) ||
+                tableFitButtonAt(app, app.mouseX, app.mouseY))) {
         SetCursor(cursorHand);
     } else if (!app.hoveredLink.empty()) {
         SetCursor(cursorHand);
@@ -2194,7 +2213,9 @@ static bool codeCopyButtonAt(const App& app, int mouseX, int mouseY) {
     float btnW = dpi(app, 72.0f);
     float btnH = dpi(app, 26.0f);
     float btnPad = 8.0f * app.contentScale * app.zoomFactor;
-    float btnX = cb.bounds.right - btnW - btnPad;
+    float rightEdge =
+        std::min(cb.bounds.right, app.scrollX + documentViewportWidth(app));
+    float btnX = rightEdge - btnW - btnPad;
     float btnY = cb.bounds.top + btnPad;
     return docX >= btnX && docX <= btnX + btnW &&
            docY >= btnY && docY <= btnY + btnH;
@@ -2215,7 +2236,9 @@ static bool diagramPngButtonAt(const App& app, int mouseX, int mouseY) {
     float btnW = dpi(app, 72.0f);
     float btnH = dpi(app, 26.0f);
     float btnPad = 8.0f * app.contentScale * app.zoomFactor;
-    float copyX = cb.bounds.right - btnW - btnPad;
+    float rightEdge =
+        std::min(cb.bounds.right, app.scrollX + documentViewportWidth(app));
+    float copyX = rightEdge - btnW - btnPad;
     float pngW = dpi(app, 52.0f);
     float pngX = copyX - pngW - dpi(app, 6.0f);
     float btnY = cb.bounds.top + btnPad;
@@ -2242,6 +2265,70 @@ static bool tableCopyButtonAt(const App& app, int mouseX, int mouseY) {
     float btnY = tb.bounds.top + btnPad;
     return docX >= btnX && docX <= btnX + btnW &&
            docY >= btnY && docY <= btnY + btnH;
+}
+
+// True when (mouseX, mouseY) is on the hovered diagram's fit-to-width
+// toggle (drawn left of the copy-as-image button)
+static bool diagramFitButtonAt(const App& app, int mouseX, int mouseY) {
+    if (app.hoveredCodeBlock < 0 ||
+        app.hoveredCodeBlock >= (int)app.codeBlocks.size()) {
+        return false;
+    }
+    const auto& cb = app.codeBlocks[app.hoveredCodeBlock];
+    if (!cb.isDiagram || !cb.fitCandidate) return false;
+    float previewOffsetX = documentViewportX(app);
+    float docX = (mouseX - previewOffsetX) + app.scrollX;
+    float docY = mouseY + app.scrollY;
+    float btnW = dpi(app, 72.0f);
+    float btnH = dpi(app, 26.0f);
+    float btnPad = 8.0f * app.contentScale * app.zoomFactor;
+    float rightEdge =
+        std::min(cb.bounds.right, app.scrollX + documentViewportWidth(app));
+    float copyX = rightEdge - btnW - btnPad;
+    float pngW = dpi(app, 52.0f);
+    float pngX = copyX - pngW - dpi(app, 6.0f);
+    float fitW = dpi(app, 44.0f);
+    float fitX = pngX - fitW - dpi(app, 6.0f);
+    float btnY = cb.bounds.top + btnPad;
+    return docX >= fitX && docX <= fitX + fitW &&
+           docY >= btnY && docY <= btnY + btnH;
+}
+
+// True when (mouseX, mouseY) is on the hovered table's fit-to-width
+// toggle (drawn left of the copy-as-TSV button)
+static bool tableFitButtonAt(const App& app, int mouseX, int mouseY) {
+    if (app.hoveredTable < 0 ||
+        app.hoveredTable >= (int)app.tableRects.size()) {
+        return false;
+    }
+    const auto& tb = app.tableRects[app.hoveredTable];
+    if (!tb.fitCandidate) return false;
+    float previewOffsetX = documentViewportX(app);
+    float docX = (mouseX - previewOffsetX) + app.scrollX;
+    float docY = mouseY + app.scrollY;
+    float btnW = dpi(app, 88.0f);
+    float btnH = dpi(app, 26.0f);
+    float btnPad = 8.0f * app.contentScale * app.zoomFactor;
+    float rightEdge =
+        std::min(tb.bounds.right, app.scrollX + documentViewportWidth(app));
+    float btnX = rightEdge - btnW - btnPad;
+    float fitW = dpi(app, 44.0f);
+    float fitX = btnX - fitW - dpi(app, 6.0f);
+    float btnY = tb.bounds.top + btnPad;
+    return docX >= fitX && docX <= fitX + fitW &&
+           docY >= btnY && docY <= btnY + btnH;
+}
+
+// Flip a table/diagram between natural size and fit-to-width and relayout
+static void toggleFitBlock(App& app, HWND hwnd, unsigned key) {
+    auto it = std::find(app.fitBlocks.begin(), app.fitBlocks.end(), key);
+    if (it != app.fitBlocks.end()) {
+        app.fitBlocks.erase(it);
+    } else {
+        app.fitBlocks.push_back(key);
+    }
+    app.layoutDirty = true;
+    InvalidateRect(hwnd, nullptr, FALSE);
 }
 
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
@@ -2678,6 +2765,10 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         app.hoveredCodeBlock = -1;
         app.selecting = false;
         InvalidateRect(hwnd, nullptr, FALSE);
+    } else if (diagramFitButtonAt(app, app.mouseX, app.mouseY)) {
+        toggleFitBlock(app, hwnd,
+                       app.codeBlocks[app.hoveredCodeBlock].fitKey);
+        app.selecting = false;
     } else if (diagramPngButtonAt(app, app.mouseX, app.mouseY)) {
         // Diagram image button: 2x raster to the clipboard
         if (copyDiagramImage(
@@ -2691,6 +2782,10 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         app.hoveredCodeBlock = -1;
         app.selecting = false;
         InvalidateRect(hwnd, nullptr, FALSE);
+    } else if (tableFitButtonAt(app, app.mouseX, app.mouseY)) {
+        toggleFitBlock(app, hwnd,
+                       app.tableRects[app.hoveredTable].fitKey);
+        app.selecting = false;
     } else if (tableCopyButtonAt(app, app.mouseX, app.mouseY)) {
         // Table copy button: cells joined by tabs paste into a
         // spreadsheet as a grid

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -575,7 +575,10 @@ render_document:
             float btnW = dpi(app, 72.0f);
             float btnH = dpi(app, 26.0f);
             float btnPad = 8.0f * app.contentScale * app.zoomFactor;
-            float btnX = cb.bounds.right - btnW - btnPad - app.scrollX;
+            // Blocks wider than the viewport keep their buttons reachable
+            float rightEdge = std::min(
+                cb.bounds.right, app.scrollX + documentViewportWidth(app));
+            float btnX = rightEdge - btnW - btnPad - app.scrollX;
             float btnY = cb.bounds.top + btnPad - app.scrollY;
 
             // Button background
@@ -610,6 +613,43 @@ render_document:
             if (cb.isDiagram) {
                 float pngW = dpi(app, 52.0f);
                 float pngX = btnX - pngW - dpi(app, 6.0f);
+
+                // Oversized diagrams add the fit-to-width toggle
+                if (cb.fitCandidate) {
+                    float fitW = dpi(app, 44.0f);
+                    float fitX = pngX - fitW - dpi(app, 6.0f);
+                    app.brush->SetColor(D2D1::ColorF(
+                        app.theme.isDark ? 0.3f : 0.85f,
+                        app.theme.isDark ? 0.3f : 0.85f,
+                        app.theme.isDark ? 0.3f : 0.85f,
+                        0.9f));
+                    app.renderTarget->FillRoundedRectangle(
+                        D2D1::RoundedRect(
+                            D2D1::RectF(fitX, btnY, fitX + fitW,
+                                        btnY + btnH), 4, 4),
+                        app.brush);
+                    app.brush->SetColor(D2D1::ColorF(
+                        app.theme.isDark ? 0.9f : 0.15f,
+                        app.theme.isDark ? 0.9f : 0.15f,
+                        app.theme.isDark ? 0.9f : 0.15f,
+                        1.0f));
+                    const wchar_t* fitLabel =
+                        cb.fitActive ? L"1:1" : L"Fit";
+                    IDWriteTextLayout* fitLayout = nullptr;
+                    app.dwriteFactory->CreateTextLayout(
+                        fitLabel, (UINT32)wcslen(fitLabel), app.codeFormat,
+                        fitW, btnH, &fitLayout);
+                    if (fitLayout) {
+                        fitLayout->SetTextAlignment(
+                            DWRITE_TEXT_ALIGNMENT_CENTER);
+                        fitLayout->SetParagraphAlignment(
+                            DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+                        app.renderTarget->DrawTextLayout(
+                            D2D1::Point2F(fitX, btnY), fitLayout,
+                            app.brush);
+                        fitLayout->Release();
+                    }
+                }
                 app.brush->SetColor(D2D1::ColorF(
                     app.theme.isDark ? 0.3f : 0.85f,
                     app.theme.isDark ? 0.3f : 0.85f,
@@ -683,6 +723,41 @@ render_document:
                 app.renderTarget->DrawTextLayout(
                     D2D1::Point2F(btnX, btnY), btnLayout, app.brush);
                 btnLayout->Release();
+            }
+
+            // Oversized tables add the fit-to-width toggle
+            if (tb.fitCandidate) {
+                float fitW = dpi(app, 44.0f);
+                float fitX = btnX - fitW - dpi(app, 6.0f);
+                app.brush->SetColor(D2D1::ColorF(
+                    app.theme.isDark ? 0.3f : 0.85f,
+                    app.theme.isDark ? 0.3f : 0.85f,
+                    app.theme.isDark ? 0.3f : 0.85f,
+                    0.9f));
+                app.renderTarget->FillRoundedRectangle(
+                    D2D1::RoundedRect(
+                        D2D1::RectF(fitX, btnY, fitX + fitW, btnY + btnH),
+                        4, 4),
+                    app.brush);
+                app.brush->SetColor(D2D1::ColorF(
+                    app.theme.isDark ? 0.9f : 0.15f,
+                    app.theme.isDark ? 0.9f : 0.15f,
+                    app.theme.isDark ? 0.9f : 0.15f,
+                    1.0f));
+                const wchar_t* fitLabel = tb.fitActive ? L"1:1" : L"Fit";
+                IDWriteTextLayout* fitLayout = nullptr;
+                app.dwriteFactory->CreateTextLayout(
+                    fitLabel, (UINT32)wcslen(fitLabel), app.codeFormat,
+                    fitW, btnH, &fitLayout);
+                if (fitLayout) {
+                    fitLayout->SetTextAlignment(
+                        DWRITE_TEXT_ALIGNMENT_CENTER);
+                    fitLayout->SetParagraphAlignment(
+                        DWRITE_PARAGRAPH_ALIGNMENT_CENTER);
+                    app.renderTarget->DrawTextLayout(
+                        D2D1::Point2F(fitX, btnY), fitLayout, app.brush);
+                    fitLayout->Release();
+                }
             }
             app.drawCalls++;
         }
@@ -1690,7 +1765,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.keyProfile = app->keyProfile;
                 settings.keyOverrides = app->keyOverrides;
                 if (!app->currentFile.empty()) {
-                    rememberReadingPosition(settings, app->currentFile, app->scrollY);
+                    rememberReadingPosition(settings, app->currentFile,
+                                            app->scrollY, app->zoomFactor);
                 }
 
                 // Get window placement for position/size/maximized state
@@ -2147,6 +2223,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     // editor at the top instead
     if (!startInEditMode && !app.currentFile.empty()) {
         app.pendingScrollRestore = findReadingPosition(savedSettings, app.currentFile);
+        // Per-document zoom overrides the global one for known documents
+        float docZoom = findReadingZoom(savedSettings, app.currentFile);
+        if (docZoom > 0.0f && fabsf(docZoom - app.zoomFactor) > 0.01f) {
+            app.zoomFactor = docZoom;
+            app.appliedZoomFactor = docZoom;
+            updateTextFormats(app);
+            app.layoutDirty = true;
+        }
     }
 
     // Set window title with filename

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -628,6 +628,196 @@ static bool isFileRefToken(const std::string& token, size_t extLength) {
     return true;
 }
 
+// GitHub-style :shortcode: emoji. Names are the common GitHub set; the
+// replacements are UTF-8 byte sequences (DirectWrite's emoji fallback
+// renders them in color).
+struct EmojiEntry {
+    const char* name;
+    const char* utf8;
+};
+static const EmojiEntry kEmoji[] = {
+    {"+1", "\xF0\x9F\x91\x8D"}, {"-1", "\xF0\x9F\x91\x8E"},
+    {"100", "\xF0\x9F\x92\xAF"}, {"airplane", "\xE2\x9C\x88\xEF\xB8\x8F"},
+    {"alarm_clock", "\xE2\x8F\xB0"}, {"alien", "\xF0\x9F\x91\xBD"},
+    {"anchor", "\xE2\x9A\x93"}, {"angry", "\xF0\x9F\x98\xA0"},
+    {"arrow_down", "\xE2\xAC\x87\xEF\xB8\x8F"},
+    {"arrow_left", "\xE2\xAC\x85\xEF\xB8\x8F"},
+    {"arrow_right", "\xE2\x9E\xA1\xEF\xB8\x8F"},
+    {"arrow_up", "\xE2\xAC\x86\xEF\xB8\x8F"},
+    {"art", "\xF0\x9F\x8E\xA8"}, {"balloon", "\xF0\x9F\x8E\x88"},
+    {"bar_chart", "\xF0\x9F\x93\x8A"}, {"battery", "\xF0\x9F\x94\x8B"},
+    {"bear", "\xF0\x9F\x90\xBB"}, {"bee", "\xF0\x9F\x90\x9D"},
+    {"beer", "\xF0\x9F\x8D\xBA"}, {"bell", "\xF0\x9F\x94\x94"},
+    {"bike", "\xF0\x9F\x9A\xB2"}, {"birthday", "\xF0\x9F\x8E\x82"},
+    {"blossom", "\xF0\x9F\x8C\xBC"}, {"blue_circle", "\xF0\x9F\x94\xB5"},
+    {"bomb", "\xF0\x9F\x92\xA3"}, {"book", "\xF0\x9F\x93\x96"},
+    {"bookmark", "\xF0\x9F\x94\x96"}, {"books", "\xF0\x9F\x93\x9A"},
+    {"boom", "\xF0\x9F\x92\xA5"}, {"brain", "\xF0\x9F\xA7\xA0"},
+    {"bug", "\xF0\x9F\x90\x9B"}, {"bulb", "\xF0\x9F\x92\xA1"},
+    {"bus", "\xF0\x9F\x9A\x8C"}, {"butterfly", "\xF0\x9F\xA6\x8B"},
+    {"cake", "\xF0\x9F\x8D\xB0"}, {"calendar", "\xF0\x9F\x93\x85"},
+    {"camera", "\xF0\x9F\x93\xB7"}, {"candle", "\xF0\x9F\x95\xAF\xEF\xB8\x8F"},
+    {"car", "\xF0\x9F\x9A\x97"}, {"cat", "\xF0\x9F\x90\xB1"},
+    {"cd", "\xF0\x9F\x92\xBF"},
+    {"chart_with_downwards_trend", "\xF0\x9F\x93\x89"},
+    {"chart_with_upwards_trend", "\xF0\x9F\x93\x88"},
+    {"checkered_flag", "\xF0\x9F\x8F\x81"},
+    {"clap", "\xF0\x9F\x91\x8F"}, {"clapper", "\xF0\x9F\x8E\xAC"},
+    {"clipboard", "\xF0\x9F\x93\x8B"},
+    {"cloud", "\xE2\x98\x81\xEF\xB8\x8F"},
+    {"clown_face", "\xF0\x9F\xA4\xA1"}, {"coffee", "\xE2\x98\x95"},
+    {"comet", "\xE2\x98\x84\xEF\xB8\x8F"},
+    {"computer", "\xF0\x9F\x92\xBB"},
+    {"construction", "\xF0\x9F\x9A\xA7"},
+    {"crescent_moon", "\xF0\x9F\x8C\x99"},
+    {"crossed_fingers", "\xF0\x9F\xA4\x9E"}, {"crown", "\xF0\x9F\x91\x91"},
+    {"cry", "\xF0\x9F\x98\xA2"}, {"dart", "\xF0\x9F\x8E\xAF"},
+    {"date", "\xF0\x9F\x93\x85"}, {"deciduous_tree", "\xF0\x9F\x8C\xB3"},
+    {"desktop_computer", "\xF0\x9F\x96\xA5\xEF\xB8\x8F"},
+    {"dog", "\xF0\x9F\x90\xB6"}, {"dollar", "\xF0\x9F\x92\xB5"},
+    {"electric_plug", "\xF0\x9F\x94\x8C"},
+    {"email", "\xE2\x9C\x89\xEF\xB8\x8F"},
+    {"envelope", "\xE2\x9C\x89\xEF\xB8\x8F"},
+    {"evergreen_tree", "\xF0\x9F\x8C\xB2"},
+    {"exclamation", "\xE2\x9D\x97"}, {"eyes", "\xF0\x9F\x91\x80"},
+    {"factory", "\xF0\x9F\x8F\xAD"}, {"file_folder", "\xF0\x9F\x93\x81"},
+    {"fire", "\xF0\x9F\x94\xA5"}, {"flashlight", "\xF0\x9F\x94\xA6"},
+    {"floppy_disk", "\xF0\x9F\x92\xBE"},
+    {"four_leaf_clover", "\xF0\x9F\x8D\x80"},
+    {"fox_face", "\xF0\x9F\xA6\x8A"}, {"game_die", "\xF0\x9F\x8E\xB2"},
+    {"gear", "\xE2\x9A\x99\xEF\xB8\x8F"}, {"gem", "\xF0\x9F\x92\x8E"},
+    {"ghost", "\xF0\x9F\x91\xBB"}, {"gift", "\xF0\x9F\x8E\x81"},
+    {"globe_with_meridians", "\xF0\x9F\x8C\x90"},
+    {"green_circle", "\xF0\x9F\x9F\xA2"}, {"grin", "\xF0\x9F\x98\x81"},
+    {"guitar", "\xF0\x9F\x8E\xB8"}, {"hammer", "\xF0\x9F\x94\xA8"},
+    {"handshake", "\xF0\x9F\xA4\x9D"},
+    {"heart", "\xE2\x9D\xA4\xEF\xB8\x8F"},
+    {"heart_eyes", "\xF0\x9F\x98\x8D"},
+    {"heavy_check_mark", "\xE2\x9C\x94\xEF\xB8\x8F"},
+    {"heavy_minus_sign", "\xE2\x9E\x96"},
+    {"heavy_plus_sign", "\xE2\x9E\x95"},
+    {"hospital", "\xF0\x9F\x8F\xA5"}, {"hourglass", "\xE2\x8C\x9B"},
+    {"hourglass_flowing_sand", "\xE2\x8F\xB3"},
+    {"house", "\xF0\x9F\x8F\xA0"}, {"inbox_tray", "\xF0\x9F\x93\xA5"},
+    {"information_source", "\xE2\x84\xB9\xEF\xB8\x8F"},
+    {"iphone", "\xF0\x9F\x93\xB1"}, {"jack_o_lantern", "\xF0\x9F\x8E\x83"},
+    {"joy", "\xF0\x9F\x98\x82"}, {"key", "\xF0\x9F\x94\x91"},
+    {"keyboard", "\xE2\x8C\xA8\xEF\xB8\x8F"},
+    {"label", "\xF0\x9F\x8F\xB7\xEF\xB8\x8F"},
+    {"leaves", "\xF0\x9F\x8D\x83"}, {"link", "\xF0\x9F\x94\x97"},
+    {"lock", "\xF0\x9F\x94\x92"}, {"loud_sound", "\xF0\x9F\x94\x8A"},
+    {"loudspeaker", "\xF0\x9F\x93\xA2"}, {"mag", "\xF0\x9F\x94\x8D"},
+    {"mega", "\xF0\x9F\x93\xA3"}, {"memo", "\xF0\x9F\x93\x9D"},
+    {"microphone", "\xF0\x9F\x8E\xA4"}, {"microscope", "\xF0\x9F\x94\xAC"},
+    {"moneybag", "\xF0\x9F\x92\xB0"}, {"movie_camera", "\xF0\x9F\x8E\xA5"},
+    {"muscle", "\xF0\x9F\x92\xAA"}, {"musical_note", "\xF0\x9F\x8E\xB5"},
+    {"mute", "\xF0\x9F\x94\x87"}, {"neutral_face", "\xF0\x9F\x98\x90"},
+    {"new", "\xF0\x9F\x86\x95"}, {"newspaper", "\xF0\x9F\x93\xB0"},
+    {"no_entry", "\xE2\x9B\x94"}, {"ok", "\xF0\x9F\x86\x97"},
+    {"ok_hand", "\xF0\x9F\x91\x8C"},
+    {"open_file_folder", "\xF0\x9F\x93\x82"},
+    {"outbox_tray", "\xF0\x9F\x93\xA4"}, {"owl", "\xF0\x9F\xA6\x89"},
+    {"package", "\xF0\x9F\x93\xA6"},
+    {"page_facing_up", "\xF0\x9F\x93\x84"},
+    {"panda_face", "\xF0\x9F\x90\xBC"}, {"paperclip", "\xF0\x9F\x93\x8E"},
+    {"pencil2", "\xE2\x9C\x8F\xEF\xB8\x8F"},
+    {"penguin", "\xF0\x9F\x90\xA7"}, {"pill", "\xF0\x9F\x92\x8A"},
+    {"pizza", "\xF0\x9F\x8D\x95"}, {"point_left", "\xF0\x9F\x91\x88"},
+    {"point_right", "\xF0\x9F\x91\x89"}, {"poop", "\xF0\x9F\x92\xA9"},
+    {"popcorn", "\xF0\x9F\x8D\xBF"}, {"pray", "\xF0\x9F\x99\x8F"},
+    {"pushpin", "\xF0\x9F\x93\x8C"}, {"puzzle_piece", "\xF0\x9F\xA7\xA9"},
+    {"question", "\xE2\x9D\x93"}, {"rabbit", "\xF0\x9F\x90\xB0"},
+    {"rainbow", "\xF0\x9F\x8C\x88"}, {"raised_hands", "\xF0\x9F\x99\x8C"},
+    {"recycle", "\xE2\x99\xBB\xEF\xB8\x8F"},
+    {"red_circle", "\xF0\x9F\x94\xB4"}, {"robot", "\xF0\x9F\xA4\x96"},
+    {"rocket", "\xF0\x9F\x9A\x80"}, {"roll_eyes", "\xF0\x9F\x99\x84"},
+    {"rose", "\xF0\x9F\x8C\xB9"},
+    {"rotating_light", "\xF0\x9F\x9A\xA8"},
+    {"round_pushpin", "\xF0\x9F\x93\x8D"}, {"runner", "\xF0\x9F\x8F\x83"},
+    {"satellite", "\xF0\x9F\x9B\xB0\xEF\xB8\x8F"},
+    {"school", "\xF0\x9F\x8F\xAB"}, {"scissors", "\xE2\x9C\x82\xEF\xB8\x8F"},
+    {"scream", "\xF0\x9F\x98\xB1"}, {"seedling", "\xF0\x9F\x8C\xB1"},
+    {"shield", "\xF0\x9F\x9B\xA1\xEF\xB8\x8F"}, {"ship", "\xF0\x9F\x9A\xA2"},
+    {"shrug", "\xF0\x9F\xA4\xB7"}, {"skull", "\xF0\x9F\x92\x80"},
+    {"sleeping", "\xF0\x9F\x98\xB4"}, {"smile", "\xF0\x9F\x98\x84"},
+    {"smirk", "\xF0\x9F\x98\x8F"}, {"snail", "\xF0\x9F\x90\x8C"},
+    {"snowflake", "\xE2\x9D\x84\xEF\xB8\x8F"}, {"sob", "\xF0\x9F\x98\xAD"},
+    {"sos", "\xF0\x9F\x86\x98"}, {"sparkles", "\xE2\x9C\xA8"},
+    {"speech_balloon", "\xF0\x9F\x92\xAC"}, {"star", "\xE2\xAD\x90"},
+    {"star2", "\xF0\x9F\x8C\x9F"}, {"stopwatch", "\xE2\x8F\xB1\xEF\xB8\x8F"},
+    {"sunglasses", "\xF0\x9F\x98\x8E"},
+    {"sunny", "\xE2\x98\x80\xEF\xB8\x8F"},
+    {"sweat_smile", "\xF0\x9F\x98\x85"}, {"tada", "\xF0\x9F\x8E\x89"},
+    {"telephone", "\xE2\x98\x8E\xEF\xB8\x8F"},
+    {"telescope", "\xF0\x9F\x94\xAD"}, {"thinking", "\xF0\x9F\xA4\x94"},
+    {"thought_balloon", "\xF0\x9F\x92\xAD"},
+    {"thumbsdown", "\xF0\x9F\x91\x8E"}, {"thumbsup", "\xF0\x9F\x91\x8D"},
+    {"top", "\xF0\x9F\x94\x9D"}, {"trophy", "\xF0\x9F\x8F\x86"},
+    {"tulip", "\xF0\x9F\x8C\xB7"}, {"turtle", "\xF0\x9F\x90\xA2"},
+    {"umbrella", "\xE2\x98\x94"}, {"unicorn", "\xF0\x9F\xA6\x84"},
+    {"video_camera", "\xF0\x9F\x93\xB9"},
+    {"video_game", "\xF0\x9F\x8E\xAE"},
+    {"warning", "\xE2\x9A\xA0\xEF\xB8\x8F"},
+    {"wastebasket", "\xF0\x9F\x97\x91\xEF\xB8\x8F"},
+    {"wave", "\xF0\x9F\x91\x8B"}, {"whale", "\xF0\x9F\x90\xB3"},
+    {"white_check_mark", "\xE2\x9C\x85"},
+    {"white_circle", "\xE2\x9A\xAA"}, {"wink", "\xF0\x9F\x98\x89"},
+    {"world_map", "\xF0\x9F\x97\xBA\xEF\xB8\x8F"},
+    {"wrench", "\xF0\x9F\x94\xA7"}, {"x", "\xE2\x9D\x8C"},
+    {"yellow_circle", "\xF0\x9F\x9F\xA1"}, {"zap", "\xE2\x9A\xA1"},
+    {"zzz", "\xF0\x9F\x92\xA4"},
+};
+
+static const char* emojiFor(const std::string& name) {
+    for (const auto& entry : kEmoji) {
+        if (name == entry.name) return entry.utf8;
+    }
+    return nullptr;
+}
+
+static bool isEmojiNameChar(char c) {
+    return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' ||
+           c == '+' || c == '-';
+}
+
+// Replaces :shortcode: with its emoji, in place, in every Text node
+// outside code
+static void splitEmojiShortcodes(const ElementPtr& parent) {
+    if (parent->type == ElementType::Code ||
+        parent->type == ElementType::CodeBlock ||
+        parent->type == ElementType::MermaidDiagram) {
+        return;
+    }
+    for (auto& child : parent->children) {
+        if (child->type != ElementType::Text) {
+            splitEmojiShortcodes(child);
+            continue;
+        }
+        std::string& text = child->text;
+        size_t pos = 0;
+        while ((pos = text.find(':', pos)) != std::string::npos) {
+            size_t end = pos + 1;
+            while (end < text.size() && isEmojiNameChar(text[end]) &&
+                   end - pos <= 40) {
+                end++;
+            }
+            if (end >= text.size() || text[end] != ':' || end == pos + 1) {
+                pos = end;
+                continue;
+            }
+            const char* emoji =
+                emojiFor(text.substr(pos + 1, end - pos - 1));
+            if (emoji) {
+                text.replace(pos, end - pos + 1, emoji);
+                pos += strlen(emoji);
+            } else {
+                // The closing colon may open the next shortcode
+                pos = end;
+            }
+        }
+    }
+}
+
 static void splitFileRefs(const ElementPtr& parent) {
     if (parent->type == ElementType::Code ||
         parent->type == ElementType::CodeBlock ||
@@ -761,6 +951,7 @@ ParseResult MarkdownParser::parse(const std::string& markdown) {
     splitInlineExtensions(ctx.root);
     splitWikiLinks(ctx.root);
     splitFileRefs(ctx.root);
+    splitEmojiShortcodes(ctx.root);
     detectGitHubAlerts(ctx.root);
     result.root = ctx.root;
     result.success = true;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -23,6 +23,12 @@
 #pragma comment(lib, "urlmon.lib")
 #pragma comment(lib, "shlwapi.lib")
 
+// Fit-to-width override lookup for a table/diagram ordinal key
+static bool fitBlockEnabled(const App& app, unsigned key) {
+    return std::find(app.fitBlocks.begin(), app.fitBlocks.end(), key) !=
+           app.fitBlocks.end();
+}
+
 namespace {
 constexpr float kHugeWidth = 100000.0f;
 constexpr float kLineBucketTolerance = 5.0f;
@@ -1037,12 +1043,13 @@ static App::LayoutShapeType mermaidShapeType(mermaid::NodeShape shape) {
 static bool layoutMermaidDiagram(App& app, const std::string& source,
                                  size_t sourceOffset, float& y,
                                  float indent, float maxWidth,
-                                 D2D1_RECT_F* renderedBounds = nullptr) {
+                                 D2D1_RECT_F* renderedBounds = nullptr,
+                                 float scaleMul = 1.0f) {
     auto parsed = mermaid::parse(source);
     if (!parsed.success || parsed.diagram.nodes.empty()) return false;
 
     const auto& diagram = parsed.diagram;
-    float scale = app.contentScale * app.zoomFactor;
+    float scale = app.contentScale * app.zoomFactor * scaleMul;
     float maxLabelWidth = 280.0f * scale;
     float measureHeight = 10000.0f * scale;
     float paddingX = 18.0f * scale;
@@ -1769,8 +1776,9 @@ static bool layoutMermaidExtDiagram(App& app, mermaidext::Kind kind,
                                     const std::string& source,
                                     size_t sourceOffset, float& y,
                                     float indent, float maxWidth,
-                                    D2D1_RECT_F* renderedBounds) {
-    float scale = app.contentScale * app.zoomFactor;
+                                    D2D1_RECT_F* renderedBounds,
+                                    float scaleMul = 1.0f) {
+    float scale = app.contentScale * app.zoomFactor * scaleMul;
     DiagramFormats formats(app);
 
     auto measureFn = [&](const std::string& text,
@@ -1996,20 +2004,52 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
     if (languageName == "mermaid") {
         D2D1_RECT_F renderedBounds{};
         mermaidext::Kind kind = mermaidext::detectKind(code);
+        unsigned fitKey = 0x80000000u | app.layoutDiagramSeq++;
+        bool fitActive = fitBlockEnabled(app, fitKey);
+        bool fitCandidate = false;
         bool rendered = false;
-        if (kind == mermaidext::Kind::Flowchart) {
-            rendered = layoutMermaidDiagram(
-                app, code, elem->sourceOffset, y, indent, maxWidth,
-                &renderedBounds);
-        } else if (kind != mermaidext::Kind::None) {
-            rendered = layoutMermaidExtDiagram(
-                app, kind, code, elem->sourceOffset, y, indent, maxWidth,
-                &renderedBounds);
+        LayoutSnapshot preSnap = takeSnapshot(app);
+        float preY = y;
+        float scaleMul = 1.0f;
+        // Label re-wrapping makes width nonlinear in scale, so fitting
+        // shrinks iteratively from the measured bounds of each pass
+        for (int pass = 0; pass < 4; pass++) {
+            if (kind == mermaidext::Kind::Flowchart) {
+                rendered = layoutMermaidDiagram(
+                    app, code, elem->sourceOffset, y, indent, maxWidth,
+                    &renderedBounds, scaleMul);
+            } else if (kind != mermaidext::Kind::None) {
+                rendered = layoutMermaidExtDiagram(
+                    app, kind, code, elem->sourceOffset, y, indent, maxWidth,
+                    &renderedBounds, scaleMul);
+            }
+            if (!rendered) break;
+            float renderedW = renderedBounds.right - indent;
+            if (renderedW > maxWidth + 1.0f) {
+                if (pass == 0) fitCandidate = true;
+                if (fitActive && scaleMul > 0.15f) {
+                    scaleMul = std::max(
+                        0.15f, scaleMul * (maxWidth / renderedW) * 0.98f);
+                    rollbackTo(app, preSnap);
+                    y = preY;
+                    continue;
+                }
+            }
+            break;
         }
         if (rendered) {
-            app.codeBlocks.push_back({renderedBounds, toWide(code), true});
+            App::CodeBlockInfo info;
+            info.bounds = renderedBounds;
+            info.codeText = toWide(code);
+            info.isDiagram = true;
+            info.fitKey = fitKey;
+            info.fitCandidate = fitCandidate || fitActive;
+            info.fitActive = fitActive;
+            app.codeBlocks.push_back(std::move(info));
             return;
         }
+        rollbackTo(app, preSnap);
+        y = preY;
     }
 
     std::wstring langHint = toWide(elem->language);
@@ -2725,7 +2765,18 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
     float totalWidth = 0;
     for (int c = 0; c < colCount; c++) totalWidth += colWidths[c];
 
-    if (totalWidth > maxWidth) {
+    unsigned fitKey = 0x40000000u | app.layoutTableSeq++;
+    bool fitCandidate = false;
+    bool fitActive = fitBlockEnabled(app, fitKey);
+
+    if (totalWidth > maxWidth && fitActive) {
+        // Fit-to-width override: shrink every column proportionally with
+        // no minimum floor; dense cells wrap hard, nothing scrolls
+        float k = maxWidth / totalWidth;
+        for (int c = 0; c < colCount; c++) colWidths[c] *= k;
+        totalWidth = maxWidth;
+        fitCandidate = true;
+    } else if (totalWidth > maxWidth) {
         // Floor: at least ~2.5 CJK glyphs per line so no column degenerates
         // into a vertical strip
         float minCol = std::max(minColWidth, fontSize * 2.5f + cellPadding * 2);
@@ -2763,6 +2814,8 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
         for (int c = 0; c < colCount; c++) totalWidth += colWidths[c];
         // Minimum widths can push past maxWidth; the table then joins
         // horizontal scrolling instead of squeezing columns unreadably
+        // (unless the fit toggle squeezes it on purpose)
+        if (totalWidth > maxWidth + 1.0f) fitCandidate = true;
         app.contentWidth = std::max(app.contentWidth, indent + totalWidth);
     }
 
@@ -2885,6 +2938,9 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
         info.bounds =
             D2D1::RectF(indent, tableStartY, indent + totalWidth, tableEndY);
         info.tsv = std::move(tsv);
+        info.fitKey = fitKey;
+        info.fitCandidate = fitCandidate || fitActive;
+        info.fitActive = fitActive;
         app.tableRects.push_back(std::move(info));
     }
 
@@ -3097,6 +3153,8 @@ bool layoutBegin(App& app) {
     app.layoutComplete = false;
     app.contentWidth = layoutWidth;
     app.scrollAnchors.clear();
+    app.layoutTableSeq = 0;
+    app.layoutDiagramSeq = 0;
     return true;
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -90,8 +90,10 @@ void saveSettings(const Settings& settings) {
     if (!settings.readingPositions.empty()) {
         file << "[Positions]\n";
         for (const auto& pos : settings.readingPositions) {
-            // Windows paths cannot contain '|'
-            file << "pos=" << pos.scrollY << "|" << pos.path << "\n";
+            // Windows paths cannot contain '|'; the second field is the
+            // per-document zoom (0 = none)
+            file << "pos=" << pos.scrollY << "|" << pos.zoom << "|"
+                 << pos.path << "\n";
         }
     }
 }
@@ -151,23 +153,26 @@ void applyKeymap(App& app, const Settings& settings) {
     app.keyProfile = settings.keyProfile;
 }
 
-void rememberReadingPosition(Settings& settings, const std::string& path, float scrollY) {
+void rememberReadingPosition(Settings& settings, const std::string& path,
+                             float scrollY, float zoom) {
     if (path.empty()) return;
     auto& list = settings.readingPositions;
     for (size_t i = 0; i < list.size(); i++) {
         if (_stricmp(list[i].path.c_str(), path.c_str()) == 0) {
+            if (zoom <= 0.0f) zoom = list[i].zoom;  // keep a known zoom
             list.erase(list.begin() + i);
             break;
         }
     }
-    list.insert(list.begin(), {path, scrollY});
+    list.insert(list.begin(), {path, scrollY, zoom});
     if (list.size() > 50) list.resize(50);
 }
 
-void persistReadingPosition(const std::string& path, float scrollY) {
+void persistReadingPosition(const std::string& path, float scrollY,
+                            float zoom) {
     if (path.empty()) return;
     Settings settings = loadSettings();
-    rememberReadingPosition(settings, path, scrollY);
+    rememberReadingPosition(settings, path, scrollY, zoom);
     saveSettings(settings);
 }
 
@@ -176,6 +181,13 @@ float findReadingPosition(const Settings& settings, const std::string& path) {
         if (_stricmp(pos.path.c_str(), path.c_str()) == 0) return pos.scrollY;
     }
     return -1.0f;
+}
+
+float findReadingZoom(const Settings& settings, const std::string& path) {
+    for (const auto& pos : settings.readingPositions) {
+        if (_stricmp(pos.path.c_str(), path.c_str()) == 0) return pos.zoom;
+    }
+    return 0.0f;
 }
 
 Settings loadSettings() {
@@ -269,12 +281,20 @@ Settings loadSettings() {
                 settings.sessionTabs.push_back(value);
             }
         } else if (key == "pos") {
+            // New format: scrollY|zoom|path; legacy: scrollY|path
             size_t sep = value.find('|');
             if (sep != std::string::npos && sep + 1 < value.size()) {
                 try {
                     float y = std::stof(value.substr(0, sep));
-                    if (y >= 0.0f) {
-                        settings.readingPositions.push_back({value.substr(sep + 1), y});
+                    float zoom = 0.0f;
+                    std::string path = value.substr(sep + 1);
+                    size_t sep2 = path.find('|');
+                    if (sep2 != std::string::npos && sep2 + 1 < path.size()) {
+                        zoom = std::stof(path.substr(0, sep2));
+                        path = path.substr(sep2 + 1);
+                    }
+                    if (y >= 0.0f && !path.empty()) {
+                        settings.readingPositions.push_back({path, y, zoom});
                     }
                 } catch (...) {}
             }

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -193,6 +193,43 @@ int main() {
         check(!has("v2.md"), "dotted archive names are not references");
     }
 
+    // Emoji shortcodes become their emoji, code stays literal
+    {
+        auto emoji = parseDocument(parser,
+            "Ship it :rocket: with :+1: but `:tada:` stays and "
+            ":not_a_real_code: survives\n"
+            "```\n:fire: in a fence\n```\n",
+            "notes.md");
+        check(emoji.success, "emoji test parses");
+        std::string flat;
+        std::string codeFlat;
+        std::function<void(const qmd::ElementPtr&)> walk =
+            [&](const qmd::ElementPtr& node) {
+            if (node->type == qmd::ElementType::Code ||
+                node->type == qmd::ElementType::CodeBlock) {
+                codeFlat += node->text;
+                for (const auto& child : node->children)
+                    codeFlat += child->text;
+                return;
+            }
+            flat += node->text;
+            for (const auto& child : node->children) walk(child);
+        };
+        if (emoji.root) walk(emoji.root);
+        check(flat.find("\xF0\x9F\x9A\x80") != std::string::npos,
+              ":rocket: replaced with the emoji");
+        check(flat.find("\xF0\x9F\x91\x8D") != std::string::npos,
+              ":+1: replaced with the emoji");
+        check(flat.find(":rocket:") == std::string::npos,
+              "no literal :rocket: remains");
+        check(flat.find(":not_a_real_code:") != std::string::npos,
+              "unknown shortcodes stay literal");
+        check(codeFlat.find(":tada:") != std::string::npos,
+              "inline code shortcodes untouched");
+        check(codeFlat.find(":fire:") != std::string::npos,
+              "fenced code shortcodes untouched");
+    }
+
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";
         return 1;


### PR DESCRIPTION
Three quality-of-life features:

**Per-document zoom memory**
- Reading-position entries in settings.ini gain a zoom field (`pos=scrollY|zoom|path`); legacy two-field lines still parse.
- A document reopens at the zoom it was last viewed at, applied together with the scroll restore.
- Documents without a stored zoom keep following the session zoom, so nothing changes until you actually zoom a document.

**Emoji shortcodes**
- `:rocket:`, `:+1:`, `:warning:` and ~150 other GitHub-style names resolve to their emoji during inline parsing.
- Code spans, code blocks, and diagram sources are untouched; unknown names stay literal.
- Covered by a new document_tests case.

**Fit-to-width for wide tables and diagrams**
- Tables and mermaid diagrams wider than the reading column get a `Fit` hover button beside their existing copy buttons.
- Fitting a table shrinks its columns proportionally, bypassing the readability floor; fitting a diagram relayouts it at a smaller scale, iterating on measured bounds because label re-wrapping makes width nonlinear in the scale factor.
- The button flips to `1:1` to restore natural size. The choice is per block and resets when switching documents; it survives watch reloads.
- Hover buttons on blocks wider than the viewport now clamp to the visible right edge so they stay reachable (previously a very wide diagram parked its Copy/Image buttons off-screen).

All four test suites pass; verified interactively on a test document with a 10-column table and a 9-node flowchart.