### PR TITLE
Ctrl+F4 closes the tab in both modes (#181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 - **Paste screenshots** - Ctrl+V a bitmap in edit mode and it saves as a PNG beside the document with the link inserted
 - **Pin on top** - A pushpin in the title bar keeps the window above every other app
 - **Rich tables** - Tables with bold, italic, code, and clickable links in cells
-- **Tabs** - Win11 Notepad-style tabs in the title bar: files opened from Explorer join the window as tabs, Ctrl+Tab cycles, Ctrl+W closes, middle-click closes, Ctrl+T opens the file browser into a new tab, unsaved buffers show a dot, and dragging reorders tabs. Right-click a tab for close operations (close, close all but this, close all to the left/right) plus copy path and reveal in Explorer. Pulling a tab out of the strip floats it as a card: drop it on open space for a new window (which keeps the tab row), or onto another Tinta window to move it there — and dropping a single-file window onto a tab strip merges it back. Single-file windows stay tabless; turn the Explorer behavior off with the "Open files in tabs" setting
+- **Tabs** - Win11 Notepad-style tabs in the title bar: files opened from Explorer join the window as tabs, Ctrl+Tab cycles, Ctrl+W or Ctrl+F4 closes (Ctrl+F4 also while editing, where Ctrl+W is word wrap), middle-click closes, Ctrl+T opens the file browser into a new tab, unsaved buffers show a dot, and dragging reorders tabs. Right-click a tab for close operations (close, close all but this, close all to the left/right) plus copy path and reveal in Explorer. Pulling a tab out of the strip floats it as a card: drop it on open space for a new window (which keeps the tab row), or onto another Tinta window to move it there — and dropping a single-file window onto a tab strip merges it back. Single-file windows stay tabless; turn the Explorer behavior off with the "Open files in tabs" setting
 - **Folder browser** - Press B to browse and open Markdown or Mermaid files (Ctrl+click a file to open it in a new tab)
 - **Table of contents** - Press Tab to see document headings, click to jump; the panel follows your reading position, and typing filters the headings
 - **Unified editor** - Press `:` to edit: your raw Markdown on the left with the rendered page floating beside it as a sheet on the editor's desk. A slim line-number gutter, a soft accent wash on the caret's line and its rendered block, a tool rail with formatting controls plus table-size and diagram-template pickers, and Markdown assists (lists continue on Enter, Tab indents, Ctrl+B/I wrap). Search and find-replace work in the editor too
@@ -129,6 +129,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 | `Ctrl+P` | Print / export to PDF |
 | `Ctrl+E` | Show/hide preview pane (in edit mode) |
 | `Ctrl+W` | Toggle word wrap (in edit mode) |
+| `Ctrl+F4` | Close the current tab (viewer and edit mode) |
 | `Q` | Quit |
 
 ## Customization

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -3327,6 +3327,12 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             tabCloseIndex(app, hwnd, app.activeTab);
             return;
         }
+        if (wParam == VK_F4) {
+            // Ctrl+F4 closes the tab in BOTH modes - the reachable close
+            // while editing, where Ctrl+W means word wrap (#181)
+            tabCloseIndex(app, hwnd, app.activeTab);
+            return;
+        }
         if (wParam == 'T') {
             // New tab = the start page (browser-style new-tab page); its
             // Open/Browse/recents land in this tab. The old open-into-a-

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -2050,7 +2050,7 @@ void renderHelpOverlay(App& app) {
         {kToc.c_str(),    tr(app, "help.view.toc")},
         {L"Ctrl+T",       tr(app, "help.view.new_tab")},
         {L"Ctrl+Tab",     tr(app, "help.view.next_tab")},
-        {L"Ctrl+W",       tr(app, "help.view.close_tab")},
+        {L"Ctrl+W / Ctrl+F4", tr(app, "help.view.close_tab")},
         {kTheme.c_str(),  tr(app, "help.view.theme")},
         {kStats.c_str(),  tr(app, "help.view.stats")},
         {kHelp.c_str(),   tr(app, "help.view.help")},


### PR DESCRIPTION
Point 2 of #181: there was no close-tab shortcut reachable from edit mode - Ctrl+W toggles word wrap there (its documented editor meaning since the tabs release) and Ctrl+F4 did nothing.

Ctrl+F4 now closes the current tab in viewer and edit mode alike. It goes through tabCloseIndex like every other close, so a dirty buffer still gets the unsaved-changes dialog, a clean edit session parks silently, and the last tab closes into the start page. Help overlay shows "Ctrl+W / Ctrl+F4" on the close row; README documents the new key.