### PR TITLE
Excel ranges paste as markdown tables (#181)

### DIFF
--- a/include/tableedit.h
+++ b/include/tableedit.h
@@ -24,4 +24,11 @@ void tableEditCancel(App& app);
 // (call after the edit-mode clip pops)
 void renderTableEditOverlay(App& app);
 
+// Excel/TSV paste (#181): true when pasted text reads as a uniform
+// tab-separated grid (2+ rows, equal tab counts per row)
+bool tsvLooksLikeTable(const std::wstring& text);
+// That grid as a markdown table, first row as the header (no trailing
+// newline - the caller pads for its insertion context)
+std::wstring tsvToMarkdownTable(const std::wstring& text);
+
 #endif  // TINTA_TABLEEDIT_H

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -406,6 +406,21 @@ void editorReplaceRangeExternal(App& app, size_t start, size_t end,
     app.editorRowMetricsWidth = -1.0f;
 }
 
+// Pad a markdown table for insertion at pos: a table cannot interrupt a
+// paragraph, so a blank line must separate it on both sides (#181)
+static std::wstring padTableForInsert(const App& app,
+                                      const std::wstring& table, size_t pos) {
+    int nlBefore = 0;
+    for (size_t k = pos; k > 0 && app.editorText[k - 1] == L'\n' && nlBefore < 2; k--) {
+        nlBefore++;
+    }
+    std::wstring pre;
+    if (pos > 0 && nlBefore < 2) pre = (nlBefore == 1) ? L"\n" : L"\n\n";
+    std::wstring post = L"\n";
+    if (pos < app.editorText.size() && app.editorText[pos] != L'\n') post = L"\n\n";
+    return pre + table + post;
+}
+
 static void editorUndo(App& app) {
     if (app.undoStack.empty()) return;
     auto action = app.undoStack.back();
@@ -1652,6 +1667,15 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 }
                 if (!paste.empty()) {
                     if (app.editorHasSelection) editorDeleteSelection(app);
+                    // Excel range copies arrive as TSV: paste them as a
+                    // markdown table (#181). Ctrl+Shift+V pastes raw.
+                    if (!(GetKeyState(VK_SHIFT) & 0x8000) &&
+                        tsvLooksLikeTable(paste)) {
+                        paste = padTableForInsert(
+                            app, tsvToMarkdownTable(paste), app.editorCursorPos);
+                        signalPushKey(app, SIG_SUCCESS, SIGI_CHECK,
+                                      "toast.paste_table");
+                    }
                     size_t before = app.editorCursorPos;
                     app.editorText.insert(app.editorCursorPos, paste);
                     app.editorCursorPos += paste.size();
@@ -2165,6 +2189,13 @@ void editorClipboardPaste(App& app, HWND hwnd) {
     std::wstring paste = editorGetClipboard(hwnd);
     if (paste.empty()) return;
     if (app.editorHasSelection) editorDeleteSelection(app);
+    // Same Excel/TSV conversion as Ctrl+V (#181); the rail button has
+    // no modifier, Ctrl+Shift+V is the raw-paste escape hatch
+    if (tsvLooksLikeTable(paste)) {
+        paste = padTableForInsert(app, tsvToMarkdownTable(paste),
+                                  app.editorCursorPos);
+        signalPushKey(app, SIG_SUCCESS, SIGI_CHECK, "toast.paste_table");
+    }
     size_t before = app.editorCursorPos;
     app.editorText.insert(app.editorCursorPos, paste);
     app.editorCursorPos += paste.size();

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -117,6 +117,7 @@ const Entry kEntries[] = {
     { "toast.wrap_on",         L"Word wrap on (Ctrl+W to turn off)",        L"\u5DF2\u5F00\u542F\u81EA\u52A8\u6362\u884C\uFF08Ctrl+W \u5173\u95ED\uFF09", L"\u81EA\u52D5\u6539\u884C\u3092\u30AA\u30F3\u306B\u3057\u307E\u3057\u305F (Ctrl+W\u3067\u30AA\u30D5)", L"\uC790\uB3D9 \uC904\uBC14\uAFC0 \uCF1C\uAE30 (Ctrl+W\uB85C \uB044\uAE30)" },
     { "toast.wrap_off",        L"Word wrap off (Ctrl+W to turn on)",        L"\u5DF2\u5173\u95ED\u81EA\u52A8\u6362\u884C\uFF08Ctrl+W \u5F00\u542F\uFF09", L"\u81EA\u52D5\u6539\u884C\u3092\u30AA\u30D5\u306B\u3057\u307E\u3057\u305F (Ctrl+W\u3067\u30AA\u30F3)", L"\uC790\uB3D9 \uC904\uBC14\uAFC0 \uB044\uAE30 (Ctrl+W\uB85C \uCF1C\uAE30)" },
     { "toast.copied",          L"Copied!",                                  L"\u5DF2\u590D\u5236\uFF01",                             L"\u30B3\u30D4\u30FC\u3057\u307E\u3057\u305F\uFF01",             L"\uBCF5\uC0AC\uD588\uC2B5\uB2C8\uB2E4!" },
+    { "toast.paste_table",     L"Pasted as a table \u00B7 Ctrl+Shift+V pastes plain", L"\u5DF2\u7C98\u8D34\u4E3A\u8868\u683C\uFF08Ctrl+Shift+V \u7C98\u8D34\u7EAF\u6587\u672C\uFF09", L"\u8868\u3068\u3057\u3066\u8CBC\u308A\u4ED8\u3051\u307E\u3057\u305F (Ctrl+Shift+V\u3067\u305D\u306E\u307E\u307E)", L"\uD45C\uB85C \uBD99\uC5EC\uB123\uC5C8\uC2B5\uB2C8\uB2E4 (Ctrl+Shift+V\uB294 \uC77C\uBC18 \uBD99\uC5EC\uB123\uAE30)" },
 
     // Code block hover button + confirmation pill
     { "codeblock.copy",        L"Copy",                                     L"\u590D\u5236",                                         L"\u30B3\u30D4\u30FC",                              L"\uBCF5\uC0AC" },
@@ -739,6 +740,10 @@ const BuiltinTranslation kBuiltinTranslations[] = {
       L"Kopiert!",
       L"Copi\u00E9 !",
       L"Copiato!" },
+    { "toast.paste_table",
+      L"Als Tabelle eingef\u00FCgt (Ctrl+Shift+V f\u00FCgt unver\u00E4ndert ein)",
+      L"Coll\u00E9 en tableau (Ctrl+Shift+V colle le texte brut)",
+      L"Incollato come tabella (Ctrl+Shift+V incolla il testo semplice)" },
     { "toast.save_failed",
       L"Speichern fehlgeschlagen \u2014 Datei ist evtl. gesperrt oder schreibgesch\u00FCtzt",
       L"\u00C9chec de l'enregistrement \u2014 le fichier est peut-\u00EAtre verrouill\u00E9 ou en lecture seule",

--- a/src/tableedit.cpp
+++ b/src/tableedit.cpp
@@ -300,6 +300,81 @@ const App::TableCellRect* activeCellRect(const App& app) {
 
 }  // namespace
 
+// --- Excel/TSV paste (#181) -----------------------------------------
+
+// Clipboard text as lines, tolerating CRLF; Excel terminates a range
+// copy with one newline, so trailing empty lines are dropped
+static std::vector<std::wstring> tsvLines(const std::wstring& text) {
+    std::vector<std::wstring> lines;
+    size_t start = 0;
+    while (start <= text.size()) {
+        size_t nl = text.find(L'\n', start);
+        std::wstring line = (nl == std::wstring::npos)
+            ? text.substr(start) : text.substr(start, nl - start);
+        if (!line.empty() && line.back() == L'\r') line.pop_back();
+        lines.push_back(std::move(line));
+        if (nl == std::wstring::npos) break;
+        start = nl + 1;
+    }
+    while (!lines.empty() && lines.back().empty()) lines.pop_back();
+    return lines;
+}
+
+// A paste reads as a spreadsheet grid when it has 2+ rows and every row
+// carries the same number of tabs - exactly what Excel (or any TSV
+// export) puts on the clipboard for a range copy. Single lines and
+// ragged tab counts paste untouched; tabs in code are common.
+bool tsvLooksLikeTable(const std::wstring& text) {
+    if (text.find(L'\t') == std::wstring::npos) return false;
+    std::vector<std::wstring> lines = tsvLines(text);
+    if (lines.size() < 2) return false;
+    size_t tabs = std::wstring::npos;
+    for (const std::wstring& line : lines) {
+        size_t count = (size_t)std::count(line.begin(), line.end(), L'\t');
+        if (count == 0) return false;
+        if (tabs == std::wstring::npos) tabs = count;
+        else if (count != tabs) return false;
+    }
+    return true;
+}
+
+// The grid as a markdown table: first row becomes the header, cells are
+// trimmed and pipe-escaped. No trailing newline - the caller pads for
+// its insertion context.
+std::wstring tsvToMarkdownTable(const std::wstring& text) {
+    std::vector<std::wstring> lines = tsvLines(text);
+    std::wstring out;
+    size_t cols = 0;
+    for (size_t r = 0; r < lines.size(); r++) {
+        const std::wstring& line = lines[r];
+        std::vector<std::wstring> cells;
+        size_t start = 0;
+        while (start <= line.size()) {
+            size_t tab = line.find(L'\t', start);
+            std::wstring cell = (tab == std::wstring::npos)
+                ? line.substr(start) : line.substr(start, tab - start);
+            size_t a = cell.find_first_not_of(L' ');
+            size_t b = cell.find_last_not_of(L' ');
+            cell = (a == std::wstring::npos) ? L"" : cell.substr(a, b - a + 1);
+            cells.push_back(sanitizeCellText(cell));
+            if (tab == std::wstring::npos) break;
+            start = tab + 1;
+        }
+        if (r == 0) cols = cells.size();
+        cells.resize(cols);
+        out += L"|";
+        for (const std::wstring& cell : cells) {
+            out += L" " + cell + L" |";
+        }
+        if (r == 0) {
+            out += L"\n|";
+            for (size_t c = 0; c < cols; c++) out += L" --- |";
+        }
+        if (r + 1 < lines.size()) out += L"\n";
+    }
+    return out;
+}
+
 bool tableEditMouseDown(App& app, HWND hwnd, float docX, float docY) {
     // + row / + column affordances first: they sit outside cell rects
     if (app.tableAddRowRect.right > app.tableAddRowRect.left &&


### PR DESCRIPTION
The main ask of #181: copy a range in Excel (or any TSV source), paste it in edit mode, get a markdown table.

- Detection: 2+ lines where every line carries the same number of tabs - exactly what Excel puts on the clipboard for a range copy. Single lines and ragged tab counts paste untouched, so tabs in code are safe.
- First row becomes the header, cells are trimmed and pipe-escaped.
- Pasting mid-paragraph splits it with blank lines on both sides so the table always parses.
- Ctrl+Shift+V pastes the raw text; a signal chip confirms the conversion and mentions the escape hatch.
- Works from both Ctrl+V and the editor context menu's Paste.

Verified live: Excel-style CRLF TSV, mid-line insertion, pipe-in-cell escaping, and the negative cases (plain text, single tabbed line).