### PR TITLE
In-place table editing in the rendered edit view (#148)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES
     src/settings.cpp
     src/config_dir.cpp
     src/signals.cpp
+    src/tableedit.cpp
     src/d2d_init.cpp
     src/syntax.cpp
     src/utils.cpp

--- a/include/app.h
+++ b/include/app.h
@@ -811,9 +811,29 @@ struct App {
         unsigned fitKey = 0;   // per-layout ordinal for the fit toggle
         bool fitCandidate = false;  // wider than the column at natural size
         bool fitActive = false;
+        size_t sourceOffset = SIZE_MAX;  // Table element source (#148)
     };
     std::vector<TableInfo> tableRects;
     int hoveredTable = -1;
+
+    // In-place table editing in the rendered preview (#148, edit mode).
+    // Cells are identified by the table's source offset plus row/col so
+    // they survive relayouts; rects are document coordinates.
+    struct TableCellRect {
+        size_t tableSrc = 0;  // Table element sourceOffset (first cell text)
+        int row = 0, col = 0; // row 0 = header
+        D2D1_RECT_F rect{};
+    };
+    std::vector<TableCellRect> tableCellRects;  // filled in edit mode only
+    bool tableEditActive = false;
+    size_t tableEditSrc = 0;
+    int tableEditRow = -1, tableEditCol = -1;
+    std::wstring tableEditText;
+    size_t tableEditCaret = 0;
+    // Hover affordances: + row under the table, + column at its right edge
+    size_t tableAddSrc = 0;              // table the buttons belong to
+    D2D1_RECT_F tableAddRowRect{};       // document coordinates
+    D2D1_RECT_F tableAddColRect{};
 
     // Fit-to-width overrides for oversized tables/diagrams, keyed by their
     // per-layout ordinal (cleared when the document changes)
@@ -1211,6 +1231,7 @@ struct App {
         linkRects.clear();
         codeBlocks.clear();
         tableRects.clear();
+        tableCellRects.clear();
         textRects.clear();
         lineBuckets.clear();
         docText.clear();

--- a/include/editor.h
+++ b/include/editor.h
@@ -49,6 +49,11 @@ void confirmExitAction(App& app, HWND hwnd, int action);
 
 // Editor reparse (called from timer)
 void editorReparse(App& app);
+// External edits: undo-capable range replace plus dirty + immediate
+// reparse, used by the preview table cell editor (#148)
+void editorReplaceRangeExternal(App& app, size_t start, size_t end,
+                                const std::wstring& repl);
+void editorMarkDirtyAndReparse(App& app);
 
 // Editor search
 void performEditorSearch(App& app);

--- a/include/tableedit.h
+++ b/include/tableedit.h
@@ -1,0 +1,27 @@
+#ifndef TINTA_TABLEEDIT_H
+#define TINTA_TABLEEDIT_H
+
+#include "app.h"
+
+// In-place table editing in the rendered preview (#148, edit mode).
+// Clicking a cell opens an inline input over it; typing edits the raw
+// markdown through the editor's undo stack. Tab commits and moves to
+// the next cell (adding a row past the last one), Enter commits, Esc
+// cancels. Hovering a table offers + row and + column affordances.
+
+// Mouse press in the preview pane (document coords already resolved by
+// the caller). Returns true when the press was consumed.
+bool tableEditMouseDown(App& app, HWND hwnd, float docX, float docY);
+// Keyboard while a cell editor is open; true = consumed
+bool tableEditKeyDown(App& app, HWND hwnd, WPARAM key);
+// Printable character while a cell editor is open; true = consumed
+bool tableEditChar(App& app, wchar_t ch);
+// Commit any open cell editor (mode exits, saves, clicks elsewhere)
+void tableEditCommit(App& app);
+// Drop the editor without applying (document switch, exit edit mode)
+void tableEditCancel(App& app);
+// Cell input overlay plus the hover + affordances; screen coordinates
+// (call after the edit-mode clip pops)
+void renderTableEditOverlay(App& app);
+
+#endif  // TINTA_TABLEEDIT_H

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2,6 +2,7 @@
 #include "document.h"
 #include "drafts.h"
 #include "signals.h"
+#include "tableedit.h"
 #include "editrail.h"
 #include "settings.h"
 #include "tabs.h"
@@ -378,6 +379,33 @@ static void pushUndo(App& app, App::EditAction::Type type, size_t pos,
     app.redoStack.clear();
 }
 
+// Undo-capable range replace for out-of-pane editors (the table cell
+// editor, #148): the whole swap lands on the undo stack as one pair
+void editorReplaceRangeExternal(App& app, size_t start, size_t end,
+                                const std::wstring& repl) {
+    if (start > app.editorText.size()) start = app.editorText.size();
+    if (end > app.editorText.size()) end = app.editorText.size();
+    if (end < start) end = start;
+    std::wstring removed = app.editorText.substr(start, end - start);
+    if (removed == repl) return;  // no-op edits stay off the undo stack
+    if (!removed.empty()) {
+        app.editorText.erase(start, end - start);
+        pushUndo(app, App::EditAction::Delete, start, removed,
+                 app.editorCursorPos, start);
+    }
+    if (!repl.empty()) {
+        app.editorText.insert(start, repl);
+        pushUndo(app, App::EditAction::Insert, start, repl, start,
+                 start + repl.size());
+    }
+    app.editorCursorPos = start + repl.size();
+    app.editorHasSelection = false;
+    app.editorDesiredCol = -1;
+    rebuildLineStarts(app);
+    app.clearEditorLineLayoutCache();
+    app.editorRowMetricsWidth = -1.0f;
+}
+
 static void editorUndo(App& app) {
     if (app.undoStack.empty()) return;
     auto action = app.undoStack.back();
@@ -731,6 +759,13 @@ static void scheduleReparse(App& app) {
     SetTimer(app.hwnd, TIMER_EDITOR_REPARSE, 300, nullptr);
 }
 
+// External edits (table cell editor #148) want the dirty bookkeeping AND
+// an immediate reparse so their source offsets stay fresh
+void editorMarkDirtyAndReparse(App& app) {
+    scheduleReparse(app);
+    editorReparse(app);
+}
+
 void editorReparse(App& app) {
     KillTimer(app.hwnd, TIMER_EDITOR_REPARSE);
     if (!app.editMode || !app.editorShowPreview) return;
@@ -766,6 +801,7 @@ static void enterEditModeWithContent(App& app, const std::string& content) {
     app.folderBrowserAnimation = 0.0f;
     app.folderBrowserEditingPath = false;
     app.folderBrowserNaming = 0;
+    tableEditCancel(app);  // no stale cell editor from a previous buffer
 
     app.editorText = fromUtf8(content);
     // Normalize \r\n to \n
@@ -910,6 +946,8 @@ void enterRecoveredDraft(App& app, HWND hwnd, const std::string& content,
 }
 
 void exitEditMode(App& app) {
+    // An open table cell commits before the mode question is asked (#148)
+    tableEditCommit(app);
     if (app.editorDirty) {
         // Unsaved changes: a modal dialog with clickable buttons. The
         // timestamp opens a grace window so smashed Esc presses land on a
@@ -1158,6 +1196,8 @@ void renderQuickNoteEmptyState(App& app) {
 }
 
 void saveEditorFile(App& app, HWND hwnd) {
+    // The open table cell belongs in the save (#148)
+    tableEditCommit(app);
     if (app.currentFile.empty()) {
         // Untitled quick note: name it now; cancel keeps editing untitled
         if (!promptSaveAsPath(app, hwnd)) return;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -14,6 +14,7 @@
 #include "render.h"
 #include "overlays.h"
 #include "signals.h"
+#include "tableedit.h"
 #include "pandoc.h"
 #include "print.h"
 #include "export.h"
@@ -1829,6 +1830,21 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             quickNoteOpenFile(app, hwnd);
             return;
         }
+        // In-place table editing (#148): cells and the + affordances
+        // catch preview presses before selection handling
+        if (app.editorShowPreview) {
+            float docX = (float)x - documentViewportX(app) + app.scrollX;
+            float docY = (float)y + app.scrollY;
+            if (tableEditMouseDown(app, hwnd, docX, docY)) {
+                app.swallowNextMouseUp = true;
+                return;
+            }
+            if (app.tableEditActive) {
+                // A press anywhere else in the preview commits the cell
+                tableEditCommit(app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+        }
         // Fall through for preview pane clicks
     }
 
@@ -3344,6 +3360,8 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
 
     // Edit mode: Ctrl+C with preview pane selection should copy from preview
     if (app.editMode) {
+        // An open table cell editor owns the keyboard (#148)
+        if (tableEditKeyDown(app, hwnd, wParam)) return;
         if (ctrl && wParam == 'C' && app.hasSelection &&
             app.selAnchor != app.selFocus) {
             std::wstring selected = selectionTextForRange(
@@ -3930,6 +3948,8 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
 
     // Edit mode: ':' enters edit mode, otherwise route to editor
     if (app.editMode) {
+        // An open table cell editor takes the typing (#148)
+        if (tableEditChar(app, (wchar_t)wParam)) return;
         handleEditorCharInput(app, hwnd, wParam);
         return;
     }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -30,6 +30,7 @@
 #include "annotations.h"
 #include "drafts.h"
 #include "signals.h"
+#include "tableedit.h"
 #include "editrail.h"
 #include "startpage.h"
 
@@ -1062,6 +1063,9 @@ render_document:
 
         // Quick-note empty state: Open button in the blank preview pane
         renderQuickNoteEmptyState(app);
+
+        // In-place table editing: cell input + hover affordances (#148)
+        renderTableEditOverlay(app);
 
         // Render search overlay in screen coordinates (over editor pane)
         if (app.showSearch) renderSearchOverlay(app);

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2880,6 +2880,27 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
         rowHeights[r] = maxRowH;
     }
 
+    // The Table element itself never receives a sourceOffset (the parser
+    // stamps the deepest element at text time), so the table's source
+    // anchor is its first text-bearing descendant - the same convention
+    // the in-place cell editor's source parser assumes (#148)
+    size_t tableSrc = SIZE_MAX;
+    {
+        std::function<void(const ElementPtr&)> firstSrc =
+            [&](const ElementPtr& e) {
+                if (!e || tableSrc != SIZE_MAX) return;
+                if (e->sourceOffset != SIZE_MAX) {
+                    tableSrc = e->sourceOffset;
+                    return;
+                }
+                for (const auto& child : e->children) firstSrc(child);
+            };
+        for (const auto& child : elem->children) {
+            firstSrc(child);
+            if (tableSrc != SIZE_MAX) break;
+        }
+    }
+
     // Pass 2: Render cells via layoutInlineContent (produces real text runs, links, etc.)
     float tableStartY = y;
     D2D1_COLOR_F borderColor = app.theme.blockquoteBorder;
@@ -2906,6 +2927,15 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
             const auto& cell = row->children[c];
             IDWriteTextFormat* fmt = isHeader ? app.boldFormat : app.textFormat;
             D2D1_COLOR_F textColor = isHeader ? app.theme.heading : app.theme.text;
+
+            // In-place editing (#148): the preview records every cell's
+            // rect keyed by the table's source anchor plus row/col
+            if (app.editMode && tableSrc != SIZE_MAX) {
+                app.tableCellRects.push_back(
+                    {tableSrc, (int)r, (int)c,
+                     D2D1::RectF(cellX, y, cellX + colWidths[c],
+                                 y + rowHeights[r])});
+            }
 
             if (!cell->children.empty()) {
                 float cellW = colWidths[c] - cellPadding * 2;
@@ -2973,6 +3003,7 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
         info.fitKey = fitKey;
         info.fitCandidate = fitCandidate || fitActive;
         info.fitActive = fitActive;
+        info.sourceOffset = tableSrc;
         app.tableRects.push_back(std::move(info));
     }
 

--- a/src/tableedit.cpp
+++ b/src/tableedit.cpp
@@ -1,0 +1,541 @@
+#include "tableedit.h"
+#include "editor.h"
+#include "utils.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace {
+
+// --- Offset mapping -------------------------------------------------
+// Source offsets from the parser are bytes into toUtf8(editorText);
+// edits happen in wide indices. One linear walk maps between them.
+
+size_t utf8LenOfRange(const std::wstring& text, size_t wideEnd) {
+    size_t bytes = 0;
+    for (size_t i = 0; i < wideEnd && i < text.size(); i++) {
+        wchar_t c = text[i];
+        if (c < 0x80) bytes += 1;
+        else if (c < 0x800) bytes += 2;
+        else if (c >= 0xD800 && c < 0xDC00 && i + 1 < text.size()) {
+            bytes += 4;
+            i++;
+        } else bytes += 3;
+    }
+    return bytes;
+}
+
+size_t wideIndexForUtf8(const std::wstring& text, size_t byteTarget) {
+    size_t bytes = 0;
+    for (size_t i = 0; i < text.size(); i++) {
+        if (bytes >= byteTarget) return i;
+        wchar_t c = text[i];
+        if (c < 0x80) bytes += 1;
+        else if (c < 0x800) bytes += 2;
+        else if (c >= 0xD800 && c < 0xDC00 && i + 1 < text.size()) {
+            bytes += 4;
+            i++;
+        } else bytes += 3;
+    }
+    return text.size();
+}
+
+// --- Pipe-table source parsing --------------------------------------
+
+struct TableLines {
+    // Byte spans [start, end) of each table line, header first; the
+    // delimiter row sits at index 1
+    std::vector<std::pair<size_t, size_t>> lines;
+};
+
+bool lineHasPipe(const std::string& src, size_t ls, size_t le) {
+    for (size_t i = ls; i < le; i++) {
+        if (src[i] == '|') return true;
+        if (src[i] == '\\') i++;
+    }
+    return false;
+}
+
+// Collect the pipe-table's lines around the table's source offset
+bool collectTableLines(const std::string& src, size_t tableSrc,
+                       TableLines& out) {
+    if (tableSrc >= src.size()) return false;
+    // Walk back to the start of the header line, then further up while
+    // the previous line is still part of the table (the offset points at
+    // the first cell text, which lives on the header line)
+    size_t ls = src.rfind('\n', tableSrc);
+    ls = (ls == std::string::npos) ? 0 : ls + 1;
+    out.lines.clear();
+    size_t pos = ls;
+    while (pos < src.size()) {
+        size_t le = src.find('\n', pos);
+        if (le == std::string::npos) le = src.size();
+        if (!lineHasPipe(src, pos, le)) break;
+        out.lines.push_back({pos, le});
+        if (le >= src.size()) break;
+        pos = le + 1;
+    }
+    return out.lines.size() >= 2;  // header + delimiter at minimum
+}
+
+// Unescaped pipe positions within a line
+std::vector<size_t> pipePositions(const std::string& src, size_t ls,
+                                  size_t le) {
+    std::vector<size_t> pipes;
+    for (size_t i = ls; i < le; i++) {
+        if (src[i] == '\\') { i++; continue; }
+        if (src[i] == '|') pipes.push_back(i);
+    }
+    return pipes;
+}
+
+// Trimmed byte span of cell (row, col); row 0 = header, body rows skip
+// the delimiter line. start == end marks an empty cell insertion point.
+bool cellByteRange(const std::string& src, const TableLines& t, int row,
+                   int col, size_t& start, size_t& end) {
+    size_t lineIdx = row == 0 ? 0 : (size_t)row + 1;
+    if (lineIdx >= t.lines.size() || lineIdx == 1) return false;
+    size_t ls = t.lines[lineIdx].first, le = t.lines[lineIdx].second;
+    std::vector<size_t> pipes = pipePositions(src, ls, le);
+    if (pipes.empty()) return false;
+
+    // Leading pipe? Cells sit between consecutive pipes; without one,
+    // the first cell starts at the line start
+    size_t firstContent = ls;
+    while (firstContent < le && (src[firstContent] == ' ' ||
+                                 src[firstContent] == '\t')) {
+        firstContent++;
+    }
+    bool leadingPipe = firstContent < le && src[firstContent] == '|';
+
+    size_t cellStart, cellEnd;
+    if (leadingPipe) {
+        if ((size_t)col + 1 > pipes.size()) return false;
+        cellStart = pipes[col] + 1;
+        cellEnd = ((size_t)col + 1 < pipes.size()) ? pipes[col + 1] : le;
+    } else {
+        if (col == 0) {
+            cellStart = ls;
+            cellEnd = pipes[0];
+        } else {
+            if ((size_t)col > pipes.size()) return false;
+            cellStart = pipes[col - 1] + 1;
+            cellEnd = ((size_t)col < pipes.size()) ? pipes[col] : le;
+        }
+    }
+    if (cellEnd < cellStart) return false;
+
+    while (cellStart < cellEnd && (src[cellStart] == ' ' ||
+                                   src[cellStart] == '\t')) {
+        cellStart++;
+    }
+    while (cellEnd > cellStart && (src[cellEnd - 1] == ' ' ||
+                                   src[cellEnd - 1] == '\t')) {
+        cellEnd--;
+    }
+    start = cellStart;
+    end = cellEnd;
+    return true;
+}
+
+int tableColumnCount(const std::string& src, const TableLines& t) {
+    // The delimiter line defines the column count
+    std::vector<size_t> pipes =
+        pipePositions(src, t.lines[1].first, t.lines[1].second);
+    if (pipes.empty()) return 0;
+    size_t ls = t.lines[1].first;
+    while (ls < t.lines[1].second && (src[ls] == ' ' || src[ls] == '\t')) ls++;
+    bool leading = ls < t.lines[1].second && src[ls] == '|';
+    size_t le = t.lines[1].second;
+    size_t trimmedEnd = le;
+    while (trimmedEnd > ls && (src[trimmedEnd - 1] == ' ' ||
+                               src[trimmedEnd - 1] == '\t')) {
+        trimmedEnd--;
+    }
+    bool trailing = trimmedEnd > ls && src[trimmedEnd - 1] == '|';
+    int cells = (int)pipes.size() - 1;
+    if (!leading) cells++;
+    if (!trailing) cells++;
+    return std::max(0, cells);
+}
+
+int tableBodyRowCount(const TableLines& t) {
+    return (int)t.lines.size() - 2;
+}
+
+// Escape pipes and flatten newlines so the cell text stays one cell
+std::wstring sanitizeCellText(const std::wstring& text) {
+    std::wstring out;
+    out.reserve(text.size());
+    for (wchar_t c : text) {
+        if (c == L'\n' || c == L'\r') {
+            out += L' ';
+        } else if (c == L'|') {
+            out += L"\\|";
+        } else {
+            out += c;
+        }
+    }
+    return out;
+}
+
+// Fresh source text plus this table's lines; false when the table is gone
+bool currentTable(App& app, std::string& src, TableLines& t) {
+    src = toUtf8(app.editorText);
+    return collectTableLines(src, app.tableEditSrc, t);
+}
+
+void closeCellEditor(App& app) {
+    app.tableEditActive = false;
+    app.tableEditRow = -1;
+    app.tableEditCol = -1;
+    app.tableEditText.clear();
+    app.tableEditCaret = 0;
+}
+
+// Load cell (row, col) of the table at tableSrc into the inline editor
+bool openCellEditor(App& app, size_t tableSrc, int row, int col) {
+    app.tableEditSrc = tableSrc;
+    std::string src;
+    TableLines t;
+    if (!currentTable(app, src, t)) return false;
+    size_t s, e;
+    if (!cellByteRange(src, t, row, col, s, e)) return false;
+    app.tableEditActive = true;
+    app.tableEditRow = row;
+    app.tableEditCol = col;
+    app.tableEditText = toWide(src.substr(s, e - s));
+    app.tableEditCaret = app.tableEditText.size();
+    resetCursorBlink(app);
+    return true;
+}
+
+// Replace the open cell's source with the editor text
+void commitCellEditor(App& app) {
+    if (!app.tableEditActive) return;
+    std::string src;
+    TableLines t;
+    if (currentTable(app, src, t)) {
+        size_t s, e;
+        if (cellByteRange(src, t, app.tableEditRow, app.tableEditCol, s, e)) {
+            std::wstring repl = sanitizeCellText(app.tableEditText);
+            size_t ws = wideIndexForUtf8(app.editorText, s);
+            size_t we = wideIndexForUtf8(app.editorText, e);
+            std::wstring current = app.editorText.substr(ws, we - ws);
+            if (current != repl) {
+                // An empty cell's insertion point may sit flush against
+                // the pipe; pad the replacement for readable source
+                if (ws == we && !repl.empty()) repl = L" " + repl + L" ";
+                editorReplaceRangeExternal(app, ws, we, repl);
+                editorMarkDirtyAndReparse(app);
+            }
+        }
+    }
+    closeCellEditor(app);
+}
+
+// Append an empty row after the last body row
+void insertTableRow(App& app, size_t tableSrc) {
+    app.tableEditSrc = tableSrc;
+    std::string src;
+    TableLines t;
+    if (!currentTable(app, src, t)) return;
+    int cols = tableColumnCount(src, t);
+    if (cols <= 0) return;
+    std::wstring row = L"\n|";
+    for (int c = 0; c < cols; c++) row += L"   |";
+    size_t insertAt =
+        wideIndexForUtf8(app.editorText, t.lines.back().second);
+    editorReplaceRangeExternal(app, insertAt, insertAt, row);
+    editorMarkDirtyAndReparse(app);
+}
+
+// Append an empty column to every table line (delimiter included)
+void insertTableColumn(App& app, size_t tableSrc) {
+    app.tableEditSrc = tableSrc;
+    std::string src;
+    TableLines t;
+    if (!currentTable(app, src, t)) return;
+    // Back to front so earlier byte offsets stay valid
+    for (size_t i = t.lines.size(); i-- > 0;) {
+        size_t ls = t.lines[i].first, le = t.lines[i].second;
+        size_t end = le;
+        while (end > ls && (src[end - 1] == ' ' || src[end - 1] == '\t' ||
+                            src[end - 1] == '\r')) {
+            end--;
+        }
+        bool trailingPipe = end > ls && src[end - 1] == '|';
+        std::wstring add;
+        if (!trailingPipe) add += L" |";
+        add += (i == 1) ? L" --- |" : L"   |";
+        size_t at = wideIndexForUtf8(app.editorText, end);
+        editorReplaceRangeExternal(app, at, at, add);
+    }
+    editorMarkDirtyAndReparse(app);
+}
+
+// Cell under a document point, using the layout's recorded rects
+const App::TableCellRect* cellAt(const App& app, float docX, float docY) {
+    for (const auto& c : app.tableCellRects) {
+        if (docX >= c.rect.left && docX <= c.rect.right &&
+            docY >= c.rect.top && docY <= c.rect.bottom) {
+            return &c;
+        }
+    }
+    return nullptr;
+}
+
+// The open cell's current document rect, or nullptr after a relayout
+// that dropped it
+const App::TableCellRect* activeCellRect(const App& app) {
+    for (const auto& c : app.tableCellRects) {
+        if (c.tableSrc == app.tableEditSrc && c.row == app.tableEditRow &&
+            c.col == app.tableEditCol) {
+            return &c;
+        }
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+bool tableEditMouseDown(App& app, HWND hwnd, float docX, float docY) {
+    // + row / + column affordances first: they sit outside cell rects
+    if (app.tableAddRowRect.right > app.tableAddRowRect.left &&
+        docX >= app.tableAddRowRect.left && docX <= app.tableAddRowRect.right &&
+        docY >= app.tableAddRowRect.top && docY <= app.tableAddRowRect.bottom) {
+        tableEditCommit(app);
+        insertTableRow(app, app.tableAddSrc);
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return true;
+    }
+    if (app.tableAddColRect.right > app.tableAddColRect.left &&
+        docX >= app.tableAddColRect.left && docX <= app.tableAddColRect.right &&
+        docY >= app.tableAddColRect.top && docY <= app.tableAddColRect.bottom) {
+        tableEditCommit(app);
+        insertTableColumn(app, app.tableAddSrc);
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return true;
+    }
+
+    const App::TableCellRect* cell = cellAt(app, docX, docY);
+    if (app.tableEditActive) {
+        if (cell && cell->tableSrc == app.tableEditSrc &&
+            cell->row == app.tableEditRow && cell->col == app.tableEditCol) {
+            return true;  // click inside the open editor keeps focus
+        }
+        tableEditCommit(app);
+        // fall through: the same click may open the next cell
+    }
+    if (cell) {
+        openCellEditor(app, cell->tableSrc, cell->row, cell->col);
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return true;
+    }
+    return false;
+}
+
+bool tableEditKeyDown(App& app, HWND hwnd, WPARAM key) {
+    if (!app.tableEditActive) return false;
+    // Ctrl chords pass through (save commits the open cell first)
+    if (GetKeyState(VK_CONTROL) & 0x8000) return false;
+    switch (key) {
+        case VK_ESCAPE:
+            tableEditCancel(app);
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return true;
+        case VK_RETURN:
+            tableEditCommit(app);
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return true;
+        case VK_TAB: {
+            bool back = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+            size_t tableSrc = app.tableEditSrc;
+            int row = app.tableEditRow, col = app.tableEditCol;
+            tableEditCommit(app);
+
+            std::string src;
+            TableLines t;
+            app.tableEditSrc = tableSrc;
+            if (!currentTable(app, src, t)) return true;
+            int cols = tableColumnCount(src, t);
+            int bodyRows = tableBodyRowCount(t);
+            if (back) {
+                if (--col < 0) {
+                    col = cols - 1;
+                    row = row == 0 ? 0 : row - 1;
+                }
+            } else if (++col >= cols) {
+                col = 0;
+                row++;
+                if (row > bodyRows) {
+                    // Tab past the last cell grows the table (notion-style)
+                    insertTableRow(app, tableSrc);
+                }
+            }
+            openCellEditor(app, tableSrc, row, col);
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return true;
+        }
+        case VK_BACK:
+            if (app.tableEditCaret > 0) {
+                app.tableEditText.erase(--app.tableEditCaret, 1);
+                resetCursorBlink(app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            return true;
+        case VK_DELETE:
+            if (app.tableEditCaret < app.tableEditText.size()) {
+                app.tableEditText.erase(app.tableEditCaret, 1);
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            return true;
+        case VK_LEFT:
+            if (app.tableEditCaret > 0) app.tableEditCaret--;
+            resetCursorBlink(app);
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return true;
+        case VK_RIGHT:
+            if (app.tableEditCaret < app.tableEditText.size())
+                app.tableEditCaret++;
+            resetCursorBlink(app);
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return true;
+        case VK_HOME:
+            app.tableEditCaret = 0;
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return true;
+        case VK_END:
+            app.tableEditCaret = app.tableEditText.size();
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return true;
+        default:
+            return true;  // the open cell owns the keyboard
+    }
+}
+
+bool tableEditChar(App& app, wchar_t ch) {
+    if (!app.tableEditActive) return false;
+    if (ch < 0x20 || ch == 127) return true;  // controls handled as keys
+    app.tableEditText.insert(app.tableEditCaret++, 1, ch);
+    resetCursorBlink(app);
+    if (app.hwnd) InvalidateRect(app.hwnd, nullptr, FALSE);
+    return true;
+}
+
+void tableEditCommit(App& app) {
+    commitCellEditor(app);
+}
+
+void tableEditCancel(App& app) {
+    closeCellEditor(app);
+}
+
+void renderTableEditOverlay(App& app) {
+    if (!app.editMode || !editorPreviewVisible(app)) return;
+    if (!app.renderTarget || !app.brush || !app.textFormat) return;
+
+    float viewX = documentViewportX(app);
+    auto toScreen = [&](const D2D1_RECT_F& r) {
+        return D2D1::RectF(r.left + viewX - app.scrollX, r.top - app.scrollY,
+                           r.right + viewX - app.scrollX,
+                           r.bottom - app.scrollY);
+    };
+
+    // Hover affordances: + row under the table, + column at its right.
+    // Rects live in document coordinates for the input hit-test.
+    app.tableAddRowRect = app.tableAddColRect = D2D1_RECT_F{};
+    float scale = app.contentScale * app.zoomFactor;
+    float band = 14.0f * scale;
+    float docMouseX = (float)app.mouseX - viewX + app.scrollX;
+    float docMouseY = (float)app.mouseY + app.scrollY;
+    for (const auto& tbl : app.tableRects) {
+        if (tbl.sourceOffset == SIZE_MAX) continue;
+        bool nearTable = docMouseX >= tbl.bounds.left - band &&
+                         docMouseX <= tbl.bounds.right + band * 2 &&
+                         docMouseY >= tbl.bounds.top - band &&
+                         docMouseY <= tbl.bounds.bottom + band * 2;
+        if (!nearTable && !(app.tableEditActive &&
+                            tbl.sourceOffset == app.tableEditSrc)) {
+            continue;
+        }
+        app.tableAddSrc = tbl.sourceOffset;
+        app.tableAddRowRect =
+            D2D1::RectF(tbl.bounds.left, tbl.bounds.bottom,
+                        tbl.bounds.right, tbl.bounds.bottom + band);
+        app.tableAddColRect =
+            D2D1::RectF(tbl.bounds.right, tbl.bounds.top,
+                        tbl.bounds.right + band, tbl.bounds.bottom);
+
+        auto drawPlusBand = [&](const D2D1_RECT_F& docRect, bool hovered) {
+            D2D1_RECT_F r = toScreen(docRect);
+            D2D1_COLOR_F bg = app.theme.accent;
+            bg.a = hovered ? 0.18f : 0.07f;
+            app.brush->SetColor(bg);
+            app.renderTarget->FillRoundedRectangle(
+                D2D1::RoundedRect(r, 3.0f * scale, 3.0f * scale), app.brush);
+            D2D1_COLOR_F ink = app.theme.accent;
+            ink.a = hovered ? 0.95f : 0.55f;
+            app.brush->SetColor(ink);
+            float cx = (r.left + r.right) * 0.5f;
+            float cy = (r.top + r.bottom) * 0.5f;
+            float s = 4.0f * scale;
+            app.renderTarget->DrawLine(D2D1::Point2F(cx - s, cy),
+                                       D2D1::Point2F(cx + s, cy), app.brush,
+                                       1.4f);
+            app.renderTarget->DrawLine(D2D1::Point2F(cx, cy - s),
+                                       D2D1::Point2F(cx, cy + s), app.brush,
+                                       1.4f);
+        };
+        bool rowHover = docMouseX >= app.tableAddRowRect.left &&
+                        docMouseX <= app.tableAddRowRect.right &&
+                        docMouseY >= app.tableAddRowRect.top &&
+                        docMouseY <= app.tableAddRowRect.bottom;
+        bool colHover = docMouseX >= app.tableAddColRect.left &&
+                        docMouseX <= app.tableAddColRect.right &&
+                        docMouseY >= app.tableAddColRect.top &&
+                        docMouseY <= app.tableAddColRect.bottom;
+        drawPlusBand(app.tableAddRowRect, rowHover);
+        drawPlusBand(app.tableAddColRect, colHover);
+        break;  // one table's affordances at a time
+    }
+
+    // The inline cell input
+    if (!app.tableEditActive) return;
+    const App::TableCellRect* cell = activeCellRect(app);
+    if (!cell) return;  // relayout mid-frame; the next paint finds it
+
+    D2D1_RECT_F r = toScreen(cell->rect);
+    float pad = 8.0f * scale;
+    D2D1_COLOR_F fill = app.theme.background;
+    fill.a = 1.0f;
+    app.brush->SetColor(fill);
+    app.renderTarget->FillRectangle(r, app.brush);
+    D2D1_COLOR_F ring = app.theme.accent;
+    ring.a = 0.9f;
+    app.brush->SetColor(ring);
+    app.renderTarget->DrawRectangle(r, app.brush, 1.5f);
+
+    D2D1_COLOR_F ink = app.theme.text;
+    app.brush->SetColor(ink);
+    app.renderTarget->DrawText(
+        app.tableEditText.c_str(), (UINT32)app.tableEditText.size(),
+        app.textFormat,
+        D2D1::RectF(r.left + pad, r.top + pad, r.right - pad, r.bottom),
+        app.brush);
+
+    if (app.cursorBlinkOn) {
+        std::wstring beforeCaret =
+            app.tableEditText.substr(0, app.tableEditCaret);
+        float cw = beforeCaret.empty()
+                       ? 0.0f
+                       : measureText(app, beforeCaret, app.textFormat);
+        float cx = r.left + pad + cw + 1.0f;
+        app.renderTarget->DrawLine(
+            D2D1::Point2F(cx, r.top + pad),
+            D2D1::Point2F(cx, r.top + pad + app.textFormat->GetFontSize() *
+                                                1.4f),
+            app.brush, 1.2f);
+    }
+}

--- a/src/tabs.cpp
+++ b/src/tabs.cpp
@@ -8,6 +8,7 @@
 #include "document.h"
 #include "drafts.h"
 #include "signals.h"
+#include "tableedit.h"
 #include "editor.h"
 #include "startpage.h"
 #include "file_utils.h"
@@ -54,6 +55,8 @@ void syncActiveTab(App& app) {
 // (another document loads immediately after).
 void parkActiveEditBuffer(App& app) {
     if (!app.editMode || app.tabs.empty()) return;
+    // An open table cell belongs to this buffer, not the next tab (#148)
+    tableEditCommit(app);
     App::DocTab& tab = app.tabs[app.activeTab];
     tab.editMode = true;
     tab.editorDirty = app.editorDirty;


### PR DESCRIPTION
Click a table cell while edit mode is active to edit it directly in the rendered preview.

- Click any cell to open an inline editor (accent ring + caret) right on the cell
- Type, Enter commits, Esc cancels, Tab/Shift+Tab moves between cells
- Tab past the last cell adds a new row (notion-style)
- Hover the table to reveal + bands: below the table to add a row, at the right edge to add a column
- Every commit rewrites just the affected cell range in the markdown source and lands on the undo stack as a single operation
- Cell text is sanitized (pipes escaped, newlines flattened) so the table never breaks
- External source edits now rebuild the raw pane line index, keeping both panes in sync

Fulfills the wish from #148.