### PR TITLE
Open Store config files using their actual filesystem paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,17 @@ if(BUILD_TESTING)
     target_link_libraries(i18n_tests PRIVATE shell32)
     target_compile_definitions(i18n_tests PRIVATE UNICODE _UNICODE)
     add_test(NAME i18n COMMAND i18n_tests)
+
+    add_executable(config_path_tests
+        tests/config_path_tests.cpp
+        src/config_dir.cpp
+    )
+    target_include_directories(config_path_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(config_path_tests PRIVATE shell32)
+    target_compile_definitions(config_path_tests PRIVATE UNICODE _UNICODE)
+    add_test(NAME config_paths COMMAND config_path_tests)
 endif()
 
 # Install

--- a/include/settings.h
+++ b/include/settings.h
@@ -31,6 +31,10 @@ void persistOpenInTabs(const App& app);
 // settings.ini beside tinta.exe opts in, #147), else %APPDATA%\Tinta
 std::wstring tintaConfigDir();
 
+// Resolve the actual file before handing it to an external editor, which
+// does not share a Store/MSIX process's virtualized AppData view.
+std::wstring configFilePathForShell(const std::wstring& path);
+
 // User-remappable single-key actions (#77), written to settings.ini as a
 // [Keys] section. Char actions trigger via WM_CHAR (edit ':', help '?');
 // the rest are WM_KEYDOWN virtual-key codes. Ctrl combos stay fixed.

--- a/src/config_dir.cpp
+++ b/src/config_dir.cpp
@@ -44,3 +44,32 @@ std::wstring tintaConfigDir() {
     }
     return cached;
 }
+
+std::wstring configFilePathForShell(const std::wstring& path) {
+    if (path.empty()) return path;
+    // Resolve the file, not just its parent: MSIX can merge redirected
+    // files with existing, unvirtualized files in the same AppData folder.
+    HANDLE file = CreateFileW(path.c_str(), 0,
+                             FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                             nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file == INVALID_HANDLE_VALUE) return path;
+
+    DWORD size = GetFinalPathNameByHandleW(file, nullptr, 0, VOLUME_NAME_DOS);
+    std::wstring resolved(size, L'\0');
+    DWORD length = size ? GetFinalPathNameByHandleW(file, resolved.data(), size,
+                                                  VOLUME_NAME_DOS) : 0;
+    CloseHandle(file);
+    if (!length || length >= size) return path;
+    resolved.resize(length);
+
+    // Shell file associations expect ordinary DOS/UNC paths, not the
+    // extended-path prefix returned by GetFinalPathNameByHandleW.
+    if (resolved.rfind(L"\\\\?\\UNC\\", 0) == 0) {
+        return L"\\\\" + resolved.substr(8);
+    }
+    if (resolved.rfind(L"\\\\?\\", 0) == 0 && resolved.size() > 6 &&
+        resolved[5] == L':') {
+        resolved.erase(0, 4);
+    }
+    return resolved;
+}

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -1462,5 +1462,6 @@ void openLanguagesIniFile() {
             }
         }
     }
