### PR TITLE
Consistent file references and default-app opens (#162)

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -665,6 +665,9 @@ struct App {
     std::string linkPeekUrl;    // hoveredLink value the dwell timer armed for
     std::wstring linkPeekTitle;
     bool linkPeekActive = false;
+    // Peeking a plain-text file: the whole-file code block drops its card
+    // chrome, since the peek panel already frames the content
+    bool peekFrameless = false;
     ID2D1Bitmap* linkPeekBitmap = nullptr;  // owned while active
     D2D1_RECT_F linkPeekAnchorDoc{};        // hovered link rect (doc coords)
     D2D1_RECT_F linkPeekPanel{};            // placed panel (screen coords)

--- a/include/markdown.h
+++ b/include/markdown.h
@@ -112,6 +112,14 @@ private:
     bool m_taskLists = true;
 };
 
+// File-reference extension gate (#127/#141/#162): true when the path
+// ends in one of the extensions the plain-path scanner recognizes
+bool fileRefKnownExtension(const std::string& path);
+// True for Tinta's own document types (.md/.mmd/.markdown): these open
+// in a tab, while other known text files open with their registered
+// application (#162)
+bool fileRefIsMarkdown(const std::string& path);
+
 // Utility functions
 std::string elementTypeToString(ElementType type);
 void debugPrintElement(const ElementPtr& elem, int indent = 0);

--- a/src/inline_style.cpp
+++ b/src/inline_style.cpp
@@ -45,9 +45,10 @@ std::string percentDecode(const std::string& value) {
     return out;
 }
 
-// A real [text](target) whose target is a local markdown path gets the
-// same live/broken treatment as a plain-text reference
-bool isLocalMarkdownUrl(const std::string& url) {
+// A real [text](target) whose target is a local text-file path gets the
+// same live/broken treatment as a plain-text reference - any extension
+// the plain-path scanner recognizes, not just markdown (#162)
+bool isLocalFileRefUrl(const std::string& url) {
     if (url.empty() || url[0] == '#') return false;
     if (url.find("://") != std::string::npos) return false;
     if (url.rfind("//", 0) == 0 || url.rfind("\\\\", 0) == 0) return false;
@@ -57,13 +58,7 @@ bool isLocalMarkdownUrl(const std::string& url) {
             return false;  // wiki:, mailto:, and other schemes
         }
     }
-    std::string lower = url;
-    for (char& c : lower) c = (char)std::tolower((unsigned char)c);
-    return lower.size() > 3 &&
-           (lower.rfind(".md") == lower.size() - 3 ||
-            (lower.size() > 4 && lower.rfind(".mmd") == lower.size() - 4) ||
-            (lower.size() > 9 &&
-             lower.rfind(".markdown") == lower.size() - 9));
+    return qmd::fileRefKnownExtension(url);
 }
 
 // Resolves against the current file's folder and checks the disk, cached
@@ -159,7 +154,7 @@ void flattenInline(App& app, const std::vector<ElementPtr>& elements,
                 std::string target;
                 if (elem->url.rfind("fileref:", 0) == 0) {
                     target = elem->url.substr(8);
-                } else if (isLocalMarkdownUrl(elem->url)) {
+                } else if (isLocalFileRefUrl(elem->url)) {
                     target = elem->url;
                 }
                 if (!target.empty()) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1744,6 +1744,9 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     if (app.showThemeEditor || app.showShortcutEditor) return;
     // Unsaved-changes dialog is modal: buttons act on the release
     if (app.editMode && app.confirmExitPending) return;
+    // Create-missing-reference dialog: buttons act on the release; the
+    // press must not start a document selection underneath it
+    if (app.createRefPending) return;
 
     // Settings: sliders drag from the press; everything else acts on release
     if (app.showSettings) {
@@ -2197,12 +2200,20 @@ static void navRecordJump(App& app, const std::string& fromPath,
     app.navForward.clear();
 }
 
-// A live .md reference joins the window as a tab (#127)
-static void openFileRefTarget(App& app, HWND hwnd, const std::string& path) {
+// A live reference: markdown joins the window as a tab (#127), other
+// text files open with their registered application (#162). Returns
+// true when the target opened inside Tinta.
+static bool openFileRefTarget(App& app, HWND hwnd, const std::string& path) {
+    if (!qmd::fileRefIsMarkdown(path)) {
+        ShellExecuteW(hwnd, L"open", toWide(path).c_str(), nullptr,
+                      nullptr, SW_SHOWNORMAL);
+        return false;
+    }
     if (_stricmp(app.currentFile.c_str(), path.c_str()) != 0) {
         navRecordJump(app, app.currentFile, app.scrollY);
     }
     tabOpenPath(app, hwnd, path, true);
+    return true;
 }
 
 // Start page actions (design t7). Ids match startPageHitAt: 1 open,
@@ -2316,8 +2327,11 @@ static void createRefAction(App& app, HWND hwnd, int action) {
             out.close();
             // The layout cached this path as missing; the ghost turns live
             app.fileRefCache.erase(app.createRefPath);
-            openFileRefTarget(app, hwnd, app.createRefPath);
-            enterEditMode(app);
+            // A markdown target opens in a tab ready to type; other text
+            // files hand off to their registered application (#162)
+            if (openFileRefTarget(app, hwnd, app.createRefPath)) {
+                enterEditMode(app);
+            }
         }
     }
     app.createRefPath.clear();
@@ -2585,7 +2599,6 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     if (app.createRefPending) {
         float mx = (float)GET_X_LPARAM(lParam);
         float my = (float)GET_Y_LPARAM(lParam);
-        app.swallowNextMouseUp = true;
         for (const auto& hit : app.createRefHits) {
             if (mx >= hit.first.left && mx <= hit.first.right &&
                 my >= hit.first.top && my <= hit.first.bottom) {

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -12,6 +12,32 @@
 
 namespace qmd {
 
+// Extensions that get the live/broken file-reference treatment. The
+// plain-path scanner, explicit [text](target) links, and the click
+// handler (#162) all share this gate.
+const char* const kFileRefExtensions[] = {
+    ".markdown", ".json", ".yaml", ".toml", ".mmd", ".yml",
+    ".ini",      ".csv",  ".log",  ".txt",  ".md",  ".xml",
+};
+
+static bool endsWithNoCase(const std::string& s, const char* suffix) {
+    size_t len = strlen(suffix);
+    return s.size() > len &&
+           _strnicmp(s.c_str() + s.size() - len, suffix, len) == 0;
+}
+
+bool fileRefKnownExtension(const std::string& path) {
+    for (const char* ext : kFileRefExtensions) {
+        if (endsWithNoCase(path, ext)) return true;
+    }
+    return false;
+}
+
+bool fileRefIsMarkdown(const std::string& path) {
+    return endsWithNoCase(path, ".md") || endsWithNoCase(path, ".mmd") ||
+           endsWithNoCase(path, ".markdown");
+}
+
 // Parser context for MD4C callbacks
 struct ParserContext {
     ElementPtr root;
@@ -826,11 +852,6 @@ static void splitFileRefs(const ElementPtr& parent) {
         return;
     }
 
-    static const char* kExtensions[] = {
-        ".markdown", ".json", ".yaml", ".toml", ".mmd", ".yml",
-        ".ini",      ".csv",  ".log",  ".txt",  ".md",
-    };
-
     std::vector<ElementPtr> rebuilt;
     bool changed = false;
     for (auto& child : parent->children) {
@@ -848,7 +869,7 @@ static void splitFileRefs(const ElementPtr& parent) {
             size_t dot = text.find('.', scan);
             if (dot == std::string::npos) break;
             size_t extLength = 0;
-            for (const char* extension : kExtensions) {
+            for (const char* extension : kFileRefExtensions) {
                 size_t length = strlen(extension);
                 if (dot + length <= text.size() &&
                     _strnicmp(text.c_str() + dot, extension, length) == 0 &&

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -939,7 +939,11 @@ ID2D1Bitmap* renderPeekBitmap(App& app, const std::wstring& path,
     updateTextFormats(app);
     app.root = parsed.root;
     app.currentFile = toUtf8(path);  // relative images resolve at the target
+    // Plain-text targets drop the whole-file code block's card: the peek
+    // panel is already the frame
+    app.peekFrameless = isPlainTextDocumentPath(std::wstring_view(path));
     layoutAtPrintWidth(app, widthDips);
+    app.peekFrameless = false;
     // The layout starts below the (invisible) title strip; the peek slice
     // begins there and shrinks to short targets
     float topPad = chromeTopHeight(app);

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2066,8 +2066,13 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
 
     float blockHeight = lineCount * lineHeight + padding * 2;
     size_t bgRectIndex = app.layoutRects.size();
-    app.layoutRects.push_back({D2D1::RectF(indent, y, indent + maxWidth, y + blockHeight),
-                               app.theme.codeBackground});
+    // Peeking a plain-text file: the panel already frames the content,
+    // so the whole-file wrapper block skips its own card
+    bool frameless = app.peekFrameless;
+    if (!frameless) {
+        app.layoutRects.push_back({D2D1::RectF(indent, y, indent + maxWidth, y + blockHeight),
+                                   app.theme.codeBackground});
+    }
 
     std::wstring wcode = toWide(code);
 
@@ -2166,7 +2171,9 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
     // wide code participates in horizontal scrolling like diagrams do
     float widestExtent = maxLineWidth + padding * 2;
     if (widestExtent > maxWidth) {
-        app.layoutRects[bgRectIndex].rect.right = indent + widestExtent;
+        if (!frameless) {
+            app.layoutRects[bgRectIndex].rect.right = indent + widestExtent;
+        }
         app.contentWidth = std::max(app.contentWidth, indent + widestExtent);
     }
 


### PR DESCRIPTION
Closes #162.

- Explicit `[text](target)` links get the same live/broken file-reference treatment as bare paths for every extension the plain-path scanner recognizes (one shared list, `.xml` added) - so they peek on hover and ghost when missing, matching bare references.
- Clicking a live non-markdown reference now opens the file with its registered application (ShellExecute) instead of a Tinta tab; markdown targets keep joining as tabs. Create-on-click hands new non-markdown files to the same handler.
- The peek drops the whole-file code-block card for plain-text targets - the panel already frames the content.
- The create-file dialog no longer leaks a document selection: the press is swallowed while the dialog is open, and the stray swallowNextMouseUp no longer eats the next click''s release.

Verified live: explicit .txt/.json/.yaml links render dashed and peek, clicking notes.txt launched the registered Notepad with no new tab, companion.md still opens as a tab, and cancelling the create dialog leaves no selection behind. Full all-target build, tests 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)