### PR TITLE
Heading font becomes a theme property (#155)

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -80,8 +80,9 @@ enum class SyntaxTokenType { Plain, Keyword, String, Comment, Number, Function, 
 // Theme colors
 struct D2DTheme {
     const wchar_t* name;
-    const wchar_t* fontFamily;       // Main font
-    const wchar_t* codeFontFamily;   // Monospace font
+    const wchar_t* fontFamily;        // Main font
+    const wchar_t* headingFontFamily; // Headings; null/empty inherits fontFamily
+    const wchar_t* codeFontFamily;    // Monospace font
     bool isDark;
     D2D1_COLOR_F background;
     D2D1_COLOR_F text;
@@ -127,17 +128,26 @@ extern const int THEME_COUNT;
 // stable addresses for the app lifetime, so D2DTheme's const wchar_t*
 // members stay valid. Indices: [0, THEME_COUNT) built-in, then customs.
 struct CustomTheme {
-    std::wstring name, fontFamily, codeFontFamily;
+    std::wstring name, fontFamily, headingFontFamily, codeFontFamily;
     D2DTheme theme;
 };
 int themeCount();
 const D2DTheme& themeAt(int index);  // out-of-range clamps to theme 0
+
+// The face headings render with: headingfont= when the theme sets one,
+// else the theme's main font - so font= means the whole document (#155)
+inline const wchar_t* themeHeadingFont(const D2DTheme& t) {
+    return (t.headingFontFamily && t.headingFontFamily[0])
+               ? t.headingFontFamily
+               : t.fontFamily;
+}
 void loadCustomThemes();
 // Adds or replaces (by name) a user theme and rewrites themes.ini.
 // Returns the theme's registry index, or -1 on failure.
 int saveCustomTheme(const D2DTheme& t, const std::wstring& name,
                     const std::wstring& fontFamily,
-                    const std::wstring& codeFontFamily);
+                    const std::wstring& codeFontFamily,
+                    const std::wstring& headingFontFamily = L"");
 
 // Persistent settings
 struct Settings {

--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -141,7 +141,7 @@ void updateTextFormats(App& app) {
         DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
         fontSize, L"en-us", &app.textFormat);
 
-    app.dwriteFactory->CreateTextFormat(fontFamily, nullptr,
+    app.dwriteFactory->CreateTextFormat(themeHeadingFont(app.theme), nullptr,
         DWRITE_FONT_WEIGHT_BOLD, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
         28.0f * scale, L"en-us", &app.headingFormat);
 
@@ -180,8 +180,11 @@ void updateTextFormats(App& app) {
         DWRITE_FONT_WEIGHT_NORMAL, DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_STRETCH_NORMAL,
         fontSize * 0.68f, L"en-us", &app.supSubFormat);
 
-    // Heading formats by level (use Segoe UI to match previous behavior)
-    const wchar_t* headingFont = L"Segoe UI";
+    // Heading formats by level: the theme's heading face, which inherits
+    // the main font unless the theme sets headingfont= (#155). Abyss pins
+    // its headings to Segoe UI in data - bolding its Light body family
+    // would render faux-bold.
+    const wchar_t* headingFont = themeHeadingFont(app.theme);
     float headingSizes[] = {32, 26, 22, 18, 16, 14};
     for (int i = 0; i < 6; i++) {
         app.dwriteFactory->CreateTextFormat(headingFont, nullptr,

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -2633,8 +2633,14 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             } else if (action == TE_SAVE) {
                 std::wstring name = app.themeEditorName.empty()
                     ? L"My theme" : app.themeEditorName;
+                const D2DTheme& base = themeAt(app.themeEditorBase);
+                // Carry the base theme's heading face so deriving from a
+                // theme with headingfont= (Abyss included) keeps its look
+                std::wstring baseHeading =
+                    (base.headingFontFamily && base.headingFontFamily[0])
+                        ? base.headingFontFamily : L"";
                 int idx = saveCustomTheme(app.themeEditorTheme, name,
-                    app.themeEditorFont, themeAt(app.themeEditorBase).codeFontFamily);
+                    app.themeEditorFont, base.codeFontFamily, baseHeading);
                 if (idx >= 0) {
                     // Preview format cache must grow for the chooser
                     for (auto& pf : app.themePreviewFormats) {

--- a/src/themes.cpp
+++ b/src/themes.cpp
@@ -8,7 +8,7 @@ const D2DTheme THEMES[] = {
 
     // 1. Paper - Warm sepia, literary manuscript feel
     {
-        L"Paper", L"Segoe UI", L"Consolas", false,
+        L"Paper", L"Segoe UI", nullptr, L"Consolas", false,
         hexColor(0xF5F1E8),    // background - warm cream
         hexColor(0x3D3329),    // text - deep brown
         hexColor(0x2A1F16),    // heading - dark brown
@@ -29,7 +29,7 @@ const D2DTheme THEMES[] = {
 
     // 2. Sakura - Japanese cherry blossom, soft pink elegance
     {
-        L"Sakura", L"Segoe UI", L"Consolas", false,
+        L"Sakura", L"Segoe UI", nullptr, L"Consolas", false,
         hexColor(0xFDF8F8),    // background - soft blush white
         hexColor(0x404040),    // text - soft charcoal
         hexColor(0xC44569),    // heading - deep rose
@@ -50,7 +50,7 @@ const D2DTheme THEMES[] = {
 
     // 3. Arctic - Nordic ice blues, crisp and clean
     {
-        L"Arctic", L"Segoe UI", L"Cascadia Code", false,
+        L"Arctic", L"Segoe UI", nullptr, L"Cascadia Code", false,
         hexColor(0xF7FAFC),    // background - ice white
         hexColor(0x2D3748),    // text - deep slate
         hexColor(0x1A365D),    // heading - navy
@@ -71,7 +71,7 @@ const D2DTheme THEMES[] = {
 
     // 4. Meadow - Fresh organic greens, nature-inspired
     {
-        L"Meadow", L"Segoe UI", L"Consolas", false,
+        L"Meadow", L"Segoe UI", nullptr, L"Consolas", false,
         hexColor(0xF7FAF7),    // background - soft white-green
         hexColor(0x1A2F1A),    // text - forest
         hexColor(0x1C4532),    // heading - deep green
@@ -92,7 +92,7 @@ const D2DTheme THEMES[] = {
 
     // 5. Dusk - Golden hour warmth, sunset tones
     {
-        L"Dusk", L"Segoe UI", L"Consolas", false,
+        L"Dusk", L"Segoe UI", nullptr, L"Consolas", false,
         hexColor(0xFFFBF5),    // background - warm white
         hexColor(0x553C10),    // text - deep amber
         hexColor(0x9C4221),    // heading - burnt orange
@@ -117,7 +117,7 @@ const D2DTheme THEMES[] = {
 
     // 6. Midnight - Deep space, cosmic tranquility
     {
-        L"Midnight", L"Segoe UI", L"Cascadia Code", true,
+        L"Midnight", L"Segoe UI", nullptr, L"Cascadia Code", true,
         hexColor(0x0D1B2A),    // background - deep navy
         hexColor(0xE0E1DD),    // text - soft blue-white
         hexColor(0xF0F4F8),    // heading - moonlight
@@ -138,7 +138,7 @@ const D2DTheme THEMES[] = {
 
     // 7. Dracula - Classic dark, purples and pinks
     {
-        L"Dracula", L"Segoe UI", L"Consolas", true,
+        L"Dracula", L"Segoe UI", nullptr, L"Consolas", true,
         hexColor(0x282A36),    // background - deep purple-gray
         hexColor(0xF8F8F2),    // text - light gray
         hexColor(0xFF79C6),    // heading - pink
@@ -159,7 +159,7 @@ const D2DTheme THEMES[] = {
 
     // 8. Forest - Deep mystical greens
     {
-        L"Forest", L"Segoe UI", L"Consolas", true,
+        L"Forest", L"Segoe UI", nullptr, L"Consolas", true,
         hexColor(0x0D1512),    // background - deep green-black
         hexColor(0xB8C5B2),    // text - sage
         hexColor(0x9AE6B4),    // heading - bright green
@@ -180,7 +180,7 @@ const D2DTheme THEMES[] = {
 
     // 9. Ember - Warm charcoal with fire accents
     {
-        L"Ember", L"Segoe UI", L"Consolas", true,
+        L"Ember", L"Segoe UI", nullptr, L"Consolas", true,
         hexColor(0x1A1614),    // background - warm black
         hexColor(0xD4C5B9),    // text - warm gray
         hexColor(0xF6AD55),    // heading - amber
@@ -201,7 +201,7 @@ const D2DTheme THEMES[] = {
 
     // 10. Abyss - True black, neon accents (OLED-friendly)
     {
-        L"Abyss", L"Segoe UI Light", L"Cascadia Mono", true,
+        L"Abyss", L"Segoe UI Light", L"Segoe UI", L"Cascadia Mono", true,
         hexColor(0x000000),    // background - pure black
         hexColor(0xEDEDED),    // text - off-white (OLED halation)
         hexColor(0x2EE6CF),    // heading - cyan, off the RGB rail
@@ -232,6 +232,7 @@ const int THEME_COUNT = sizeof(THEMES) / sizeof(THEMES[0]);
 //   name=Nordish
 //   dark=1
 //   font=Segoe UI
+//   headingfont=Segoe UI    ; optional, headings inherit font= when absent
 //   codefont=Cascadia Mono
 //   background=2E3440
 //   text=D8DEE9
@@ -301,6 +302,8 @@ std::string wideToUtf8Theme(const std::wstring& w) {
 void bindStrings(CustomTheme& ct) {
     ct.theme.name = ct.name.c_str();
     ct.theme.fontFamily = ct.fontFamily.c_str();
+    // Empty means "inherit the main font" - themeHeadingFont resolves it
+    ct.theme.headingFontFamily = ct.headingFontFamily.c_str();
     ct.theme.codeFontFamily = ct.codeFontFamily.c_str();
 }
 
@@ -308,6 +311,7 @@ void applyThemeKey(CustomTheme& ct, const std::string& key, const std::string& v
     D2DTheme& t = ct.theme;
     if (key == "name") ct.name = utf8ToWideTheme(value);
     else if (key == "font") ct.fontFamily = utf8ToWideTheme(value);
+    else if (key == "headingfont") ct.headingFontFamily = utf8ToWideTheme(value);
     else if (key == "codefont") ct.codeFontFamily = utf8ToWideTheme(value);
     else if (key == "dark") t.isDark = (value == "1");
     else if (key == "background") parseHexColor(value, t.background);
@@ -340,6 +344,10 @@ void writeThemesIni() {
         file << "name=" << wideToUtf8Theme(ct->name) << "\n";
         file << "dark=" << (t.isDark ? 1 : 0) << "\n";
         file << "font=" << wideToUtf8Theme(ct->fontFamily) << "\n";
+        if (!ct->headingFontFamily.empty()) {
+            file << "headingfont=" << wideToUtf8Theme(ct->headingFontFamily)
+                 << "\n";
+        }
         file << "codefont=" << wideToUtf8Theme(ct->codeFontFamily) << "\n";
         file << "background=" << colorToHex(t.background) << "\n";
         file << "text=" << colorToHex(t.text) << "\n";
@@ -412,7 +420,8 @@ void loadCustomThemes() {
 
 int saveCustomTheme(const D2DTheme& t, const std::wstring& name,
                     const std::wstring& fontFamily,
-                    const std::wstring& codeFontFamily) {
+                    const std::wstring& codeFontFamily,
+                    const std::wstring& headingFontFamily) {
     if (name.empty()) return -1;
     CustomTheme* slot = nullptr;
     int index = -1;
@@ -430,6 +439,7 @@ int saveCustomTheme(const D2DTheme& t, const std::wstring& name,
     }
     slot->name = name;
     slot->fontFamily = fontFamily.empty() ? L"Segoe UI" : fontFamily;
+    slot->headingFontFamily = headingFontFamily;  // empty inherits font
     slot->codeFontFamily = codeFontFamily.empty() ? L"Consolas" : codeFontFamily;
     slot->theme = t;
     bindStrings(*slot);


### PR DESCRIPTION
Follow-up to #158 for the second half of #155: headings hardcoded Segoe UI, so a custom theme with font=Yu Gothic UI styled body text while heading kanji still went through the fallback - the mismatch habsark screenshotted.

The heading face is now a theme property with one rule: it inherits font= unless the theme sets the new optional headingfont= key in themes.ini. That makes font= mean the whole document, keeps every existing custom theme working unchanged, and lets themes deliberately split display and body faces. The nine Segoe UI built-ins render identically; Abyss sets headingfont=Segoe UI in data, replacing the old hardcoded exception (bolding its Segoe UI Light body family would render faux-bold headings). The theme editor passes the base theme's heading face through saves.

Verified live: a custom font=Yu Gothic UI theme now renders heading and body kanji in the same face on an en-locale machine (previously a visible YaHei/Yu Gothic mismatch), and Abyss headings are unchanged. Tests 5/5.