### PR TITLE
Bump version to 3.5.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,34 +45,24 @@ jobs:
           body: |
             ## Tinta v${{ steps.version.outputs.VERSION }}
 
-            **Markdown, distilled.** The table editor release: edit tables by clicking them in the rendered view, pin the side panels, floating outline and browser cards, and one calm chip system for every notification.
+            **Markdown, distilled.** The follow-up release: everything reported in the first day of 3.5.0, fixed - and Excel ranges paste as tables.
 
             ### Installation
             - Easiest: `winget install "Tinta Markdown Viewer" -s msstore` (Store-signed, no security prompts, auto-updates), or the [Microsoft Store page](https://apps.microsoft.com/detail/9MZ5MZ3L9RKF)
             - Portable: download `tinta.exe` below and run it (SmartScreen may ask: "More info", then "Run anyway")
             - Optionally run `tinta.exe /register` to register Markdown and Mermaid files
 
-            ### Edit tables in place (#148)
-            - In edit mode, click any table cell in the rendered page and type into it: Tab and Shift+Tab move between cells, Enter commits, Esc cancels, and Tab past the last cell starts a new row
-            - + buttons under and beside the table add rows and columns; every change lands in the Markdown source as a single undo step
+            ### Excel ranges paste as tables (#181)
+            - Copy a range in Excel (or any tab-separated text with two or more rows), paste it in edit mode, and it becomes a markdown table with the first row as the header
+            - Ctrl+Shift+V pastes the raw text; a chip confirms the conversion
 
-            ### Pinned side panels (#156)
-            - Pin the table of contents or the file browser and it stays open beside the document: keys and clicks pass through to the page, and pinned panels come back on the next launch
-            - Both panels can be open and pinned at once, with the document reflowing between them
+            ### Close a tab from the editor (#181)
+            - Ctrl+F4 closes the current tab in both viewer and edit mode, where Ctrl+W keeps its word-wrap meaning
 
-            ### One signal system
-            - Every notification is now a uniform chip in the bottom right: passive ones drain away, actionable ones wait to be answered, hovering holds them, and missed ones collect in a bell tray
-            - Save results, update offers, draft recovery, and the exit/create prompts all share the same look
-
-            ### Redesigned side panels
-            - The table of contents is a floating card with type-scaled entries and a scroll thread tracking your position
-            - The file browser card gains a clickable breadcrumb path, cleaner icons, and folder and file counts
-
-            ### Smaller improvements
-            - Custom themes can set a heading font separately from the body font (#155)
-            - File references cover more text formats, and non-Markdown targets open in their registered application (#162)
-            - Store installs: the Settings buttons that open the configuration files now find the real virtualized file (#166)
-            - Creating an annotation no longer leaks the A keystroke into the note box (#161)
+            ### Fixed
+            - Long wrapped paragraphs in the editor no longer leave a blank band before the next line; clicks and arrow keys inside them land exactly (#181)
+            - Entering edit mode, opening help, annotating, and the right-click menu all work beside pinned side panels (#185)
+            - Presentational `<font>` wrappers from office and AI-tool exports are hidden while their text stays, and images inside table cells no longer leave a ghost at the top of the document and now size and align with their cell (#187)
 
             ### What's included
             - Export as HTML, DOCX, or PDF - plus the Pandoc formats above

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v3.5.5] - 2026-08-29
+
+The follow-up release: everything reported in the first day of 3.5.0, fixed - and Excel ranges paste as tables.
+
+### Added
+- Paste a range copied from Excel (or any tab-separated text with two or more rows) in edit mode and it becomes a markdown table with the first row as the header; Ctrl+Shift+V pastes the raw text (#181, #183)
+- Ctrl+F4 closes the current tab in both viewer and edit mode, where Ctrl+W keeps its word-wrap meaning (#181, #184)
+
+### Fixed
+- Long wrapped paragraphs in the editor no longer leave a blank band before the next line: wrapped rows sit on the same grid the editor scrolls by, which also makes clicks and arrow keys inside them exact (#181, #182)
+- Entering edit mode, opening help, and annotating work through pinned side panels (#185, #186)
+- The right-click menu opens beside an open side panel: a pinned panel stays, an unpinned one is dismissed first (#185, #188)
+- Presentational `<font style="...">` wrappers exported by office and AI tools are ignored while their content remains visible, so such tables render with clean text and correct column widths - contributed by @wxh-777 (#187)
+- Table layout measurements no longer leave a ghost image at the document origin, and images in centered or right-aligned cells size and move with the cell content - contributed by @wxh-777 (#187)
+
 ## [v3.5.0] - 2026-08-28
 
 The table editor release: edit tables by clicking them in the rendered view, pin the side panels, floating outline and browser cards, and one calm chip system for every notification.
@@ -13,8 +28,6 @@ The table editor release: edit tables by clicking them in the rendered view, pin
 - File references to any known text format get the full link treatment (.xml added), and non-Markdown targets open in their registered application (#162, #163)
 
 ### Fixed
-- Presentational `<font style="...">` wrappers exported by office and AI tools are ignored while their content remains visible, so Chinese test-case tables render with clean text and correct column measurements
-- Table layout measurements no longer leave temporary images at the document origin, and images in centered or right-aligned cells now move with the cell content
 - Store installs: the Settings buttons that open the configuration .ini files now resolve the virtualized AppData path so the editor finds the real file - contributed by @brianhassel-gh (#166)
 - Pressing A to create an annotation no longer leaks the keystroke into the note box (#161, #164)
 - Plain-text link peeks render frameless instead of as a code block, and cancelling the create-reference dialog no longer leaves a stuck selection (#163)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(tinta VERSION 3.5.0 LANGUAGES C CXX)
+project(tinta VERSION 3.5.5 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
CMake version, CHANGELOG (wxh-777's #187 bullets move from the released 3.5.0 section into 3.5.5), and the release notes template for the v3.5.5 tag.