### PR TITLE
Tabs-off windows no longer inherit the saved session (#147)

### DIFF
--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -2246,9 +2246,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     };
 
     // Last session's tabs come back on plain launches (files that vanished
-    // from disk in the meantime are dropped)
+    // from disk in the meantime are dropped). With "Open files in tabs"
+    // off the session stays parked: one window, one document — a file
+    // launch must not drag the previous session in as extra tabs (#147)
     bool restoreSession = !quickNote && !cascadeWindow && !startInEditMode &&
-                          printPagesDir.empty() &&
+                          printPagesDir.empty() && savedSettings.openInTabs &&
                           !savedSettings.sessionTabs.empty();
     std::vector<std::string> sessionPaths;
     int sessionActive = 0;


### PR DESCRIPTION
With "Open files in tabs" off, launching a file merged the saved session into the new window's tab row: open A, then open B, and B's window carried A as a second tab. The session-restore flag never checked the tabs mode, and file-argument launches deliberately append to the restored session (correct for the Notepad model, wrong for one-window-per-document).

Session restore now requires openInTabs: tabs-off means one window, one document, and a bare launch lands on the start page instead of auto-reopening the previous session - which also covers the "do not automatically open documents I did not close" part of #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)