### PR TITLE
Portable mode: settings.ini beside the exe becomes the config home (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 - **Update check** - Portable builds check GitHub once a day and offer a new release as a quiet, dismissible chip
 - **Search** - Find text with F or Ctrl+F, cycle through matches with Enter; every match shows as a tick on the scrollbar
 - **Persistent settings** - Remembers your theme, zoom level, and window position
+- **Portable mode** - Create a `settings.ini` next to `tinta.exe` (an empty file works) and the whole configuration — settings, custom themes, languages, drafts — lives beside the executable and travels with it; without one, everything stays in `%APPDATA%\Tinta`
 - **Localized interface** - English, Simplified Chinese, Japanese, Korean, German, French, and Italian UI; follows Windows or a chosen language
 - **Text selection & copy** - Select text and copy to clipboard
 - **Zoom support** - Ctrl+scroll to zoom in/out

--- a/include/settings.h
+++ b/include/settings.h
@@ -27,6 +27,10 @@ void persistThemeChoice(const App& app);
 void persistEditorMode(const App& app);
 void persistOpenInTabs(const App& app);
 
+// The configuration home: the exe's folder in portable mode (a
+// settings.ini beside tinta.exe opts in, #147), else %APPDATA%\Tinta
+std::wstring tintaConfigDir();
+
 // User-remappable single-key actions (#77), written to settings.ini as a
 // [Keys] section. Char actions trigger via WM_CHAR (edit ':', help '?');
 // the rest are WM_KEYDOWN virtual-key codes. Ctrl combos stay fixed.

--- a/src/drafts.cpp
+++ b/src/drafts.cpp
@@ -1,4 +1,5 @@
 #include "drafts.h"
+#include "settings.h"
 #include "tabs.h"
 #include "editor.h"
 #include "utils.h"
@@ -7,16 +8,11 @@
 #include <fstream>
 #include <sstream>
 
-// %APPDATA%\Tinta\drafts, created on first use
+// The config home's drafts folder (portable beside the exe, else
+// %APPDATA%\Tinta), created on first use
 static std::wstring draftsDirPath() {
-    wchar_t appDataPath[MAX_PATH];
-    if (FAILED(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0,
-                                appDataPath))) {
-        return L"";
-    }
-    std::wstring path = appDataPath;
-    path += L"\\Tinta";
-    CreateDirectoryW(path.c_str(), nullptr);
+    std::wstring path = tintaConfigDir();
+    if (path.empty()) return L"";
     path += L"\\drafts";
     CreateDirectoryW(path.c_str(), nullptr);
     return path;

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -1,5 +1,6 @@
 #include "i18n.h"
 #include "app.h"
+#include "settings.h"
 
 #include <windows.h>
 #include <string.h>
@@ -1277,14 +1278,10 @@ std::wstring langUtf8ToWide(const std::string& s) {
 }
 
 std::wstring languagesIniPath() {
-    wchar_t appData[MAX_PATH];
-    if (FAILED(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0, appData))) {
-        return L"";
-    }
-    std::wstring path = appData;
-    path += L"\\Tinta";
-    CreateDirectoryW(path.c_str(), nullptr);
-    return path + L"\\languages.ini";
+    // Follows the config home: portable beside the exe, else %APPDATA%
+    std::wstring dir = tintaConfigDir();
+    if (dir.empty()) return L"";
+    return dir + L"\\languages.ini";
 }
 
 // Section-name aliases onto the compiled languages

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -17,16 +17,49 @@ static int settingsLanguageIndex(const Settings& settings) {
     return detectSystemLanguage();
 }
 
-std::wstring getSettingsPath() {
+// Portable mode (#147): a settings.ini beside the executable makes that
+// folder the configuration home - settings, themes.ini, languages.ini,
+// and drafts all live there, so the whole setup travels with the exe.
+// Without it, everything stays in %APPDATA%\Tinta as before (Store
+// installs land here automatically: their folder is read-only, so an
+// exe-adjacent settings.ini cannot exist). Resolved once per run.
+std::wstring tintaConfigDir() {
+    static std::wstring cached;
+    static bool resolved = false;
+    if (resolved) return cached;
+    resolved = true;
+
+    wchar_t exePath[MAX_PATH];
+    if (GetModuleFileNameW(nullptr, exePath, MAX_PATH) > 0) {
+        std::wstring dir = exePath;
+        size_t slash = dir.find_last_of(L"\\/");
+        if (slash != std::wstring::npos) {
+            dir = dir.substr(0, slash);
+            DWORD attrs =
+                GetFileAttributesW((dir + L"\\settings.ini").c_str());
+            if (attrs != INVALID_FILE_ATTRIBUTES &&
+                !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+                cached = dir;
+                return cached;
+            }
+        }
+    }
+
     wchar_t appDataPath[MAX_PATH];
-    if (SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0, appDataPath))) {
+    if (SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0,
+                                   appDataPath))) {
         std::wstring path = appDataPath;
         path += L"\\Tinta";
         CreateDirectoryW(path.c_str(), nullptr);  // Create if not exists
-        path += L"\\settings.ini";
-        return path;
+        cached = path;
     }
-    return L"";
+    return cached;
+}
+
+std::wstring getSettingsPath() {
+    std::wstring dir = tintaConfigDir();
+    if (dir.empty()) return L"";
+    return dir + L"\\settings.ini";
 }
 
 void saveSettings(const Settings& settings) {

--- a/src/themes.cpp
+++ b/src/themes.cpp
@@ -237,6 +237,8 @@ const int THEME_COUNT = sizeof(THEMES) / sizeof(THEMES[0]);
 //   text=D8DEE9
 //   ...
 
+#include "settings.h"
+
 #include <shlobj.h>
 #include <fstream>
 #include <memory>
@@ -248,14 +250,10 @@ namespace {
 std::vector<std::unique_ptr<CustomTheme>> g_customThemes;
 
 std::wstring themesIniPath() {
-    wchar_t appData[MAX_PATH];
-    if (FAILED(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0, appData))) {
-        return L"";
-    }
-    std::wstring path = appData;
-    path += L"\\Tinta";
-    CreateDirectoryW(path.c_str(), nullptr);
-    return path + L"\\themes.ini";
+    // Follows the config home: portable beside the exe, else %APPDATA%
+    std::wstring dir = tintaConfigDir();
+    if (dir.empty()) return L"";
+    return dir + L"\\themes.ini";
 }
 
 bool parseHexColor(const std::string& value, D2D1_COLOR_F& out) {


### PR DESCRIPTION
The second half of #147. Create a settings.ini next to tinta.exe (an empty file opts in) and that folder becomes the configuration home: settings, custom themes, language packs, and draft autosaves all live beside the executable and travel with it. Without one, everything stays in %APPDATA%\Tinta exactly as before - Store installs fall back automatically because their install folder is read-only.

All four config paths (settings.ini, themes.ini, languages.ini, drafts/) now route through a single resolver, checked once per run. Verified end-to-end: a portable folder reads its own theme, writes its settings and recents back on exit, and leaves %APPDATA% untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)