### PR TITLE
Panel clicks no longer latch a scrollbar drag

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1963,16 +1963,36 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         if (app.showThemeChooser || browserClaims || tocClaims) {
             // The content scrollbar stays usable beside a side panel: a
             // click on it dismisses an unpinned folder browser ("back to
-            // the document") and simply works alongside the TOC
-            bool scrollbarClick =
-                (app.scrollbarHovered && app.verticalScrollbarVisible) ||
-                (app.hScrollbarHovered &&
-                 app.contentWidth > documentViewportWidth(app));
-            if (!app.showThemeChooser && scrollbarClick) {
+            // the document") and simply works alongside the TOC.
+            // Recompute the band at the click: scrollbarHovered freezes
+            // stale while the mouse is over a panel (its mousemove returns
+            // before the hover update), and a stale true here turned panel
+            // clicks into scrollbar drags bound to the mouse.
+            float viewportX = documentViewportX(app);
+            float viewportWidth = documentViewportWidth(app);
+            bool vClick = false, hClick = false;
+            if (app.verticalScrollbarVisible) {
+                float sbWidth = dpi(app, 14.0f);
+                float sbRight = viewportX + viewportWidth;
+                vClick = (float)app.mouseX >= sbRight - sbWidth &&
+                         (float)app.mouseX <= sbRight;
+            }
+            if (!vClick && app.contentWidth > viewportWidth) {
+                float sbHeight = dpi(app, 14.0f);
+                hClick = (float)app.mouseY >= app.height - sbHeight &&
+                         (float)app.mouseX >= viewportX &&
+                         (float)app.mouseX <= viewportX + viewportWidth;
+            }
+            if (!app.showThemeChooser && (vClick || hClick)) {
                 if (app.showFolderBrowser && !app.browserPinned) {
                     app.showFolderBrowser = false;
                     closeFolderBrowserInput(app);
                 }
+                // The drag start below keys off the hover flags, which
+                // freeze while the mouse crosses a panel - refresh them
+                // from this click's own geometry
+                app.scrollbarHovered = vClick;
+                app.hScrollbarHovered = hClick;
                 // fall through to the scrollbar handling below
             } else {
                 return;
@@ -2754,6 +2774,18 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     }
 
     ReleaseCapture();
+
+    // A scrollbar drag ends at this release no matter where it lands -
+    // the panel branches below must not run first and leave the drag
+    // latched, which bound the scroll to plain mouse movement
+    if (app.scrollbarDragging || app.hScrollbarDragging) {
+        app.scrollbarDragging = false;
+        app.hScrollbarDragging = false;
+        app.mouseDown = false;
+        app.selecting = false;
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
 
     // TOC click handling
     if (app.showToc) {


### PR DESCRIPTION
User-found after the pinned panels landed: click a Contents section, move into the document, and the scroll followed the mouse. Cause chain: the mouse-down gate beside an open panel decided "this is a scrollbar click" from app.scrollbarHovered, which freezes while the pointer is over a panel (panel mousemoves return before the hover update runs) - so a stale flag turned a TOC row click into a scrollbar drag with a track-jump, and the mouse-up ran the TOC branch first, which returned before the drag-clearing code, leaving scrollbarDragging latched onto plain mouse movement.

Three-part fix: the gate recomputes both scrollbar bands from the click's own coordinates (the #114 lesson applied to hover flags), the carve-out refreshes the hover flags so the drag start sees current state (the old path also silently failed the opposite way), and handleMouseUp ends any active scrollbar drag before the panel branches can consume the release.

Verified with the exact repro: cross the scrollbar band, jump from the pinned Contents, sweep the mouse across the content - a pixel comparison of before/after shows the document does not move. Tests 5/5.