### PR TITLE
Both side panels open and pinned together

### DIFF
--- a/include/app.h
+++ b/include/app.h
@@ -1370,14 +1370,16 @@ inline float documentViewportX(const App& app) {
     if (!app.editMode) {
         // Side panels push the content aside instead of covering it; the
         // shift follows the panel's slide-in animation. A right-docked TOC
-        // leaves x at 0 and only narrows the viewport.
+        // leaves x at 0 and only narrows the viewport. Both panels can be
+        // up at once (#156): left-side occupants add up.
+        float x = 0.0f;
         if (app.showFolderBrowser) {
-            return folderBrowserPanelWidth(app) * app.folderBrowserAnimation;
+            x += folderBrowserPanelWidth(app) * app.folderBrowserAnimation;
         }
         if (app.showToc && app.tocOnLeft) {
-            return tocPanelWidth(app) * app.tocAnimation;
+            x += tocPanelWidth(app) * app.tocAnimation;
         }
-        return 0.0f;
+        return x;
     }
     // Preview hidden: zero-width viewport at the right edge — document
     // rendering flows through unchanged and clips to nothing
@@ -1432,9 +1434,10 @@ inline float documentViewportWidth(const App& app) {
     } else {
         width = static_cast<float>(app.width);
         // Snap to the panel's final width (not the animated position) so
-        // the reading column relayouts once per toggle, not per frame
+        // the reading column relayouts once per toggle, not per frame.
+        // Both panels can be up together (#156).
         if (app.showFolderBrowser) width -= folderBrowserPanelWidth(app);
-        else if (app.showToc) width -= tocPanelWidth(app);
+        if (app.showToc) width -= tocPanelWidth(app);
     }
     return width > 0.0f ? width : 0.0f;
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -3709,19 +3709,26 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 toggleZenMode(app, hwnd);
                 break;
             case 'Q':
-                if (!app.showThemeChooser && !app.showSearch && !app.showFolderBrowser && !app.showToc) {
+                // Pinned panels are part of the layout: Q still quits
+                // through them (an unpinned panel's filter already
+                // swallowed the key before this switch)
+                if (!app.showThemeChooser && !app.showSearch &&
+                    (!app.showFolderBrowser || app.browserPinned) &&
+                    (!app.showToc || app.tocPinned)) {
                     PostQuitMessage(0);
                 }
                 break;
             case 'N':
                 // New file: folder browser with the naming row active (#74)
-                if (!app.showSearch && !app.showThemeChooser && !app.showToc) {
+                if (!app.showSearch && !app.showThemeChooser) {
                     startNewFileFlow(app, hwnd);
                 }
                 break;
             case 'B':
-                // B to toggle folder browser
-                if (!app.showSearch && !app.showThemeChooser && !app.showToc) {
+                // B to toggle folder browser - an open TOC no longer
+                // blocks it; an unpinned TOC swallows B as filter input
+                // before this switch anyway
+                if (!app.showSearch && !app.showThemeChooser) {
                     app.showFolderBrowser = !app.showFolderBrowser;
                     closeFolderBrowserInput(app);
                     if (app.showFolderBrowser) {
@@ -3752,7 +3759,9 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 break;
             case VK_TAB:
-                if (!app.showSearch && !app.showThemeChooser && !app.showFolderBrowser) {
+                // The browser no longer blocks the TOC: both panels can
+                // be up (and pinned) together (#156)
+                if (!app.showSearch && !app.showThemeChooser) {
                     app.showToc = !app.showToc;
                     app.tocFilter.clear();
                     if (app.showToc) {

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1431,8 +1431,15 @@ void renderLightbox(App& app) {
 }
 
 float tocPanelX(const App& app, float panelWidth) {
-    return app.tocOnLeft ? -panelWidth * (1.0f - app.tocAnimation)
-                         : app.width - panelWidth * app.tocAnimation;
+    if (app.tocOnLeft) {
+        // A left-docked TOC sits beside an open browser, not on top of it
+        float base = app.showFolderBrowser
+                         ? folderBrowserPanelWidth(app) *
+                               app.folderBrowserAnimation
+                         : 0.0f;
+        return base - panelWidth * (1.0f - app.tocAnimation);
+    }
+    return app.width - panelWidth * app.tocAnimation;
 }
 
 int themeChooserRows() {


### PR DESCRIPTION
User-found: the Contents and the file browser could not be up at the same time - the Tab and B toggles carried mutual-exclusion guards from the exclusive-overlay era, and the viewport math subtracted only the first open panel. The guards drop the exclusion (an unpinned panel''s type-to-filter still swallows keys before the toggles, so overlay behavior is unchanged), documentViewportX/Width account for every open panel, a left-docked Contents shifts beside an open browser instead of stacking on it, N works through a pinned Contents, and Q quits through pinned panels.

Verified: launching with both pins restores browser left, Contents right, document reflowed between them; a clean close writes both pin flags back (browser pin persistence confirmed end to end). Tests 5/5.