### PR TITLE
Fix test-target link break from portable mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     src/markdown.cpp
     src/themes.cpp
     src/settings.cpp
+    src/config_dir.cpp
     src/d2d_init.cpp
     src/syntax.cpp
     src/utils.cpp
@@ -173,18 +174,20 @@ if(BUILD_TESTING)
         src/inline_style.cpp
         src/markdown.cpp
         src/themes.cpp
+        src/config_dir.cpp
     )
     target_include_directories(inline_style_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${md4c_SOURCE_DIR}/src
     )
-    target_link_libraries(inline_style_tests PRIVATE md4c d2d1 dwrite windowscodecs)
+    target_link_libraries(inline_style_tests PRIVATE md4c d2d1 dwrite windowscodecs shell32)
     target_compile_definitions(inline_style_tests PRIVATE UNICODE _UNICODE)
     add_test(NAME inline_styles COMMAND inline_style_tests)
 
     add_executable(i18n_tests
         tests/i18n_tests.cpp
         src/i18n.cpp
+        src/config_dir.cpp
     )
     target_include_directories(i18n_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/src/config_dir.cpp
+++ b/src/config_dir.cpp
@@ -1,0 +1,46 @@
+#include "settings.h"
+
+#include <windows.h>
+#include <shlobj.h>
+#include <string>
+
+// Portable mode (#147): a settings.ini beside the executable makes that
+// folder the configuration home - settings, themes.ini, languages.ini,
+// and drafts all live there, so the whole setup travels with the exe.
+// Without it, everything stays in %APPDATA%\Tinta as before (Store
+// installs land here automatically: their folder is read-only, so an
+// exe-adjacent settings.ini cannot exist). Resolved once per run.
+// Lives in its own translation unit so the test targets that compile
+// themes.cpp or i18n.cpp can link it without dragging in settings.cpp.
+std::wstring tintaConfigDir() {
+    static std::wstring cached;
+    static bool resolved = false;
+    if (resolved) return cached;
+    resolved = true;
+
+    wchar_t exePath[MAX_PATH];
+    if (GetModuleFileNameW(nullptr, exePath, MAX_PATH) > 0) {
+        std::wstring dir = exePath;
+        size_t slash = dir.find_last_of(L"\\/");
+        if (slash != std::wstring::npos) {
+            dir = dir.substr(0, slash);
+            DWORD attrs =
+                GetFileAttributesW((dir + L"\\settings.ini").c_str());
+            if (attrs != INVALID_FILE_ATTRIBUTES &&
+                !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+                cached = dir;
+                return cached;
+            }
+        }
+    }
+
+    wchar_t appDataPath[MAX_PATH];
+    if (SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0,
+                                   appDataPath))) {
+        std::wstring path = appDataPath;
+        path += L"\\Tinta";
+        CreateDirectoryW(path.c_str(), nullptr);  // Create if not exists
+        cached = path;
+    }
+    return cached;
+}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -17,44 +17,8 @@ static int settingsLanguageIndex(const Settings& settings) {
     return detectSystemLanguage();
 }
 
-// Portable mode (#147): a settings.ini beside the executable makes that
-// folder the configuration home - settings, themes.ini, languages.ini,
-// and drafts all live there, so the whole setup travels with the exe.
-// Without it, everything stays in %APPDATA%\Tinta as before (Store
-// installs land here automatically: their folder is read-only, so an
-// exe-adjacent settings.ini cannot exist). Resolved once per run.
-std::wstring tintaConfigDir() {
-    static std::wstring cached;
-    static bool resolved = false;
-    if (resolved) return cached;
-    resolved = true;
-
-    wchar_t exePath[MAX_PATH];
-    if (GetModuleFileNameW(nullptr, exePath, MAX_PATH) > 0) {
-        std::wstring dir = exePath;
-        size_t slash = dir.find_last_of(L"\\/");
-        if (slash != std::wstring::npos) {
-            dir = dir.substr(0, slash);
-            DWORD attrs =
-                GetFileAttributesW((dir + L"\\settings.ini").c_str());
-            if (attrs != INVALID_FILE_ATTRIBUTES &&
-                !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
-                cached = dir;
-                return cached;
-            }
-        }
-    }
-
-    wchar_t appDataPath[MAX_PATH];
-    if (SUCCEEDED(SHGetFolderPathW(nullptr, CSIDL_APPDATA, nullptr, 0,
-                                   appDataPath))) {
-        std::wstring path = appDataPath;
-        path += L"\\Tinta";
-        CreateDirectoryW(path.c_str(), nullptr);  // Create if not exists
-        cached = path;
-    }
-    return cached;
-}
+// tintaConfigDir (portable mode #147) lives in config_dir.cpp so test
+// targets can link it without this translation unit.
 
 std::wstring getSettingsPath() {
     std::wstring dir = tintaConfigDir();


### PR DESCRIPTION
The v3.4.0 tag build failed: i18n_tests and inline_style_tests compile i18n.cpp / themes.cpp, which call tintaConfigDir() since #151, but neither links settings.cpp. Local ctest missed it because only the tinta target was being rebuilt, so the test executables were stale.

tintaConfigDir now lives in its own translation unit (src/config_dir.cpp) linked by the app and both test targets, avoiding dragging settings.cpp (and its i18n dependency) into the tests. Full all-target build and ctest verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)