### PR TITLE
Clicked heading stays active in the Contents

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -748,6 +748,10 @@ struct App {
     bool tocPinned = false;
     bool browserPinned = false;
     float tocAnimation = 0.0f;  // 0 to 1 slide-in from the chosen side
+    // A clicked heading stays the active row even when the scroll cannot
+    // reach it (short documents); any real scroll hands back to the spy
+    int tocSpyOverride = -1;
+    float tocSpyOverrideScroll = 0.0f;  // targetScrollY at the jump
     struct HeadingInfo {
         std::wstring text;
         int level;       // 1-6

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -2817,6 +2817,11 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                     return;
                 }
                 scrollToHeadingY(app, app.headings[hit].y);
+                // The clicked heading is the active one even when the
+                // scroll cannot physically reach it (short documents);
+                // the next real scroll hands back to the spy
+                app.tocSpyOverride = hit;
+                app.tocSpyOverrideScroll = app.targetScrollY;
 
                 // Close TOC - a pinned panel stays for the next jump
                 if (!app.tocPinned) {
@@ -3615,12 +3620,15 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             }
             if (wParam == VK_RETURN) {
                 std::wstring needle = toLower(app.tocFilter);
-                for (const auto& heading : app.headings) {
+                for (size_t i = 0; i < app.headings.size(); i++) {
+                    const auto& heading = app.headings[i];
                     if (needle.empty() ||
                         toLower(heading.text).find(needle) !=
                             std::wstring::npos) {
                         ensureLayoutComplete(app);
                         scrollToHeadingY(app, heading.y);
+                        app.tocSpyOverride = (int)i;
+                        app.tocSpyOverrideScroll = app.targetScrollY;
                         app.showToc = false;
                         app.tocAnimation = 0;
                         app.tocFilter.clear();

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -18,6 +18,7 @@ static float promptKeycap(App& app, const wchar_t* label, float rightX,
 
 #include <chrono>
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 void renderSearchOverlay(App& app) {
@@ -1149,12 +1150,22 @@ void renderToc(App& app) {
                 }
             }
 
+            // A clicked heading stays active until the user scrolls: the
+            // spy line cannot reach bottom sections in short documents
             int currentIdx = -1;
-            float spyLine = app.scrollY + (float)app.height * 0.25f;
-            for (size_t i = 0; i < app.headings.size(); i++) {
-                if (app.headings[i].y <= spyLine) currentIdx = (int)i;
+            if (app.tocSpyOverride >= 0 &&
+                app.tocSpyOverride < (int)app.headings.size() &&
+                std::fabs(app.targetScrollY - app.tocSpyOverrideScroll) <
+                    1.0f) {
+                currentIdx = app.tocSpyOverride;
+            } else {
+                app.tocSpyOverride = -1;
+                float spyLine = app.scrollY + (float)app.height * 0.25f;
+                for (size_t i = 0; i < app.headings.size(); i++) {
+                    if (app.headings[i].y <= spyLine) currentIdx = (int)i;
+                }
+                if (currentIdx < 0 && !app.headings.empty()) currentIdx = 0;
             }
-            if (currentIdx < 0 && !app.headings.empty()) currentIdx = 0;
 
             float totalItemsHeight = visible.size() * itemHeight;
             float maxScroll = std::max(0.0f, totalItemsHeight - listHeight);


### PR DESCRIPTION
User-found on the pinned Contents: with a document short enough that all headings fit in the view, clicking a heading scrolled (or could not scroll) but the active pill stayed on an earlier row, since the scroll-spy derives the active row purely from scroll position and the spy line can never reach bottom sections. A click (and an Enter jump from the filter) now records its heading as the active row; the override holds while targetScrollY stays where the jump put it, and any real scroll - wheel, keys, scrollbar, all of which move targetScrollY - drops it and returns control to the spy.

Verified with a four-heading document that fits entirely in the window: clicking the last heading moves the pill to it with zero scroll available. Tests 5/5.