### PR TITLE
Heading jumps land clear of the tab strip

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -160,7 +160,9 @@ std::string slugifyHeading(const std::wstring& text) {
 }
 
 void scrollToHeadingY(App& app, float headingY) {
-    float targetY = headingY - 20.0f;
+    // The title-bar tab strip draws over the document's top band, so the
+    // landing margin must clear it or the heading arrives half-hidden
+    float targetY = headingY - chromeTopHeight(app) - dpi(app, 14.0f);
     float maxScroll = std::max(0.0f, app.contentHeight - app.height);
     app.scrollY = std::max(0.0f, std::min(targetY, maxScroll));
     app.targetScrollY = app.scrollY;


### PR DESCRIPTION
User-found: clicking a heading in the Contents scrolled the document so the heading arrived half-hidden. scrollToHeadingY still used a fixed 20px landing margin from before the title-bar tab strip existed - the strip draws over the top band of the document, so the heading landed underneath it. The margin now clears chromeTopHeight plus a small breathing gap, in DPI units. Wiki-link anchor jumps go through the same helper and benefit equally.

Verified: the Topic Ideas heading from the report now lands fully visible below the strip. Tests 5/5.