### PR TITLE
Annotate shortcut no longer leaks into the note box (#161)

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -3714,6 +3714,13 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 if (!app.showSearch && !app.showThemeChooser && !app.showToc &&
                     !app.showFolderBrowser) {
                     annotationBeginCreate(app);
+                    // The keystroke that opened the editor must not leak
+                    // its character into the note box (#161)
+                    if (app.annotEditorOpen) {
+                        app.swallowCharsUntil =
+                            std::chrono::steady_clock::now() +
+                            std::chrono::milliseconds(150);
+                    }
                     InvalidateRect(hwnd, nullptr, FALSE);
                 }
                 break;


### PR DESCRIPTION
For #161. The A keydown opened the annotation editor and the keystroke''s WM_CHAR then landed in the fresh note box as a stray "a". The keydown now arms the existing timed character swallow (the create-reference dialog''s guard) when the editor actually opened, so the opening keystroke dies before the box sees it while normal typing lands untouched. Verified live: select, press A, box opens empty, typing works.