-    ShellExecuteW(nullptr, L"open", path.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    ShellExecuteW(nullptr, L"open", configFilePathForShell(path).c_str(),
+                  nullptr, nullptr, SW_SHOWNORMAL);
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -577,7 +577,8 @@ static void openThemesIniFile() {
         std::ofstream f(p);
         f << "; Custom themes: [theme] sections, RRGGBB colors.\n";
     }
-    ShellExecuteW(nullptr, L"open", p.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    ShellExecuteW(nullptr, L"open", configFilePathForShell(p).c_str(),
+                  nullptr, nullptr, SW_SHOWNORMAL);
 }
 
 // editCurrent seeds the editor with the active theme's name so saving
@@ -754,7 +755,7 @@ static void settingsAction(App& app, HWND hwnd, int action) {
             break;
         case SET_TOC_RIGHT: app.tocOnLeft = false; break;
         case SET_OPEN_INI:
-            ShellExecuteW(nullptr, L"open", getSettingsPath().c_str(),
+            ShellExecuteW(nullptr, L"open", configFilePathForShell(getSettingsPath()).c_str(),
                           nullptr, nullptr, SW_SHOWNORMAL);
             break;
         case SET_OPEN_THEMES_INI:

--- a/tests/config_path_tests.cpp
+++ b/tests/config_path_tests.cpp
@@ -1,0 +1,83 @@
+#include "settings.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void check(bool condition, const char* message) {
+    if (condition) return;
+    std::cerr << "FAIL: " << message << '\n';
+    failures++;
+}
+
+} // namespace
+
+int main() {
+    namespace fs = std::filesystem;
+    // Unique test files only: never read/write the user's real Tinta config.
+    fs::path dir = fs::temp_directory_path() /
+        (L"tinta config \u65E5\u672C-" + std::to_wstring(GetCurrentProcessId()) +
+         L"-" + std::to_wstring(GetTickCount64()));
+    std::error_code error;
+    if (!fs::create_directory(dir, error)) {
+        std::cerr << "Cannot create config test directory: " << error.message() << '\n';
+        return 1;
+    }
+
+    check(configFilePathForShell(L"").empty(), "empty config path stays empty");
+    std::wstring missing = (dir / L"missing.ini").wstring();
+    check(configFilePathForShell(missing) == missing,
+          "missing file retains the original path for shell error handling");
+    check(!fs::exists(missing), "resolving a missing file does not create it");
+
+    for (const wchar_t* name : {L"settings.ini", L"themes.ini", L"languages.ini"}) {
+        fs::path path = dir / name;
+        {
+            std::ofstream file(path, std::ios::binary);
+            file << "; config path test\n";
+            check(file.good(), "test INI is written");
+        }
+        std::wstring resolved = configFilePathForShell(path.wstring());
+        check(resolved.rfind(L"\\\\?\\", 0) != 0,
+              "shell path has no extended DOS prefix");
+        check(fs::equivalent(path, fs::path(resolved), error) && !error,
+              "shell path identifies the same file, including spaces and Unicode");
+
+        // The helper must not depend on how a caller spells an existing path.
+        std::wstring ordinary = path.wstring();
+        std::wstring extended = ordinary.rfind(L"\\\\", 0) == 0
+            ? L"\\\\?\\UNC\\" + ordinary.substr(2) : L"\\\\?\\" + ordinary;
+        check(configFilePathForShell(extended) == resolved,
+              "extended DOS input resolves to the ordinary shell path");
+
+        HANDLE shared = CreateFileW(path.c_str(), GENERIC_READ,
+                                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                                    nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+        check(shared != INVALID_HANDLE_VALUE, "test reader opens the INI");
+        if (shared != INVALID_HANDLE_VALUE) {
+            check(configFilePathForShell(path.wstring()) == resolved,
+                  "an already open INI can still be resolved");
+            CloseHandle(shared);
+        }
+
+        std::ifstream file(fs::path(resolved), std::ios::binary);
+        std::string line;
+        std::getline(file, line);
+        check(line == "; config path test", "resolution preserves INI contents");
+        file.close();
+        check(fs::remove(path, error) && !error, "resolution releases its file handle");
+    }
+    check(fs::remove(dir, error) && !error, "temporary config directory is removed");
+
+    if (failures == 0) {
+        std::cout << "Config path tests passed\n";
+        return 0;
+    }
+    std::cerr << failures << " failure(s)\n";
+    return 1;
+}


### PR DESCRIPTION
# Open Store config files using their actual filesystem paths

## Summary

In a Store/MSIX installation, the configuration buttons can pass a logical
AppData path to the default editor even though the INI exists only in the
package's redirected storage. The editor cannot find the logical path.

Resolve the existing file with CreateFileW/GetFinalPathNameByHandleW before
ShellExecuteW, converting the returned extended DOS/UNC prefix to a shell path.
Use the shared helper for settings.ini, themes.ini and languages.ini. Existing
template creation still happens before opening the file.

Configuration locations and defaults are unchanged. Resolving each file also
preserves the mixed case where Windows opens an existing ordinary AppData file.
Unresolvable paths retain the previous shell behavior.

## Virtualization behavior

[Microsoft's Flexible virtualization documentation](https://learn.microsoft.com/th-th/windows/msix/desktop/flexible-virtualization)
explains AppData redirection and existing-file fallback. Its optional manifest
exclusions would change virtualization and uninstall behavior and require the
unvirtualizedResources restricted capability; selective exclusions require
Windows 11. This change leaves the manifest and storage policy alone.

The article explains the underlying behavior, rather than recommending this
specific implementation. The path-resolution API is documented separately:
[GetFinalPathNameByHandleW](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfinalpathnamebyhandlew).

## Verification

Based on upstream master `3c6c8db8b8377991872220d145facef47ee93fa4`.
Verified commit `b79fcca061f828e1653e098c74e0b75785eb3698` with a fresh build:

```powershell
cmake -S . -B build/pr-msix -G "Visual Studio 18 2026" -A x64 -DBUILD_TESTING=ON
cmake --build build/pr-msix --config Release --parallel 4
ctest --test-dir build/pr-msix -C Release --output-on-failure --no-tests=error
```

- Configure and full all-target Release x64 build succeeded; CTest passed **5/5**
  tests (all exit codes 0). MSVC 19.51, SDK 10.0.26100 and CMake 4.3.1.
- Added config-path tests for all three INI names, spaces/Unicode, empty/missing
  files, extended DOS paths, open readers, preserved contents and handle cleanup.
- Fresh Store Tinta 3.4.0.0, with ordinary AppData/Tinta absent: all three buttons
  reproduced Notepad's missing-path error.
- Launched the full rebuilt application under that same installed package
  identity using Microsoft's
  [Invoke-CommandInDesktopPackage](https://learn.microsoft.com/en-us/powershell/module/appx/invoke-commandindesktoppackage),
  with no portable settings file beside the executable. All three buttons
  opened their actual INI contents in Notepad without errors. Ordinary paths
  remained absent; the files were in the package's LocalCache/Roaming/Tinta.
- A separate package-context probe confirmed the resolved physical paths.
  Earlier disposable fixtures using the changed resolver also verified that an
  outside process could read those paths while the logical paths were absent.
- `git diff --check` passed.

UI testing used Windows build 26200. This was a rebuilt executable running with
Store package identity, not a replaced Store binary or a newly signed MSIX.
External edit/restart persistence, UNC network shares and older Windows versions
were not tested.
