### PR TITLE
Open-files-in-tabs toggle takes effect immediately

### DIFF
--- a/include/settings.h
+++ b/include/settings.h
@@ -25,6 +25,7 @@ void clearRecentFiles();
 void persistThemeChoice(const App& app);
 // Editor mode pill choice (and the assists switch) persist immediately
 void persistEditorMode(const App& app);
+void persistOpenInTabs(const App& app);
 
 // User-remappable single-key actions (#77), written to settings.ini as a
 // [Keys] section. Char actions trigger via WM_CHAR (edit ':', help '?');

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -682,6 +682,10 @@ static void settingsAction(App& app, HWND hwnd, int action) {
             break;
         case SET_TOGGLE_OPENTABS:
             app.openInTabs = !app.openInTabs;
+            // Takes effect for the very next Explorer open, no window
+            // closing required; also keeps older windows' exit saves
+            // from clobbering it (they no longer write this flag)
+            persistOpenInTabs(app);
             break;
         case SET_TOGGLE_ASSISTS:
             app.editorAssists = !app.editorAssists;

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1870,7 +1870,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.dismissedUpdate = app->updateDismissedVersion;
                 settings.folderSearchEnabled = app->folderSearchEnabled;
                 settings.browserFocusPath = app->browserFocusPath;
-                settings.openInTabs = app->openInTabs;
+                // openInTabs persists at toggle time (persistOpenInTabs)
+                // and is preserved from disk here: a window opened before
+                // the toggle must not write its stale value back at exit
                 // Remember the open tab set for the next launch (untitled
                 // quick-note buffers have no path to restore). Satellite
                 // windows never own the session: they re-read the owner's

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -196,6 +196,17 @@ void persistEditorMode(const App& app) {
     saveSettings(settings);
 }
 
+// "Open files in tabs" persists the moment it is toggled: the join-or-
+// spawn decision is made by the NEXT launched process reading
+// settings.ini, so an exit-time save would leave every Explorer open on
+// the old mode until all windows closed (#147 follow-up). The ini is the
+// single source of truth for this flag - the exit save leaves it alone.
+void persistOpenInTabs(const App& app) {
+    Settings settings = loadSettings();
+    settings.openInTabs = app.openInTabs;
+    saveSettings(settings);
+}
+
 // A theme change persists immediately: windows spawned afterwards
 // (quick notes, drag-outs) read settings.ini at startup and would
 // otherwise come up in the look from the previous session


### PR DESCRIPTION
Toggling "Open files in tabs" only reached settings.ini when a window exited, but the join-or-spawn decision is made by the next launched process reading that file - so the new mode only applied after every Tinta window closed, and a window opened before the toggle clobbered the value back at its own exit.

The toggle now persists immediately (same pattern as theme and assists persistence), and the exit save preserves the on-disk value instead of writing the window's stale copy. Toggle in any window, and the very next Explorer open obeys it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)