### PR TITLE
Editor markdown assists; text files as first-class references and documents

### DIFF
--- a/include/document.h
+++ b/include/document.h
@@ -15,6 +15,10 @@ inline constexpr std::array<std::wstring_view, 3> DOCUMENT_FILE_EXTENSIONS = {
 
 bool isMermaidDocumentPath(std::string_view path);
 bool isMermaidDocumentPath(std::wstring_view path);
+// Plain-text sidecars (.txt/.json/.yaml/...) render as one highlighted
+// code block instead of being parsed as markdown
+bool isPlainTextDocumentPath(std::string_view path);
+bool isPlainTextDocumentPath(std::wstring_view path);
 bool isSupportedDocumentPath(std::string_view path);
 bool isSupportedDocumentPath(std::wstring_view path);
 bool isSupportedDropPath(std::wstring_view path);

--- a/src/document.cpp
+++ b/src/document.cpp
@@ -40,6 +40,41 @@ bool isMermaidPath(std::basic_string_view<Character> path) {
     return hasExtension(path, std::basic_string_view<Character>(extension, 4));
 }
 
+// Lowercased ASCII extension incl. the dot; empty for none or non-ASCII
+template <typename Character>
+std::string extensionLower(std::basic_string_view<Character> path) {
+    size_t dot = path.find_last_of(static_cast<Character>('.'));
+    if (dot == std::basic_string_view<Character>::npos) return {};
+    std::string out;
+    for (size_t i = dot; i < path.size(); i++) {
+        Character c = path[i];
+        if (static_cast<unsigned long>(c) > 127) return {};
+        out += static_cast<char>(lowerAscii(c));
+    }
+    return out;
+}
+
+template <typename Character>
+bool isPlainTextPath(std::basic_string_view<Character> path) {
+    std::string ext = extensionLower(path);
+    return ext == ".txt" || ext == ".json" || ext == ".yaml" ||
+           ext == ".yml" || ext == ".toml" || ext == ".ini" ||
+           ext == ".csv" || ext == ".log";
+}
+
+// Fence language tag for a plain-text document's code block
+template <typename Character>
+const char* plainTextLanguage(std::basic_string_view<Character> path) {
+    std::string ext = extensionLower(path);
+    if (ext == ".json") return "json";
+    if (ext == ".yaml" || ext == ".yml") return "yaml";
+    if (ext == ".toml") return "toml";
+    if (ext == ".ini") return "ini";
+    if (ext == ".csv") return "csv";
+    if (ext == ".log") return "log";
+    return "";
+}
+
 template <typename Character>
 bool isSupportedPath(std::basic_string_view<Character> path) {
     const Character md[] = {
@@ -60,7 +95,32 @@ bool isSupportedPath(std::basic_string_view<Character> path) {
     };
     return hasExtension(path, std::basic_string_view<Character>(md, 3)) ||
         hasExtension(path, std::basic_string_view<Character>(markdown, 9)) ||
-        isMermaidPath(path);
+        isMermaidPath(path) || isPlainTextPath(path);
+}
+
+// A plain-text file becomes one highlighted code block: peek, tabs, and
+// export all reuse the normal code-block path
+qmd::ParseResult createPlainTextDocument(const std::string& content,
+                                         const char* language) {
+    auto start = std::chrono::high_resolution_clock::now();
+
+    qmd::ParseResult result;
+    result.root = std::make_shared<qmd::Element>(qmd::ElementType::Document);
+    auto block = std::make_shared<qmd::Element>(qmd::ElementType::CodeBlock);
+    block->language = language;
+    block->sourceOffset = 0;
+    block->parent = result.root.get();
+    auto text = std::make_shared<qmd::Element>(qmd::ElementType::Text);
+    text->text = content;
+    text->sourceOffset = 0;
+    text->parent = block.get();
+    block->children.push_back(std::move(text));
+    result.root->children.push_back(std::move(block));
+    result.success = true;
+    result.parseTimeUs = static_cast<size_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::high_resolution_clock::now() - start).count());
+    return result;
 }
 
 qmd::ParseResult createMermaidDocument(const std::string& content) {
@@ -88,6 +148,14 @@ bool isMermaidDocumentPath(std::string_view path) {
 
 bool isMermaidDocumentPath(std::wstring_view path) {
     return isMermaidPath(path);
+}
+
+bool isPlainTextDocumentPath(std::string_view path) {
+    return isPlainTextPath(path);
+}
+
+bool isPlainTextDocumentPath(std::wstring_view path) {
+    return isPlainTextPath(path);
 }
 
 bool isSupportedDocumentPath(std::string_view path) {
@@ -240,6 +308,9 @@ qmd::ParseResult parseDocument(qmd::MarkdownParser& parser,
                                const std::string& content,
                                std::string_view path) {
     if (isMermaidDocumentPath(path)) return createMermaidDocument(content);
+    if (isPlainTextDocumentPath(path)) {
+        return createPlainTextDocument(content, plainTextLanguage(path));
+    }
     std::string cleaned;
     if (blankFrontmatter(content, cleaned)) {
         auto result = parser.parse(cleaned);
@@ -253,6 +324,9 @@ qmd::ParseResult parseDocument(qmd::MarkdownParser& parser,
                                const std::string& content,
                                std::wstring_view path) {
     if (isMermaidDocumentPath(path)) return createMermaidDocument(content);
+    if (isPlainTextDocumentPath(path)) {
+        return createPlainTextDocument(content, plainTextLanguage(path));
+    }
     std::string cleaned;
     if (blankFrontmatter(content, cleaned)) {
         auto result = parser.parse(cleaned);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -23,6 +23,10 @@
 
 #define TIMER_EDITOR_REPARSE 2
 
+// Markdown assists (defined near the char handler)
+static void editorToggleInlineMark(App& app, HWND hwnd,
+                                   const std::wstring& mark);
+
 // --- UTF conversion ---
 
 std::string toUtf8(const std::wstring& wstr) {
@@ -1606,6 +1610,12 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 InvalidateRect(hwnd, nullptr, FALSE);
                 return;
             }
+            case 'B':
+                editorToggleInlineMark(app, hwnd, L"**");
+                return;
+            case 'I':
+                editorToggleInlineMark(app, hwnd, L"*");
+                return;
             case 'W': {
                 app.editorWordWrap = !app.editorWordWrap;
                 app.clearEditorLineLayoutCache();
@@ -1795,6 +1805,125 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     }
 }
 
+// --- Markdown assists ---
+
+// Start offset of the line containing pos
+static size_t editorLineStartBefore(const App& app, size_t pos) {
+    size_t ls = 0;
+    for (size_t s : app.editorLineStarts) {
+        if (s <= pos) ls = s;
+        else break;
+    }
+    return ls;
+}
+
+// A parsed list marker at the head of one line: "- ", "3. ", "- [ ] "
+struct ListMarkerInfo {
+    bool isList = false;
+    std::wstring indent;      // leading whitespace
+    std::wstring marker;      // marker text incl. trailing space(s)
+    bool ordered = false;
+    int number = 0;
+    wchar_t delim = L'.';     // '.' or ')' for ordered lists
+    bool task = false;
+    size_t contentStart = 0;  // offset from line start past the marker
+};
+
+static ListMarkerInfo parseListMarker(const std::wstring& text,
+                                      size_t lineStart) {
+    ListMarkerInfo info;
+    size_t i = lineStart;
+    while (i < text.size() && (text[i] == L' ' || text[i] == L'\t')) i++;
+    info.indent = text.substr(lineStart, i - lineStart);
+    size_t markerStart = i;
+    if (i < text.size() &&
+        (text[i] == L'-' || text[i] == L'*' || text[i] == L'+')) {
+        if (i + 1 >= text.size() || text[i + 1] != L' ') return info;
+        i += 2;
+        // Task boxes continue as unchecked task items
+        if (i + 4 <= text.size() && text[i] == L'[' &&
+            (text[i + 1] == L' ' || text[i + 1] == L'x' ||
+             text[i + 1] == L'X') &&
+            text[i + 2] == L']' && text[i + 3] == L' ') {
+            info.task = true;
+            i += 4;
+        }
+    } else {
+        size_t d = i;
+        while (d < text.size() && iswdigit(text[d]) && d - i < 9) d++;
+        if (d == i || d >= text.size() ||
+            (text[d] != L'.' && text[d] != L')')) {
+            return info;
+        }
+        if (d + 1 >= text.size() || text[d + 1] != L' ') return info;
+        info.ordered = true;
+        info.number = _wtoi(text.substr(i, d - i).c_str());
+        info.delim = text[d];
+        i = d + 2;
+    }
+    info.isList = true;
+    info.marker = text.substr(markerStart, i - markerStart);
+    info.contentStart = i - lineStart;
+    return info;
+}
+
+// Ctrl+B / Ctrl+I: wrap the selection in mark..mark, unwrap when it (or
+// its immediate surroundings) already carry the mark, or drop an empty
+// pair at the caret
+static void editorToggleInlineMark(App& app, HWND hwnd,
+                                   const std::wstring& mark) {
+    size_t ml = mark.size();
+    if (app.editorHasSelection) {
+        size_t s = std::min(app.editorSelStart, app.editorSelEnd);
+        size_t e = std::max(app.editorSelStart, app.editorSelEnd);
+        std::wstring sel = app.editorText.substr(s, e - s);
+        bool inside = sel.size() >= ml * 2 &&
+                      sel.compare(0, ml, mark) == 0 &&
+                      sel.compare(sel.size() - ml, ml, mark) == 0;
+        bool outside = !inside && s >= ml &&
+                       e + ml <= app.editorText.size() &&
+                       app.editorText.compare(s - ml, ml, mark) == 0 &&
+                       app.editorText.compare(e, ml, mark) == 0;
+        size_t rs = outside ? s - ml : s;
+        size_t re = outside ? e + ml : e;
+        std::wstring repl;
+        if (inside) {
+            repl = sel.substr(ml, sel.size() - ml * 2);
+        } else if (outside) {
+            repl = sel;
+        } else {
+            repl = mark + sel + mark;
+        }
+        std::wstring removed = app.editorText.substr(rs, re - rs);
+        app.editorText.erase(rs, re - rs);
+        pushUndo(app, App::EditAction::Delete, rs, removed, e, rs);
+        app.editorText.insert(rs, repl);
+        pushUndo(app, App::EditAction::Insert, rs, repl, rs,
+                 rs + repl.size());
+        if (inside || outside) {
+            app.editorSelStart = rs;
+            app.editorSelEnd = rs + repl.size();
+        } else {
+            app.editorSelStart = rs + ml;
+            app.editorSelEnd = rs + ml + sel.size();
+        }
+        app.editorCursorPos = app.editorSelEnd;
+        app.editorHasSelection = app.editorSelEnd > app.editorSelStart;
+    } else {
+        size_t before = app.editorCursorPos;
+        std::wstring ins = mark + mark;
+        app.editorText.insert(before, ins);
+        app.editorCursorPos = before + ml;
+        pushUndo(app, App::EditAction::Insert, before, ins, before,
+                 app.editorCursorPos);
+    }
+    rebuildLineStarts(app);
+    app.editorDesiredCol = -1;
+    scheduleReparse(app);
+    editorEnsureCursorVisible(app);
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
 void handleEditorCharInput(App& app, HWND hwnd, WPARAM wParam) {
     // Swallow characters while confirm-exit prompt is active
     if (app.confirmExitPending) return;
@@ -1871,7 +2000,98 @@ void handleEditorCharInput(App& app, HWND hwnd, WPARAM wParam) {
         ch = L'\n';
     }
 
-    if (ch == 9) { // Tab -> 4 spaces
+    // Enter on a list item continues the list; Enter on an empty item
+    // removes its marker and ends it
+    if (ch == L'\n' && !app.editorHasSelection) {
+        size_t ls = editorLineStartBefore(app, app.editorCursorPos);
+        ListMarkerInfo lm = parseListMarker(app.editorText, ls);
+        if (lm.isList && app.editorCursorPos >= ls + lm.contentStart) {
+            size_t le = app.editorText.find(L'\n', ls);
+            if (le == std::wstring::npos) le = app.editorText.size();
+            bool emptyItem = (le == ls + lm.contentStart);
+            if (emptyItem) {
+                std::wstring removed =
+                    app.editorText.substr(ls, lm.contentStart);
+                app.editorText.erase(ls, lm.contentStart);
+                pushUndo(app, App::EditAction::Delete, ls, removed,
+                         app.editorCursorPos, ls);
+                app.editorCursorPos = ls;
+            } else {
+                std::wstring next = lm.marker;
+                if (lm.ordered) {
+                    next = std::to_wstring(lm.number + 1);
+                    next += lm.delim;
+                    next += L' ';
+                } else if (lm.task) {
+                    next = next.substr(0, 2) + L"[ ] ";
+                }
+                std::wstring cont = L"\n" + lm.indent + next;
+                size_t before = app.editorCursorPos;
+                app.editorText.insert(before, cont);
+                app.editorCursorPos = before + cont.size();
+                pushUndo(app, App::EditAction::Insert, before, cont,
+                         before, app.editorCursorPos);
+            }
+            rebuildLineStarts(app);
+            app.editorDesiredCol = -1;
+            scheduleReparse(app);
+            editorEnsureCursorVisible(app);
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
+        }
+    }
+
+    if (ch == 9) { // Tab
+        // Ctrl+I arrives as the Tab control character: keydown handled it
+        if (GetKeyState(VK_CONTROL) & 0x8000) return;
+        bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+        if (shift) {
+            // Shift+Tab: outdent the caret line by up to 4 spaces / a tab
+            size_t ls = editorLineStartBefore(app, app.editorCursorPos);
+            size_t n = 0;
+            while (n < 4 && ls + n < app.editorText.size() &&
+                   app.editorText[ls + n] == L' ') {
+                n++;
+            }
+            if (n == 0 && ls < app.editorText.size() &&
+                app.editorText[ls] == L'\t') {
+                n = 1;
+            }
+            if (n > 0) {
+                std::wstring removed = app.editorText.substr(ls, n);
+                size_t before = app.editorCursorPos;
+                app.editorText.erase(ls, n);
+                pushUndo(app, App::EditAction::Delete, ls, removed,
+                         before, before > ls + n ? before - n : ls);
+                app.editorCursorPos =
+                    before > ls + n ? before - n : ls;
+                rebuildLineStarts(app);
+                app.editorDesiredCol = -1;
+                scheduleReparse(app);
+                editorEnsureCursorVisible(app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            return;
+        }
+        if (!app.editorHasSelection) {
+            // Tab on a list item indents the whole line one level
+            size_t ls = editorLineStartBefore(app, app.editorCursorPos);
+            ListMarkerInfo lm = parseListMarker(app.editorText, ls);
+            if (lm.isList) {
+                std::wstring spaces = L"    ";
+                size_t before = app.editorCursorPos;
+                app.editorText.insert(ls, spaces);
+                app.editorCursorPos = before + 4;
+                pushUndo(app, App::EditAction::Insert, ls, spaces, before,
+                         app.editorCursorPos);
+                rebuildLineStarts(app);
+                app.editorDesiredCol = -1;
+                scheduleReparse(app);
+                editorEnsureCursorVisible(app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
+        }
         std::wstring spaces = L"    ";
         if (app.editorHasSelection) editorDeleteSelection(app);
         size_t before = app.editorCursorPos;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -826,7 +826,10 @@ static void splitFileRefs(const ElementPtr& parent) {
         return;
     }
 
-    static const char* kExtensions[] = {".markdown", ".mmd", ".md"};
+    static const char* kExtensions[] = {
+        ".markdown", ".json", ".yaml", ".toml", ".mmd", ".yml",
+        ".ini",      ".csv",  ".log",  ".txt",  ".md",
+    };
 
     std::vector<ElementPtr> rebuilt;
     bool changed = false;

--- a/src/syntax.cpp
+++ b/src/syntax.cpp
@@ -140,6 +140,8 @@ int detectLanguage(const std::wstring& lang) {
         return 2;  // Python
     if (lower == L"javascript" || lower == L"js" || lower == L"jsx" || lower == L"ts" || lower == L"typescript" || lower == L"tsx")
         return 3;  // JavaScript/TypeScript
+    if (lower == L"json")
+        return 3;  // JSON reads well under the JS rules (strings, numbers, null)
     if (lower == L"rust" || lower == L"rs")
         return 4;  // Rust
     if (lower == L"go" || lower == L"golang")

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -22,7 +22,10 @@ int main() {
     check(isMermaidDocumentPath("diagram.mmd"), ".mmd is detected as Mermaid");
     check(!isMermaidDocumentPath("notes.md"), ".md is not detected as Mermaid");
     check(!isSupportedDocumentPath("diagram.mmdd"), "similar extensions are rejected");
-    check(!isSupportedDocumentPath("notes.txt"), ".txt is not shown as a document");
+    check(isSupportedDocumentPath("notes.txt"), ".txt opens as a plain-text document");
+    check(isSupportedDocumentPath("data.JSON"), ".json is case-insensitive");
+    check(isPlainTextDocumentPath(L"config.yaml"), ".yaml is plain text");
+    check(!isPlainTextDocumentPath("notes.md"), ".md is not plain text");
     check(isSupportedDropPath(L"notes.txt"), "existing .txt drag-and-drop remains supported");
 
     qmd::MarkdownParser parser;
@@ -191,6 +194,53 @@ int main() {
         check(!has("file.mdx"), "longer extensions are not references");
         check(!has(".md"), "a bare extension is not a reference");
         check(!has("v2.md"), "dotted archive names are not references");
+    }
+
+    // Plain-text documents become one highlighted code block
+    {
+        auto json = parseDocument(
+            parser, "{\n  \"key\": true\n}\n", "data.json");
+        check(json.success, "json document parses");
+        check(json.root && json.root->children.size() == 1,
+              "json document is a single block");
+        if (json.root && json.root->children.size() == 1) {
+            const auto& block = json.root->children[0];
+            check(block->type == qmd::ElementType::CodeBlock,
+                  "json content becomes a code block");
+            check(block->language == "json",
+                  "json block carries its language tag");
+            check(!block->children.empty() &&
+                      block->children[0]->text.find("\"key\"") !=
+                          std::string::npos,
+                  "json content is preserved verbatim");
+        }
+        auto txt = parseDocument(parser, "# not a heading\n", "notes.txt");
+        check(txt.success && txt.root && !txt.root->children.empty() &&
+                  txt.root->children[0]->type ==
+                      qmd::ElementType::CodeBlock,
+              ".txt content stays literal instead of parsing as markdown");
+    }
+
+    // Text-file references are detected like .md ones (#7)
+    {
+        auto refs = parseDocument(parser,
+            "Check config.yaml and data/out.json plus error.log here.\n",
+            "notes.md");
+        check(refs.success, "text-file ref test parses");
+        std::vector<std::string> found;
+        std::function<void(const qmd::ElementPtr&)> walk =
+            [&](const qmd::ElementPtr& node) {
+            if (node->type == qmd::ElementType::Link &&
+                node->url.rfind("fileref:", 0) == 0) {
+                found.push_back(node->url.substr(8));
+            }
+            if (node->type != qmd::ElementType::Code &&
+                node->type != qmd::ElementType::CodeBlock) {
+                for (const auto& child : node->children) walk(child);
+            }
+        };
+        if (refs.root) walk(refs.root);
+        check(found.size() == 3, "all three text-file references detected");
     }
 
     // Emoji shortcodes become their emoji, code stays literal


### PR DESCRIPTION
The last two features of the batch:

**Editor markdown assists**
- Enter on a list item continues the list: `- ` and `* ` repeat, ordered lists increment (`2.` -> `3.`), task items continue as `- [ ] `, and indentation is carried over. Enter on an empty item removes its marker and ends the list.
- Tab on a list line indents the whole line one level; Shift+Tab outdents any line by up to four spaces or a tab. Tab elsewhere keeps inserting spaces.
- Ctrl+B / Ctrl+I wrap the selection in `**bold**` / `*italic*`, unwrap when the selection (or its immediate surroundings) already carries the marks, or insert an empty pair at the caret. The selection survives the toggle so B and I can be chained.
- Quirk handled: Ctrl+I arrives a second time as the Tab control character (0x09), so the char handler ignores Tab while Ctrl is held.

**Text files as references and documents**
- `.txt` `.json` `.yaml` `.yml` `.toml` `.ini` `.csv` `.log` paths in prose are detected exactly like `.md` references: live link when the file exists, ghost when missing, create-on-click included.
- Opening one (click, drop, tab restore) renders it as a single syntax-highlighted code block instead of parsing the content as markdown; the link peek and exports reuse the same path. JSON highlights under the JavaScript rules (strings, numbers, true/false/null).

Verified interactively: list continuation/termination, ordered increments, Tab/Shift+Tab round trip, Ctrl+B wrap -> unwrap -> Ctrl+I chain with real keystrokes, live/ghost styling for text refs, a `.json` opening fully highlighted in a tab, and the hover peek rendering the same. document_tests extended for plain-text documents and text-file refs; all four suites pass.