### PR TITLE
Tables measure cells with the renderer's own shaping (#148)

### DIFF
--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2733,20 +2733,19 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
             }
             tsv += tsvCell;
 
-            // Measure natural width
+            // Measure natural width THE WAY THE RENDERER SHAPES IT — same
+            // typography and the language-aware font fallback. A raw
+            // layout here picked a different CJK font than the renderer,
+            // whose slightly wider advances then wrapped a "fitting" cell
+            // one line past its measured row height (#148)
             bool isHeader = (r == 0);
             IDWriteTextFormat* fmt = isHeader ? app.boldFormat : app.textFormat;
             float textWidth = 0;
             if (!text.empty() && fmt) {
-                IDWriteTextLayout* layout = nullptr;
-                app.dwriteFactory->CreateTextLayout(text.data(), (UINT32)text.length(),
-                    fmt, kHugeWidth, lineHeight, &layout);
-                if (layout) {
-                    DWRITE_TEXT_METRICS metrics{};
-                    layout->GetMetrics(&metrics);
-                    textWidth = metrics.widthIncludingTrailingWhitespace;
-                    layout->Release();
-                }
+                LayoutInfo mi = createLayout(app, text, fmt, lineHeight,
+                                             app.bodyTypography);
+                textWidth = mi.width;
+                if (mi.layout) mi.layout->Release();
             }
             float needed = textWidth + cellPadding * 2 + 6.0f * scale;
             if (needed > colWidths[c]) colWidths[c] = needed;


### PR DESCRIPTION
Fixes the overlap half of #148 (repro: the attached temp.md).

Table column widths were measured with a raw DirectWrite layout, but cells render through createLayout, which applies typography features and the language-aware CJK font fallback (#48). Different font, different advances: CJK columns came out a few pixels narrower than the text the renderer actually draws. The widest cell in a column - whose natural width defines that column - could then wrap one line past its measured row height, drawing its last line over the table border. The height-trial skip for simple fitting cells masked it, which is why only plain-text tables showed it (a bold span forces the full trial and the row grows correctly).

Measuring with the same shaping as the renderer removes the mismatch entirely: in the repro both tables now render every row on one line inside their borders, and CJK tables in general stop wrapping unnecessarily. Latin tables are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)