### PR TITLE
Pinned side panels (#156)

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -193,6 +193,10 @@ struct Settings {
     bool headingRules = true;
     // Table of contents panel side: false = right (default), true = left
     bool tocOnLeft = false;
+    // Pinned side panels (#156): a pinned panel stops dismissing on
+    // document clicks and hands the keyboard back to the document
+    bool tocPinned = false;
+    bool browserPinned = false;
     // UI language id ("auto" follows the Windows display language; else a
     // registry id like "en"/"zh"/"de" — see i18n.h). Persisted as a string
     // because languages.ini languages have no stable numeric index.
@@ -739,6 +743,10 @@ struct App {
     // Table of contents overlay
     bool showToc = false;
     bool tocOnLeft = false;     // panel side (persisted)
+    // Pinned panels (#156, persisted): no dismissal on document clicks,
+    // the document keeps hover, selection, and the keyboard
+    bool tocPinned = false;
+    bool browserPinned = false;
     float tocAnimation = 0.0f;  // 0 to 1 slide-in from the chosen side
     struct HeadingInfo {
         std::wstring text;
@@ -1027,8 +1035,10 @@ struct App {
     // The unsaved-exit / create-file prompt chip occupies the corner slot;
     // the chip stack starts above it (set by the prompt renderers)
     D2D1_RECT_F promptChipRect{};
-    // Close cross on the floating Contents card (t13)
+    // Close cross and pin on the floating Contents card (t13/#156)
     D2D1_RECT_F tocCloseRect{};
+    D2D1_RECT_F tocPinRect{};
+    D2D1_RECT_F folderPinRect{};  // pin button on the browser card
     // Breadcrumb segments on the browser card: rect -> number of path
     // components the click keeps (refreshed by renderFolderBrowser)
     std::vector<std::pair<D2D1_RECT_F, int>> folderCrumbHits;

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -54,7 +54,7 @@ struct FolderBrowserMetrics {
     float panelX = 0, panelWidth = 0;              // slide envelope
     float cardLeft = 0, cardRight = 0, cardTop = 0, cardBottom = 0;
     float headerY = 0, headerH = 0;                // breadcrumb row
-    float folderBtnX = 0, fileBtnX = 0, btnY = 0, btnSize = 0;
+    float pinBtnX = 0, folderBtnX = 0, fileBtnX = 0, btnY = 0, btnSize = 0;
     float listStartY = 0, listBottom = 0;          // scrolled group area
     float itemHeight = 0, labelH = 0;              // row + section label
     float namingOffset = 0;                        // pinned naming row

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -757,6 +757,16 @@ void editorReparse(App& app) {
 // --- Mode transitions ---
 
 static void enterEditModeWithContent(App& app, const std::string& content) {
+    // The unified editor owns the whole layout: side panels close on
+    // entry, pinned or not (#156) - the pin survives for the next open
+    app.showToc = false;
+    app.tocAnimation = 0.0f;
+    app.tocFilter.clear();
+    app.showFolderBrowser = false;
+    app.folderBrowserAnimation = 0.0f;
+    app.folderBrowserEditingPath = false;
+    app.folderBrowserNaming = 0;
+
     app.editorText = fromUtf8(content);
     // Normalize \r\n to \n
     std::wstring normalized;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -128,26 +128,14 @@ static void setThemeChooserCursor(const App& app, float x, float y) {
                                                       : cursorArrow);
 }
 
-static void setTocCursor(const App& app, float x, float y) {
-    float panelWidth = tocPanelWidth(app);
-    float panelX = tocPanelX(app, panelWidth);
-    float padding = dpi(app, 12.0f);
-    float listStartY = padding + dpi(app, 40.0f) + dpi(app, 8.0f);
-    float listBottom = app.height - padding;
-    float itemHeight = dpi(app, 28.0f);
-    if (x < panelX + padding || x > panelX + panelWidth - padding ||
-        y < listStartY || y > listBottom || app.headings.empty()) {
-        SetCursor(cursorArrow);
+static void setTocCursor(App& app, float x, float y) {
+    // Shares the floating card's geometry (t13); the pin and close
+    // controls get the hand as well
+    if (cursorPointInRect(x, y, app.tocPinRect) ||
+        cursorPointInRect(x, y, app.tocCloseRect) ||
+        tocItemIndexAt(app, x, y) >= 0) {
+        SetCursor(cursorHand);
         return;
-    }
-
-    int index = (int)((y - listStartY + app.tocScroll) / itemHeight);
-    if (index >= 0 && index < (int)app.headings.size()) {
-        float itemY = listStartY + index * itemHeight - app.tocScroll;
-        if (y >= itemY && y <= itemY + itemHeight) {
-            SetCursor(cursorHand);
-            return;
-        }
     }
     SetCursor(cursorArrow);
 }
@@ -166,7 +154,8 @@ static void setFolderBrowserCursor(const App& app, float x, float y) {
         return;
     }
     if (inHeader && y >= g.btnY && y <= g.btnY + g.btnSize &&
-        ((x >= g.folderBtnX && x <= g.folderBtnX + g.btnSize) ||
+        ((x >= g.pinBtnX && x <= g.pinBtnX + g.btnSize) ||
+         (x >= g.folderBtnX && x <= g.folderBtnX + g.btnSize) ||
          (x >= g.fileBtnX && x <= g.fileBtnX + g.btnSize))) {
         SetCursor(cursorHand);
         return;
@@ -1135,12 +1124,25 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     }
 
     if (app.showFolderBrowser) {
-        setFolderBrowserCursor(app, (float)app.mouseX, (float)app.mouseY);
-        return;
+        FolderBrowserMetrics fbm = folderBrowserMetrics(app);
+        bool inside = app.mouseX >= fbm.panelX &&
+                      app.mouseX <= fbm.panelX + fbm.panelWidth;
+        if (inside || !app.browserPinned) {
+            setFolderBrowserCursor(app, (float)app.mouseX, (float)app.mouseY);
+            if (inside) InvalidateRect(hwnd, nullptr, FALSE);  // row hover
+            return;
+        }
+        // Pinned (#156): the document beside the panel keeps its hover
     }
     if (app.showToc) {
-        setTocCursor(app, (float)app.mouseX, (float)app.mouseY);
-        return;
+        float tocW = tocPanelWidth(app);
+        float tocX = tocPanelX(app, tocW);
+        bool inside = app.mouseX >= tocX && app.mouseX <= tocX + tocW;
+        if (inside || !app.tocPinned) {
+            setTocCursor(app, (float)app.mouseX, (float)app.mouseY);
+            if (inside) InvalidateRect(hwnd, nullptr, FALSE);  // row hover
+            return;
+        }
     }
     if (app.showThemeChooser) {
         setThemeChooserCursor(app, (float)app.mouseX, (float)app.mouseY);
@@ -1938,23 +1940,43 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         return;
     }
 
-    // If theme chooser, folder browser, or TOC is open, don't start selection - just record for click handling
-    if (app.showThemeChooser || app.showFolderBrowser || app.showToc) {
-        // The content scrollbar stays usable beside a side panel: a click
-        // on it dismisses the folder browser ("back to the document") and
-        // simply works alongside the TOC, which is a navigation aid
-        bool scrollbarClick =
-            (app.scrollbarHovered && app.verticalScrollbarVisible) ||
-            (app.hScrollbarHovered &&
-             app.contentWidth > documentViewportWidth(app));
-        if (!app.showThemeChooser && scrollbarClick) {
-            if (app.showFolderBrowser) {
-                app.showFolderBrowser = false;
-                closeFolderBrowserInput(app);
+    // If theme chooser, folder browser, or TOC is open, don't start
+    // selection - just record for click handling. A PINNED panel only
+    // claims presses inside its own envelope (#156): the document beside
+    // it keeps selection and every other press behavior.
+    {
+        bool browserClaims = false;
+        if (app.showFolderBrowser) {
+            FolderBrowserMetrics fbm = folderBrowserMetrics(app);
+            browserClaims = !app.browserPinned ||
+                            ((float)app.mouseX >= fbm.panelX &&
+                             (float)app.mouseX <= fbm.panelX + fbm.panelWidth);
+        }
+        bool tocClaims = false;
+        if (app.showToc) {
+            float tocW = tocPanelWidth(app);
+            float tocX = tocPanelX(app, tocW);
+            tocClaims = !app.tocPinned ||
+                        ((float)app.mouseX >= tocX &&
+                         (float)app.mouseX <= tocX + tocW);
+        }
+        if (app.showThemeChooser || browserClaims || tocClaims) {
+            // The content scrollbar stays usable beside a side panel: a
+            // click on it dismisses an unpinned folder browser ("back to
+            // the document") and simply works alongside the TOC
+            bool scrollbarClick =
+                (app.scrollbarHovered && app.verticalScrollbarVisible) ||
+                (app.hScrollbarHovered &&
+                 app.contentWidth > documentViewportWidth(app));
+            if (!app.showThemeChooser && scrollbarClick) {
+                if (app.showFolderBrowser && !app.browserPinned) {
+                    app.showFolderBrowser = false;
+                    closeFolderBrowserInput(app);
+                }
+                // fall through to the scrollbar handling below
+            } else {
+                return;
             }
-            // fall through to the scrollbar handling below
-        } else {
-            return;
         }
     }
 
@@ -2747,6 +2769,10 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             // render-time hover can be a frame stale on fast move+click
             int hit = tocItemIndexAt(app, (float)clickX, (float)clickY);
             if (cursorPointInRect((float)clickX, (float)clickY,
+                                  app.tocPinRect)) {
+                // Pin toggle (#156): pinned survives document clicks
+                app.tocPinned = !app.tocPinned;
+            } else if (cursorPointInRect((float)clickX, (float)clickY,
                                   app.tocCloseRect)) {
                 app.showToc = false;
                 app.tocAnimation = 0;
@@ -2760,20 +2786,25 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 }
                 scrollToHeadingY(app, app.headings[hit].y);
 
-                // Close TOC
-                app.showToc = false;
-                app.tocAnimation = 0;
-                app.tocFilter.clear();
+                // Close TOC - a pinned panel stays for the next jump
+                if (!app.tocPinned) {
+                    app.showToc = false;
+                    app.tocAnimation = 0;
+                    app.tocFilter.clear();
+                }
             }
-        } else {
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
+        }
+        if (!app.tocPinned) {
             // Click outside panel = close TOC
             app.showToc = false;
             app.tocAnimation = 0;
             app.tocFilter.clear();
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
         }
-
-        InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        // Pinned (#156): the click belongs to the document - fall through
     }
 
     // Folder browser click handling
@@ -2806,6 +2837,13 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 return;
             }
 
+            if (cursorPointInRect((float)clickX, (float)clickY,
+                                  app.folderPinRect)) {
+                // Pin toggle (#156)
+                app.browserPinned = !app.browserPinned;
+                InvalidateRect(hwnd, nullptr, FALSE);
+                return;
+            }
             if (inHeader && clickY >= g.btnY && clickY <= g.btnY + g.btnSize &&
                 clickX >= g.folderBtnX && clickX <= g.fileBtnX + g.btnSize) {
                 // + folder / + file buttons: start naming a new item
@@ -2908,15 +2946,18 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                     }
                 }
             }
-        } else {
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
+        }
+        if (!app.browserPinned) {
             // Click outside panel = close browser
             closeFolderBrowserInput(app);
             app.showFolderBrowser = false;
             app.folderBrowserAnimation = 0;
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
         }
-
-        InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        // Pinned (#156): the click belongs to the document - fall through
     }
 
     // Theme chooser click handling
@@ -3532,8 +3573,9 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             return;
         }
         // TOC filter: printable keys narrow the heading list via WM_CHAR,
-        // Backspace edits, Enter jumps to the first match
-        if (app.showToc && !app.editMode) {
+        // Backspace edits, Enter jumps to the first match. A pinned panel
+        // hands the keyboard back to the document (#156).
+        if (app.showToc && !app.editMode && !app.tocPinned) {
             if (wParam == VK_BACK) {
                 if (!app.tocFilter.empty()) app.tocFilter.pop_back();
                 InvalidateRect(hwnd, nullptr, FALSE);
@@ -3843,8 +3885,9 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
         return;
     }
 
-    // TOC filter: typing narrows the heading list
-    if (app.showToc && !app.showSearch) {
+    // TOC filter: typing narrows the heading list (a pinned panel leaves
+    // the keyboard with the document, #156)
+    if (app.showToc && !app.showSearch && !app.tocPinned) {
         wchar_t ch = (wchar_t)wParam;
         if (ch >= 0x20 && ch != 127) {
             app.tocFilter += ch;

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1714,6 +1714,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 settings.zenWidthPct = app->zenWidthPct;
                 settings.headingRules = app->headingRules;
                 settings.tocOnLeft = app->tocOnLeft;
+                settings.tocPinned = app->tocPinned;
+                settings.browserPinned = app->browserPinned;
                 settings.language = app->languageSetting >= 0
                     ? languageIdAt(app->languageSetting) : "auto";
                 settings.keyProfile = app->keyProfile;
@@ -1815,6 +1817,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.zenWidthPct = savedSettings.zenWidthPct;
     app.headingRules = savedSettings.headingRules;
     app.tocOnLeft = savedSettings.tocOnLeft;
+    app.tocPinned = savedSettings.tocPinned;
+    app.browserPinned = savedSettings.browserPinned;
     app.languageSetting = savedSettings.language == "auto"
         ? -1 : languageIndexById(savedSettings.language);
     app.currentLanguageIndex = app.languageSetting >= 0

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -289,6 +289,7 @@ FolderBrowserMetrics folderBrowserMetrics(const App& app) {
     g.btnSize = dpi(app, 22.0f);
     g.fileBtnX = g.cardRight - dpi(app, 10.0f) - g.btnSize;
     g.folderBtnX = g.fileBtnX - dpi(app, 4.0f) - g.btnSize;
+    g.pinBtnX = g.folderBtnX - dpi(app, 4.0f) - g.btnSize;
     g.btnY = g.headerY + (g.headerH - g.btnSize) * 0.5f;
     float dividerY = g.headerY + g.headerH + dpi(app, 4.0f);
     g.listStartY = dividerY + dpi(app, 3.0f);
@@ -333,6 +334,18 @@ int folderItemIndexAt(const App& app, float x, float y) {
         if (contentY >= top && contentY < top + g.itemHeight) return i;
     }
     return -1;
+}
+
+// Map-pin for the panel pin toggles (#156): head circle plus needle
+static void drawPinGlyph(App& app, float cx, float cy, D2D1_COLOR_F color) {
+    app.brush->SetColor(color);
+    app.renderTarget->DrawEllipse(
+        D2D1::Ellipse(D2D1::Point2F(cx, cy - dpi(app, 2.0f)),
+                      dpi(app, 3.0f), dpi(app, 3.0f)),
+        app.brush, 1.3f);
+    app.renderTarget->DrawLine(D2D1::Point2F(cx, cy + dpi(app, 1.0f)),
+                               D2D1::Point2F(cx, cy + dpi(app, 6.0f)),
+                               app.brush, 1.3f);
 }
 
 // Monoline glyphs shared by the browser card's rows and header buttons
@@ -414,6 +427,7 @@ void renderFolderBrowser(App& app) {
         D2D1::RoundedRect(card, radius, radius), app.brush, 1.0f);
 
     app.folderCrumbHits.clear();
+    app.folderPinRect = D2D1_RECT_F{};
     IDWriteTextFormat* browserFormat = app.folderBrowserFormat;
     if (browserFormat) {
         float padding = dpi(app, 12.0f);
@@ -532,7 +546,7 @@ void renderFolderBrowser(App& app) {
             }
 
             float cx = g.cardLeft + padding;
-            float crumbMax = folderBtnX - dpi(app, 26.0f);
+            float crumbMax = g.pinBtnX - dpi(app, 26.0f);
 
             // The leaf always survives: drop the parent crumb first when
             // the row runs out of room, then trim the leaf as a last resort
@@ -642,6 +656,32 @@ void renderFolderBrowser(App& app) {
             };
             drawAddButton(folderBtnX, true);
             drawAddButton(fileBtnX, false);
+
+            // Pin toggle (#156): a pinned browser survives document clicks
+            {
+                bool hoveredP =
+                    app.mouseX >= g.pinBtnX && app.mouseX <= g.pinBtnX + btnSize &&
+                    app.mouseY >= btnY && app.mouseY <= btnY + btnSize;
+                if (app.browserPinned || hoveredP) {
+                    D2D1_COLOR_F bg = app.theme.accent;
+                    bg.a = (app.browserPinned ? 0.16f : 0.1f) * anim;
+                    app.brush->SetColor(bg);
+                    app.renderTarget->FillRoundedRectangle(
+                        D2D1::RoundedRect(
+                            D2D1::RectF(g.pinBtnX, btnY, g.pinBtnX + btnSize,
+                                        btnY + btnSize),
+                            dpi(app, 5.0f), dpi(app, 5.0f)),
+                        app.brush);
+                }
+                D2D1_COLOR_F pc = app.browserPinned ? app.theme.accent
+                                                    : app.theme.text;
+                pc.a = (app.browserPinned ? 0.95f : 0.6f) * anim;
+                drawPinGlyph(app, g.pinBtnX + btnSize * 0.5f,
+                             btnY + btnSize * 0.5f, pc);
+                app.folderPinRect = D2D1::RectF(g.pinBtnX, btnY,
+                                                g.pinBtnX + btnSize,
+                                                btnY + btnSize);
+            }
         }
 
         // Divider line
@@ -955,6 +995,7 @@ void renderToc(App& app) {
         D2D1::RoundedRect(card, radius, radius), app.brush, 1.0f);
 
     app.tocCloseRect = D2D1_RECT_F{};
+    app.tocPinRect = D2D1_RECT_F{};
     IDWriteTextFormat* tocBold = app.tocFormatBold;
     IDWriteTextFormat* tocNormal = app.tocFormat;
     if (tocBold && tocNormal) {
@@ -1011,6 +1052,15 @@ void renderToc(App& app) {
                                        D2D1::Point2F(ccx + s, ccy - s), app.brush, 1.3f);
             app.tocCloseRect = D2D1::RectF(ccx - dpi(app, 10.0f), cardTop,
                                            cardRight, headerY + dpi(app, 20.0f));
+
+            // Pin toggle left of the cross (#156)
+            float pcx = ccx - dpi(app, 20.0f);
+            D2D1_COLOR_F pc = app.tocPinned ? app.theme.accent : app.theme.text;
+            pc.a = (app.tocPinned ? 0.95f : 0.45f) * anim;
+            drawPinGlyph(app, pcx, ccy, pc);
+            app.tocPinRect = D2D1::RectF(pcx - dpi(app, 9.0f), cardTop,
+                                         pcx + dpi(app, 9.0f),
+                                         headerY + dpi(app, 20.0f));
         }
 
         // Active filter, right-aligned before the cross
@@ -1026,7 +1076,7 @@ void renderToc(App& app) {
                 filterColor.a = anim;
                 app.brush->SetColor(filterColor);
                 app.renderTarget->DrawTextLayout(
-                    D2D1::Point2F(cardRight - padding - dpi(app, 18.0f) - fm.width,
+                    D2D1::Point2F(cardRight - padding - dpi(app, 38.0f) - fm.width,
                                   headerY + dpi(app, 1.0f)),
                     filterLayout, app.brush);
                 filterLayout->Release();

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -58,6 +58,8 @@ void saveSettings(const Settings& settings) {
     file << "zenWidthPct=" << settings.zenWidthPct << "\n";
     file << "headingRules=" << (settings.headingRules ? 1 : 0) << "\n";
     file << "tocOnLeft=" << (settings.tocOnLeft ? 1 : 0) << "\n";
+    file << "tocPinned=" << (settings.tocPinned ? 1 : 0) << "\n";
+    file << "browserPinned=" << (settings.browserPinned ? 1 : 0) << "\n";
     file << "language=" << settings.language << "\n";
     file << "keyProfile=" << settings.keyProfile << "\n";
     file << "checkUpdates=" << (settings.checkUpdates ? 1 : 0) << "\n";
@@ -304,6 +306,10 @@ Settings loadSettings() {
             settings.headingRules = (value == "1");
         } else if (key == "tocOnLeft") {
             settings.tocOnLeft = (value == "1");
+        } else if (key == "tocPinned") {
+            settings.tocPinned = (value == "1");
+        } else if (key == "browserPinned") {
+            settings.browserPinned = (value == "1");
         } else if (key == "language") {
             if (!value.empty()) settings.language = value;  // "auto" or an id
         } else if (key == "keyProfile") {


### PR DESCRIPTION
Closes #156.

Both floating cards gain a pin next to their close controls. Pinned panels stop being transient overlays: document clicks beside them pass through untouched (selection, links, annotations, images all work), the Contents stays open across click-jumps with the scroll-spy following, the content scrollbar no longer dismisses a pinned browser, and the keyboard belongs to the document again - a pinned Contents does not capture typing for its filter, so F opens search and E enters the editor as normal. T, B, Esc, and the close cross still dismiss deliberately, and the pin state survives (persisted in settings.ini) so the panel docks again on the next open. The document already reflowed beside open panels, so pinning completes the resident reading layout the reporter asked for. Entering the unified editor closes the panels in either state.

Verified live: pin toggle, document clicks with the panel holding, click-jump keeping the panel with the spy pill following, and F reaching search through a pinned panel. Tests 5/5.