### PR TITLE
修复导出 Markdown 表格图片布局错位

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The table editor release: edit tables by clicking them in the rendered view, pin
 - File references to any known text format get the full link treatment (.xml added), and non-Markdown targets open in their registered application (#162, #163)
 
 ### Fixed
+- Presentational `<font style="...">` wrappers exported by office and AI tools are ignored while their content remains visible, so Chinese test-case tables render with clean text and correct column measurements
+- Table layout measurements no longer leave temporary images at the document origin, and images in centered or right-aligned cells now move with the cell content
 - Store installs: the Settings buttons that open the configuration .ini files now resolve the virtualized AppData path so the editor finds the real file - contributed by @brianhassel-gh (#166)
 - Pressing A to create an annotation no longer leaks the keystroke into the note box (#161, #164)
 - Plain-text link peeks render frameless instead of as a code block, and cancelling the create-reference dialog no longer leaves a stuck selection (#163)

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -305,6 +305,29 @@ static bool isBrTag(const MD_CHAR* text, MD_SIZE size) {
     return norm == "<br>" || norm == "<br/>";
 }
 
+// Some Markdown producers wrap every cell and paragraph in a presentational
+// <font> tag. It has no semantic value for the native renderer, and keeping
+// it in a Text node makes the tag visible and inflates table column widths.
+static bool isTransparentFontTag(const MD_CHAR* text, MD_SIZE size) {
+    if (size < 6 || text[0] != '<' || text[size - 1] != '>') return false;
+
+    MD_SIZE nameStart = 1;
+    if (text[nameStart] == '/') nameStart++;
+    if (nameStart + 4 >= size) return false;
+    if (tolower((unsigned char)text[nameStart]) != 'f' ||
+        tolower((unsigned char)text[nameStart + 1]) != 'o' ||
+        tolower((unsigned char)text[nameStart + 2]) != 'n' ||
+        tolower((unsigned char)text[nameStart + 3]) != 't') {
+        return false;
+    }
+
+    // Do not mistake tags such as <fontface> for <font>.
+    MD_SIZE afterName = nameStart + 4;
+    return afterName == size - 1 ||
+           isspace((unsigned char)text[afterName]) ||
+           text[afterName] == '/';
+}
+
 static int textCallback(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, void* userdata) {
     auto* ctx = static_cast<ParserContext*>(userdata);
 
@@ -323,6 +346,10 @@ static int textCallback(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, voi
                 auto elem = std::make_shared<Element>(ElementType::HardBreak);
                 elem->parent = ctx->current();
                 ctx->current()->children.push_back(elem);
+                break;
+            }
+            if (ctx->current() && ctx->current()->type != ElementType::HtmlBlock &&
+                isTransparentFontTag(text, size)) {
                 break;
             }
             ctx->addText(text, size);

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -133,7 +133,7 @@ static void addTextRun(App& app, LayoutInfo&& info, const D2D1_POINT_2F& pos,
 }
 
 struct LayoutSnapshot {
-    size_t textRuns, rects, lines, shapes, connectors;
+    size_t textRuns, rects, lines, shapes, connectors, bitmaps;
     size_t links, textRects, lineBuckets, docTextLen, tasks;
 };
 
@@ -144,6 +144,7 @@ static LayoutSnapshot takeSnapshot(App& app) {
         app.layoutLines.size(),
         app.layoutShapes.size(),
         app.layoutConnectors.size(),
+        app.layoutBitmaps.size(),
         app.linkRects.size(),
         app.textRects.size(),
         app.lineBuckets.size(),
@@ -168,6 +169,7 @@ static void rollbackTo(App& app, const LayoutSnapshot& s) {
     app.layoutLines.resize(s.lines);
     app.layoutShapes.resize(s.shapes);
     app.layoutConnectors.resize(s.connectors);
+    app.layoutBitmaps.resize(s.bitmaps);
     app.linkRects.resize(s.links);
     app.textRects.resize(s.textRects);
     app.lineBuckets.resize(s.lineBuckets);
@@ -203,6 +205,11 @@ static void shiftLayoutItems(App& app, const LayoutSnapshot& from, float dx) {
         connector.bounds.left += dx;
         connector.bounds.right += dx;
         for (auto& point : connector.points) point.x += dx;
+    }
+    for (size_t i = from.bitmaps; i < app.layoutBitmaps.size(); i++) {
+        auto& bitmap = app.layoutBitmaps[i].destRect;
+        bitmap.left += dx;
+        bitmap.right += dx;
     }
     for (size_t i = from.links; i < app.linkRects.size(); i++) {
         auto& r = app.linkRects[i];
@@ -2777,6 +2784,10 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
                     maxRight = std::max(maxRight,
                                         app.layoutRects[i].rect.right);
                 }
+                for (size_t i = snap.bitmaps; i < app.layoutBitmaps.size(); i++) {
+                    maxRight = std::max(maxRight,
+                                        app.layoutBitmaps[i].destRect.right);
+                }
                 rollbackTo(app, snap);
                 textWidth = maxRight;
             }
@@ -2953,6 +2964,9 @@ static void layoutTable(App& app, const ElementPtr& elem, float& y, float indent
                     float maxRight = 0.0f;
                     for (size_t i = cellSnap.textRuns; i < app.layoutTextRuns.size(); i++) {
                         maxRight = std::max(maxRight, app.layoutTextRuns[i].bounds.right);
+                    }
+                    for (size_t i = cellSnap.bitmaps; i < app.layoutBitmaps.size(); i++) {
+                        maxRight = std::max(maxRight, app.layoutBitmaps[i].destRect.right);
                     }
                     float contentW = maxRight - textX;
                     float dx = 0.0f;

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -118,24 +118,24 @@ int main() {
     // in presentational <font> tags. They must not become literal table text.
     {
         auto styledTable = parseDocument(parser,
-            "# 数智润德预案管理后台系统功能测试用例表\n"
+            "# 示例测试文档\n"
             "**<font style=\"color:#000000;\">文档版本</font>**：V1.0\n\n"
             "| **<font style=\"color:rgb(0, 0, 0);\">序号</font>** | "
             "**<font style=\"color:rgb(0, 0, 0);\">功能项</font>** | "
-            "**<font style=\"color:rgb(0, 0, 0);\">测试结果（正常/异常）</font>** | "
-            "**<font style=\"color:rgb(0, 0, 0);\">异常描述</font>** |\n"
+            "**<font style=\"color:rgb(0, 0, 0);\">测试状态</font>** | "
+            "**<font style=\"color:rgb(0, 0, 0);\">备注</font>** |\n"
             "| --- | --- | --- | --- |\n"
             "| <font style=\"color:rgb(0, 0, 0);\">1</font> | "
-            "<font style=\"color:#000000;\">登录：输入正确账号和密码。</font> | "
+            "<font style=\"color:#000000;\">检查输入框。</font> | "
             "<font style=\"color:#000000;\">正常</font> |  |\n"
             "| <font style=\"color:rgb(0, 0, 0);\">2</font> | "
-            "<font style=\"color:#000000;\">提交后检查异常描述。</font> | "
+            "<font style=\"color:#000000;\">提交示例数据。</font> | "
             "<font style=\"color:#000000;\">异常</font> | "
-            "<font style=\"color:#000000;\">截图</font>![](https://cdn.example.test/error.png) |\n"
+            "<font style=\"color:#000000;\">截图</font>![](https://example.test/error.png) |\n"
             "| <font style=\"color:rgb(0, 0, 0);\">3</font> | "
-            "<font style=\"color:#000000;\">空结果占位。</font> | "
+            "<font style=\"color:#000000;\">空状态占位。</font> | "
             "<font style=\"color:#000000;\">正常</font> | <br/> |\n",
-            "数智润德预案管理后台系统功能测试用例表.md");
+            "sample.md");
         check(styledTable.success, "font-wrapped Chinese table parses");
         bool sawTable = false;
         bool sawLiteralFont = false;

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -114,6 +114,56 @@ int main() {
         check(literalBr == 0, "no literal <br> text remains");
     }
 
+    // Exported documents from office/AI tools often wrap all visible content
+    // in presentational <font> tags. They must not become literal table text.
+    {
+        auto styledTable = parseDocument(parser,
+            "# 数智润德预案管理后台系统功能测试用例表\n"
+            "**<font style=\"color:#000000;\">文档版本</font>**：V1.0\n\n"
+            "| **<font style=\"color:rgb(0, 0, 0);\">序号</font>** | "
+            "**<font style=\"color:rgb(0, 0, 0);\">功能项</font>** | "
+            "**<font style=\"color:rgb(0, 0, 0);\">测试结果（正常/异常）</font>** | "
+            "**<font style=\"color:rgb(0, 0, 0);\">异常描述</font>** |\n"
+            "| --- | --- | --- | --- |\n"
+            "| <font style=\"color:rgb(0, 0, 0);\">1</font> | "
+            "<font style=\"color:#000000;\">登录：输入正确账号和密码。</font> | "
+            "<font style=\"color:#000000;\">正常</font> |  |\n"
+            "| <font style=\"color:rgb(0, 0, 0);\">2</font> | "
+            "<font style=\"color:#000000;\">提交后检查异常描述。</font> | "
+            "<font style=\"color:#000000;\">异常</font> | "
+            "<font style=\"color:#000000;\">截图</font>![](https://cdn.example.test/error.png) |\n"
+            "| <font style=\"color:rgb(0, 0, 0);\">3</font> | "
+            "<font style=\"color:#000000;\">空结果占位。</font> | "
+            "<font style=\"color:#000000;\">正常</font> | <br/> |\n",
+            "数智润德预案管理后台系统功能测试用例表.md");
+        check(styledTable.success, "font-wrapped Chinese table parses");
+        bool sawTable = false;
+        bool sawLiteralFont = false;
+        bool sawHeader = false;
+        bool sawImage = false;
+        bool sawHardBreak = false;
+        std::function<void(const qmd::ElementPtr&)> walk =
+            [&](const qmd::ElementPtr& node) {
+            if (node->type == qmd::ElementType::Table) sawTable = true;
+            if (node->type == qmd::ElementType::Image) sawImage = true;
+            if (node->type == qmd::ElementType::HardBreak) sawHardBreak = true;
+            if (node->type == qmd::ElementType::Text) {
+                if (node->text.find("<font") != std::string::npos ||
+                    node->text.find("</font>") != std::string::npos) {
+                    sawLiteralFont = true;
+                }
+                if (node->text == "序号") sawHeader = true;
+            }
+            for (const auto& child : node->children) walk(child);
+        };
+        if (styledTable.root) walk(styledTable.root);
+        check(sawTable, "font-wrapped content remains a Markdown table");
+        check(sawHeader, "font-wrapped table header text is preserved");
+        check(sawImage, "remote images inside table cells are preserved");
+        check(sawHardBreak, "HTML line breaks inside table cells are preserved");
+        check(!sawLiteralFont, "font tags are hidden from rendered text");
+    }
+
     // YAML frontmatter is hidden instead of rendering as a setext heading (#61)
     auto fm = parseDocument(parser,
         "---\ntitle: 'Barometer'\naliases:\ntags: [Barometer]\n---\n\n"


### PR DESCRIPTION
## 摘要
- 忽略办公软件和 AI 工具导出的呈现性 `<font style="...">` 标签，保留其可见文本。
- 修复表格测量阶段临时图片泄漏到文档原点的问题。
- 将图片纳入表格列宽测量，并在居中或右对齐单元格中随内容移动。
- 增加中文四列表格、远程图片和 `<br/>` 的解析回归覆盖。

## 验证
- `cmake --build build --config Release`
- `ctest --test-dir build -C Release --output-on-failure`
- 5/5 测试通过