### PR TITLE
Pinned panels restore on launch

### DIFF
--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -2209,6 +2209,28 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
         return ok ? 0 : 1;
     }
 
+    // Pinned side panels are part of the layout, so they come back on
+    // launch when a document is up (#156). The start page, quick notes,
+    // and --edit launches keep their clean slate; T/B still toggle.
+    if (!app.currentFile.empty() && !app.editMode) {
+        if (app.tocPinned) {
+            app.showToc = true;
+            app.tocAnimation = 1.0f;  // docked: no slide on restore
+            app.tocScroll = 0;
+            app.tocFilter.clear();
+            app.hoveredTocIndex = -1;
+        }
+        if (app.browserPinned) {
+            app.showFolderBrowser = true;
+            app.folderBrowserAnimation = 1.0f;
+            app.folderBrowserPath = getDirectoryFromFile(app.currentFile);
+            populateFolderItems(app);
+        }
+        if (app.tocPinned || app.browserPinned) {
+            InvalidateRect(app.hwnd, nullptr, FALSE);
+        }
+    }
+
     // First frame is on screen — now pay for the GPU in the background
     startGpuWarmup();
 


### PR DESCRIPTION
User-found on the pinned panels: the pin state persisted, but the panel itself stayed hidden on the next launch until T or B. Pinned now means what it says - part of the layout. A window opening with a document restores a pinned Contents or file browser immediately (no slide animation, the browser seeded from the document folder), with the document reflowed beside it. The start page, quick notes, and --edit launches stay clean, and T/B still toggle a pinned panel away for the session while the pin survives for the next launch.

Verified: launch with tocPinned=1 shows the docked Contents from the first frame. Tests 5/5.