### PR TITLE
Locale-aware kanji font fallback (#155)

### DIFF
--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -245,14 +245,29 @@ void updateTextFormats(App& app) {
                 };
                 builder->AddMapping(krRanges, 5, krFamilies, 3);
 
-                // --- CJK ideographs: Chinese font first ---
-                // Putting Microsoft YaHei UI before Japanese fonts ensures
-                // Chinese characters use the Chinese glyph variant and a
-                // consistent Regular weight instead of Yu Gothic UI's
-                // visually-heavier strokes.
-                const wchar_t* cjkFamilies[] = {
+                // --- CJK ideographs: ordered by the Windows UI language ---
+                // Han unification shares code points across languages but
+                // the glyph shapes differ, so whichever family sits first
+                // decides the variant every ideograph renders with. The
+                // default keeps Microsoft YaHei UI first (Chinese variants
+                // and a consistent Regular weight instead of Yu Gothic UI's
+                // visually-heavier strokes); Japanese and Korean systems
+                // reorder so kanji/hanja match the kana or hangul around
+                // them instead of coming out Simplified-Chinese (#155).
+                const wchar_t* cjkZh[] = {
                     L"Microsoft YaHei UI", L"Yu Gothic UI", L"Meiryo", L"Malgun Gothic"
                 };
+                const wchar_t* cjkJa[] = {
+                    L"Yu Gothic UI", L"Meiryo", L"Microsoft YaHei UI", L"Malgun Gothic"
+                };
+                const wchar_t* cjkKo[] = {
+                    L"Malgun Gothic", L"Microsoft YaHei UI", L"Yu Gothic UI", L"Meiryo"
+                };
+                WORD uiLang = PRIMARYLANGID(GetUserDefaultUILanguage());
+                const wchar_t** cjkFamilies =
+                    uiLang == LANG_JAPANESE ? cjkJa
+                    : uiLang == LANG_KOREAN ? cjkKo
+                                            : cjkZh;
                 DWRITE_UNICODE_RANGE cjkRanges[] = {
                     { 0x2E80, 0x303F },    // CJK radicals, Kangxi, CJK symbols & punctuation
                     { 0x3100, 0x312F },    // Bopomofo


### PR DESCRIPTION
For #155. Kana ranges already preferred Japanese fonts, but the CJK unified ideograph mapping put Microsoft YaHei UI first for everyone, so Japanese documents rendered kanji with Simplified-Chinese glyph variants and a mismatched weight next to Yu Gothic kana.

The ideograph family order now follows the Windows UI language at fallback build time: Japanese gets Yu Gothic UI / Meiryo first, Korean gets Malgun Gothic first, and everything else keeps the existing YaHei-first order (Chinese variants and consistent Regular weight), so nothing changes for current Chinese and Latin users. Verified by forcing each branch and comparing renders; the default branch is pixel-identical to before.

An explicit font family is already possible through a custom theme (font= in themes.ini or the theme editor), which covers the manual-override ask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)