### PR TITLE
Expand native LaTeX math compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Feature validation workflow
+
+- For every feature or compatibility extension, add or update runnable Markdown files in `tests/fixtures/` that demonstrate the new behavior.
+- Include mixed documents: combine the feature with existing headings, tables, lists, emphasis, links, quotes and code where applicable. Check surrounding content as well as the feature itself.
+- Exercise the fixtures in the built Tinta app using computer use or the native rendering/export harnesses. For layout changes, inspect rendered output at normal and narrow widths, and check relevant themes and exports. Record what was actually checked and any remaining limitations.
+- Add meaningful automated regression checks for parser structure or layout failures found in these documents. Keep generated screenshots and exports in an ignored build/output directory.
+- When working on a GitHub issue, reference it in completed commits. Do not automatically reply to the reporter; provide a draft reply for the maintainer when finished.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Native math matrices (`matrix`, `pmatrix`, `bmatrix`, `Bmatrix`, `vmatrix`, `Vmatrix`, `smallmatrix`), cases, aligned equations, gathered equations and arrays; nested cells, column alignment, array rules and long arrows (#190)
+- Indexed roots, binomial coefficients, continued fractions, stacked annotations, labelled arrows, more accents and symbols, mathematical alphabets, explicit delimiter sizes and spacing, and equation-local macros (#190)
+- A [math compatibility guide](docs/math-support.md) and regression coverage for parsing, native drawing, SVG output and malformed input (#190)
+
+### Fixed
+- Math text retains spaces; display/text fraction sizes, operator limits, negative spacing and grouped mathematical alphabets now have their intended behavior (#190)
+- Tall delimiters grow with their contents, and paragraphs containing tall inline equations reserve enough vertical space to avoid overlapping adjacent lines (#190)
+- Math uses installed Cambria Math when available, falling back to the theme font. SVG exports retain the chosen font family; no font data is bundled (#190)
+
 ## [v3.5.5] - 2026-08-29
 
 The follow-up release: everything reported in the first day of 3.5.0, fixed - and Excel ranges paste as tables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Math text retains spaces; display/text fraction sizes, operator limits, negative spacing and grouped mathematical alphabets now have their intended behavior (#190)
 - Tall delimiters grow with their contents, and paragraphs containing tall inline equations reserve enough vertical space to avoid overlapping adjacent lines (#190)
 - Math uses installed Cambria Math when available, falling back to the theme font. SVG exports retain the chosen font family; no font data is bundled (#190)
+- Inline math preserves highlight and strikethrough spans, link colors and clickable link areas, including in mixed Markdown documents and HTML exports (#190)
 
 ## [v3.5.5] - 2026-08-29
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(SOURCES
     src/selection.cpp
     src/math_render.cpp
     src/math_parser.cpp
+    src/math_macros.cpp
     src/tabs.cpp
     src/export_html.cpp
     src/export_docx.cpp
@@ -139,12 +140,12 @@ target_compile_definitions(tinta PRIVATE UNICODE _UNICODE
     TINTA_VERSION_PATCH=${PROJECT_VERSION_PATCH})
 
 if(BUILD_TESTING)
-    add_executable(math_parser_tests tests/math_parser_tests.cpp src/math_parser.cpp)
+    add_executable(math_parser_tests tests/math_parser_tests.cpp src/math_parser.cpp src/math_macros.cpp)
     target_include_directories(math_parser_tests PRIVATE src)
     add_test(NAME math_parser COMMAND math_parser_tests)
 
     add_executable(math_layout_tests tests/math_layout_tests.cpp
-        src/math_parser.cpp src/math_render.cpp src/markdown.cpp src/themes.cpp src/config_dir.cpp)
+        src/math_parser.cpp src/math_macros.cpp src/math_render.cpp src/markdown.cpp src/themes.cpp src/config_dir.cpp)
     target_include_directories(math_layout_tests PRIVATE include src ${md4c_SOURCE_DIR}/src)
     target_link_libraries(math_layout_tests PRIVATE md4c d2d1 dwrite windowscodecs shell32 ole32)
     target_compile_definitions(math_layout_tests PRIVATE UNICODE _UNICODE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(SOURCES
     src/i18n.cpp
     src/selection.cpp
     src/math_render.cpp
+    src/math_parser.cpp
     src/tabs.cpp
     src/export_html.cpp
     src/export_docx.cpp
@@ -138,6 +139,17 @@ target_compile_definitions(tinta PRIVATE UNICODE _UNICODE
     TINTA_VERSION_PATCH=${PROJECT_VERSION_PATCH})
 
 if(BUILD_TESTING)
+    add_executable(math_parser_tests tests/math_parser_tests.cpp src/math_parser.cpp)
+    target_include_directories(math_parser_tests PRIVATE src)
+    add_test(NAME math_parser COMMAND math_parser_tests)
+
+    add_executable(math_layout_tests tests/math_layout_tests.cpp
+        src/math_parser.cpp src/math_render.cpp src/markdown.cpp src/themes.cpp src/config_dir.cpp)
+    target_include_directories(math_layout_tests PRIVATE include src ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(math_layout_tests PRIVATE md4c d2d1 dwrite windowscodecs shell32 ole32)
+    target_compile_definitions(math_layout_tests PRIVATE UNICODE _UNICODE)
+    add_test(NAME math_layout COMMAND math_layout_tests)
+
     add_executable(mermaid_tests
         tests/mermaid_tests.cpp
         src/mermaid.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,8 @@ if(BUILD_TESTING)
         src/math_parser.cpp src/math_macros.cpp src/math_render.cpp src/markdown.cpp src/themes.cpp src/config_dir.cpp)
     target_include_directories(math_layout_tests PRIVATE include src ${md4c_SOURCE_DIR}/src)
     target_link_libraries(math_layout_tests PRIVATE md4c d2d1 dwrite windowscodecs shell32 ole32)
-    target_compile_definitions(math_layout_tests PRIVATE UNICODE _UNICODE)
+    target_compile_definitions(math_layout_tests PRIVATE UNICODE _UNICODE
+        TINTA_MATH_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/math-compatibility.md")
     add_test(NAME math_layout COMMAND math_layout_tests)
 
     add_executable(mermaid_tests

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ It's a viewer first: perfect as the double-click default for `.md` and `.mmd` fi
 - **10 beautiful themes** - 5 light and 5 dark themes to choose from
 - **Hardware-accelerated** - Smooth text rendering via DirectWrite
 - **Word wrap** - Optional soft wrap in the editor (Ctrl+W)
-- **Native LaTeX math** - `$inline$` and `$$display$$` equations rendered natively (fractions, scripts, stretchy delimiters, Greek — no MathJax, no web engine)
+- **Native LaTeX math** - `$inline$` and `$$display$$` equations with matrices, cases, aligned equations, fractions, limits, accents and custom macros. Uses an installed math font; no bundled fonts or web engine. See the [supported math syntax](docs/math-support.md).
 - **Focused editing** - Hide the preview pane while writing (Ctrl+E)
 - **Native Mermaid diagrams** - 22 diagram families, from flowcharts with subgraphs through sequence, class, state, ER, gantt, and pie to C4, sankey, kanban, and radar - rendered without a web engine
 - **Export as HTML, DOCX, or PDF** - Right-click and pick "Export as..." for a self-contained web page, a Word document that opens natively, or a vector PDF; diagrams and math come along in every format

--- a/docs/math-support.md
+++ b/docs/math-support.md
@@ -82,3 +82,21 @@ This extension does not implement complete LaTeX documents, arbitrary packages, 
 ```powershell
 out/math-compat/Release/math_layout_tests.exe samples.html samples.png
 ```
+
+Mixed-document fixtures exercise the surrounding Markdown as well as the equations:
+
+- [math-mixed-layout.md](../tests/fixtures/math-mixed-layout.md): math in headings, aligned tables, nested lists, emphasis, links, highlights, strikethrough, quotes and callouts, alongside literal code and Mermaid.
+- [math-inline-stress.md](../tests/fixtures/math-inline-stress.md): tall matrices, fractions and annotations in wrapping paragraphs, table cells and lists.
+- [markdown-regression-control.md](../tests/fixtures/markdown-regression-control.md): existing formatting without math, for comparison with a baseline executable.
+
+The automated layout suite checks all 49 equations across the three math fixtures, their enclosing Markdown structures, table column counts and literal code. On Windows with a graphics session, generate native print pages and HTML from the actual application:
+
+```powershell
+tests/render_math_fixtures.ps1 -Binary out/math-compat/Release/tinta.exe
+# Optional: compare control PNGs and HTML byte-for-byte with a baseline build.
+tests/render_math_fixtures.ps1 -Binary out/math-compat/Release/tinta.exe -BaselineBinary path/to/baseline/tinta.exe
+```
+
+The script creates a fresh ignored output directory and a portable copy of Tinta with isolated settings. It checks export completion and equation counts. Inspect its PNGs and HTML, then open the fixtures in the viewer at normal and narrow widths and in light and dark themes. Verify table borders, the text before and after tall formulas, link clicks, code literals and the final block. Export success alone is not visual validation.
+
+Tall inline equations currently expand every line in their paragraph uniformly. This avoids overlap but can leave substantial vertical space in long paragraphs; display math is more compact for large matrices. Native print pagination can continue table borders and quotes onto the next page.

--- a/docs/math-support.md
+++ b/docs/math-support.md
@@ -1,0 +1,84 @@
+# Native math compatibility
+
+Tinta renders a growing subset of LaTeX mathematics using DirectWrite and Direct2D. Use `$...$` for inline math and `$$...$$` for a centered display equation. For large matrices and derivations, display math gives the clearest layout. Paragraphs containing tall inline equations use additional line spacing.
+
+## Environments
+
+| Environment | Behavior |
+| --- | --- |
+| `matrix`, `pmatrix`, `bmatrix`, `Bmatrix`, `vmatrix`, `Vmatrix` | Centered cells, with no delimiters, parentheses, brackets, braces, bars or double bars respectively |
+| Starred matrix variants, for example `bmatrix*` | Optional `[l]`, `[c]` or `[r]` cell alignment |
+| `smallmatrix` | Smaller cells for inline notation |
+| `cases`, `rcases` | Two left-aligned columns with a brace on the left or right |
+| `aligned`, `split` | Alternating right/left alignment for equation steps; `split` has at most two columns |
+| `gathered` | One centered equation per row |
+| `array` | A column specification containing `l`, `c`, `r` and vertical `|` rules; `\hline` between rows |
+
+Use `&` between cells and `\\` or `\cr` between rows. Nested environments, grouped expressions and fractions inside cells are supported. Empty cells and a final row separator are accepted. Environment names must match. Row-height options such as `\\[4pt]`, repeated array specifications and column spanning are not implemented.
+
+The example from [#190](https://github.com/oipoistar/tinta/issues/190) now renders:
+
+```latex
+$$
+\begin{bmatrix}1&2\\5&6\end{bmatrix}\longrightarrow 6,
+\qquad
+\begin{bmatrix}3&4\\7&8\end{bmatrix}\longrightarrow 8
+$$
+```
+
+## Expressions and styles
+
+- Fractions: `\frac`, `\dfrac`, `\tfrac`, `\cfrac`.
+- Binomial coefficients: `\binom`, `\dbinom`, `\tbinom`.
+- Square and indexed roots: `\sqrt{x}`, `\sqrt[3]{x}`.
+- Subscripts and superscripts, including nested scripts.
+- Display, text, script and scriptscript styles: `\displaystyle`, `\textstyle`, `\scriptstyle`, `\scriptscriptstyle`. A style declaration applies to the remaining contents of its group or cell.
+- Operators such as `\sum`, `\prod`, `\coprod`, `\int`, `\iint`, `\iiint`, `\oint`, `\bigcup` and `\bigcap`. Display sums and limits use above/below placement; integrals use side scripts unless `\limits` is requested. `\nolimits` forces side scripts.
+- `\substack{...\\...}` for multiline limits.
+- `\overset`, `\underset`, `\stackrel` and `\xrightarrow[below]{above}` / `\xleftarrow[below]{above}`.
+- Common Greek letters and variants, relations, set and logical symbols, arrows, harpoons and named functions. The exact command mappings are in [math_parser.cpp](../src/math_parser.cpp).
+- Modular notation: `\pmod{n}`, `\pod{n}`, `\bmod`.
+
+## Text, alphabets and decoration
+
+`\text{for all }` preserves spaces and escaped punctuation, including `\&`, `\%` and `\{`. Nested `\textbf`, `\textit`, `\textrm` and `\text` are supported. Nested math delimiters inside text mode are not implemented.
+
+Math alphabets include `\mathrm`, `\mathit`, `\mathbf`, `\boldsymbol` / `\bm`, `\mathbb`, `\mathcal` / `\mathscr`, `\mathfrak`, `\mathsf` and `\mathtt`. Script and calligraphic commands use the same Unicode script alphabet. Available shapes depend on the installed fonts.
+
+Decorations include `\bar`, `\overline`, `\underline`, `\vec`, `\overrightarrow`, `\hat`, `\widehat`, `\tilde`, `\widetilde`, `\dot`, `\ddot`, `\acute`, `\grave`, `\breve`, `\check`, `\overbrace`, `\underbrace`, `\boxed`, `\cancel`, `\bcancel`, `\xcancel` and `\not`. Braces can carry annotations using scripts.
+
+## Delimiters and spacing
+
+`\left...\right` and `\middle` size delimiters with their contents. A dot denotes an invisible delimiter. The `\big`, `\Big`, `\bigg`, `\Bigg` families and their `l`, `r`, `m` variants provide explicit sizes.
+
+Spacing includes `\,`, `\:`, `\;`, `\!`, `\quad`, `\qquad`, `\enspace`, and thin/medium/thick space aliases. `\hspace`, `\kern` and `\mkern` accept `em`, `ex`, `mu`, `pt` and `px` dimensions; `ex` is approximated as half an em. `\phantom`, `\hphantom`, `\vphantom` and `\smash` control invisible layout space.
+
+## Custom macros
+
+Definitions are local to one `$...$` or `$$...$$` expression, with brace-group scoping. They never carry over to another equation, tab or document.
+
+```latex
+$$
+\newcommand{\norm}[1]{\left\lVert#1\right\rVert}
+\DeclareMathOperator*{\argmin}{arg min}
+\argmin_x \norm{x-b}^2
+$$
+```
+
+Supported definitions are `\newcommand`, `\renewcommand`, `\providecommand`, basic `\def` with sequential undelimited parameters, and `\DeclareMathOperator` / `\DeclareMathOperator*`. Up to nine arguments and an optional default first argument are supported. Recursive expansion, input size and nesting have bounds so incomplete or pathological expressions fall back to source.
+
+## Rendering and remaining scope
+
+Tinta selects the installed **Cambria Math** family when available and otherwise uses the theme font. It does not download or bundle a font. Layout uses native text, rules and lines; this is not a full OpenType MATH typesetting engine.
+
+The viewer, native raster exports and SVG math exports share the same layout. SVG references the selected font family without embedding its font data. Unsupported commands or malformed structure make the whole expression fall back to raw TeX.
+
+This extension does not implement complete LaTeX documents, arbitrary packages, document-wide macros, automatic equation numbering, `\tag`, `\label`, `\eqref`, `\(...\)` / `\[...\]` Markdown delimiters, or standalone `equation` / `align` environments outside dollar delimiters. Use `aligned` inside `$$...$$` for multiline derivations. Chemistry, units packages, color commands and TikZ remain outside the supported subset.
+
+## Regression samples
+
+[math-compatibility.md](../tests/fixtures/math-compatibility.md) contains renderable examples. `math_parser_tests` covers syntax and deterministic malformed-input mutations. `math_layout_tests` checks metrics, Markdown preservation, inline line spacing, retained drawing primitives, native offscreen drawing and SVG output. It can also generate an HTML and PNG sample sheet:
+
+```powershell
+out/math-compat/Release/math_layout_tests.exe samples.html samples.png
+```

--- a/include/math_render.h
+++ b/include/math_render.h
@@ -8,7 +8,7 @@
 
 // Native TeX-subset math rendering (#80). No MathJax, no KaTeX, no web
 // engine: a recursive-descent parser builds a box tree (runs, scripts,
-// fractions, stretchy delimiters, decorations), DirectWrite measures it,
+// fractions, grids, stretchy delimiters, decorations), DirectWrite measures it,
 // Direct2D draws it. Unsupported input returns null and the caller falls
 // back to showing the raw source in code style - the mermaid pattern.
 

--- a/include/math_render.h
+++ b/include/math_render.h
@@ -26,6 +26,11 @@ float mathBoxHeight(const MathBoxPtr& box);
 // Distance from the box top to the text baseline (for inline alignment)
 float mathBoxBaseline(const MathBoxPtr& box);
 
+// Accumulate the extra space needed above/below a normal text line to
+// contain baseline-aligned inline equations. Call once for each equation.
+void mathExpandLine(const MathBoxPtr& box, float textBaseline, float lineHeight,
+                    float& above, float& below);
+
 // Draw with the box's top-left corner at (x, y) in the current target
 void mathBoxDraw(App& app, const MathBoxPtr& box, float x, float y,
                  const D2D1_COLOR_F& color);

--- a/src/export_html.cpp
+++ b/src/export_html.cpp
@@ -1055,7 +1055,7 @@ void emitMath(ExportCtx& ctx, const ElementPtr& elem, bool display) {
     MathBoxPtr box = mathParse(ctx.app, tex, display ? 18.0f : 16.0f, display);
     if (box) {
         std::string svg =
-            mathBoxSvg(box, ctx.textColorCss, ctx.bodyFontCss);
+            mathBoxSvg(box, "currentColor", ctx.bodyFontCss);
         if (display) {
             ctx.out += "<div class=\"math-display\">" + svg + "</div>";
         } else {

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -421,8 +421,8 @@ static int textCallback(MD_TEXTTYPE type, const MD_CHAR* text, MD_SIZE size, voi
 // --- Inline extension post-pass (==highlight==, ^sup^, ~sub~) ---
 //
 // md4c has no extension hooks for these Obsidian/Typora spans, so a pass
-// over the finished tree splits Text nodes that contain them. Code spans,
-// code blocks, and Mermaid sources are never touched.
+// over the finished tree splits Text nodes, keeping intervening inline
+// math opaque. Code spans, code blocks, and Mermaid sources are never touched.
 
 namespace {
 
@@ -531,37 +531,85 @@ static void splitInlineExtensions(const ElementPtr& parent) {
 
     std::vector<ElementPtr> rebuilt;
     bool changed = false;
-    for (auto& child : parent->children) {
-        if (child->type != ElementType::Text) {
+    for (size_t i = 0; i < parent->children.size();) {
+        auto child = parent->children[i];
+        if (child->type != ElementType::Text && child->type != ElementType::MathInline) {
             splitInlineExtensions(child);
             rebuilt.push_back(child);
+            ++i;
             continue;
         }
 
-        const std::string& text = child->text;
+        // TeX is an opaque atom between text nodes: ==before $x$ after==
+        // must wrap the equation without interpreting delimiters inside it.
+        // Other wrappers and block boundaries keep their existing scope.
+        size_t begin = i;
+        while (i < parent->children.size()) {
+            const auto& part = parent->children[i];
+            if (part->type != ElementType::Text && part->type != ElementType::MathInline) break;
+            ++i;
+        }
+        if (i == begin + 1 && child->type == ElementType::MathInline) {
+            rebuilt.push_back(child);
+            continue;
+        }
+        // The usual single Text node needs neither a string copy nor an
+        // offset map. Allocate those only for a group containing math.
+        std::string combined;
+        std::vector<size_t> offsets;
+        if (i > begin + 1) {
+            offsets.push_back(0);
+            for (size_t j = begin; j < i; ++j) {
+                const auto& part = parent->children[j];
+                if (part->type == ElementType::Text) combined += part->text;
+                else combined += '\x01';
+                offsets.push_back(combined.size());
+            }
+        }
+        const std::string& text = offsets.empty() ? child->text : combined;
+        size_t partIndex = 0;
+        auto appendRange = [&](size_t start, size_t end, const ElementPtr& owner,
+                               std::vector<ElementPtr>& output) {
+            if (offsets.empty()) {
+                if (end > start) output.push_back(makeTextElement(text.substr(start, end - start), owner.get()));
+                return;
+            }
+            while (partIndex + 1 < offsets.size() && offsets[partIndex] < end) {
+                size_t lo = std::max(start, offsets[partIndex]);
+                size_t hi = std::min(end, offsets[partIndex + 1]);
+                if (lo < hi) {
+                    auto part = parent->children[begin + partIndex];
+                    if (part->type == ElementType::Text) {
+                        output.push_back(makeTextElement(text.substr(lo, hi - lo), owner.get()));
+                    } else {
+                        part->parent = owner.get();
+                        output.push_back(part);
+                    }
+                }
+                if (offsets[partIndex + 1] > end) break;
+                ++partIndex;
+            }
+        };
         size_t cursor = 0;
         ExtensionMatch m;
         bool any = false;
         while (findExtensionSpan(text, cursor, m)) {
             any = true;
-            if (m.start > cursor) {
-                rebuilt.push_back(makeTextElement(text.substr(cursor, m.start - cursor), parent.get()));
-            }
+            appendRange(cursor, m.start, parent, rebuilt);
             auto span = std::make_shared<Element>(m.type);
             span->parent = parent.get();
-            span->children.push_back(makeTextElement(
-                text.substr(m.start + m.delimLen, m.contentLen), span.get()));
+            appendRange(m.start + m.delimLen, m.start + m.delimLen + m.contentLen,
+                        span, span->children);
             rebuilt.push_back(std::move(span));
             cursor = m.start + m.delimLen + m.contentLen + m.delimLen;
         }
         if (!any) {
-            rebuilt.push_back(child);
+            rebuilt.insert(rebuilt.end(), parent->children.begin() + begin,
+                           parent->children.begin() + i);
             continue;
         }
         changed = true;
-        if (cursor < text.size()) {
-            rebuilt.push_back(makeTextElement(text.substr(cursor), parent.get()));
-        }
+        appendRange(cursor, text.size(), parent, rebuilt);
     }
     if (changed) parent->children = std::move(rebuilt);
 }

--- a/src/math_macros.cpp
+++ b/src/math_macros.cpp
@@ -1,0 +1,196 @@
+#include "math_macros.h"
+
+#include <cwctype>
+#include <unordered_map>
+#include <vector>
+
+namespace tinta_math {
+namespace {
+struct Macro {
+    std::wstring body, defaultArgument;
+    int arguments = 0;
+    bool hasDefault = false;
+};
+using Definitions = std::unordered_map<std::wstring, Macro>;
+
+bool letter(wchar_t c) { return (c >= L'a' && c <= L'z') || (c >= L'A' && c <= L'Z'); }
+bool controlWordAtEnd(const std::wstring& text) {
+    size_t i = text.size();
+    while (i && letter(text[i - 1])) --i;
+    if (i == text.size() || !i || text[i - 1] != L'\\') return false;
+    size_t slashes = 0;
+    while (i && text[--i] == L'\\') ++slashes;
+    return slashes % 2 == 1;
+}
+void joinTokens(std::wstring& left, const std::wstring& right) {
+    if (!right.empty() && letter(right[0]) && controlWordAtEnd(left)) left += L' ';
+    left += right;
+}
+
+struct Expander {
+    std::wstring text;
+    size_t pos = 0, expansions = 0;
+    bool failed = false;
+    Definitions macros;
+    std::vector<Definitions> scopes;
+
+    void whitespace() {
+        while (pos < text.size()) {
+            if (iswspace(text[pos])) { ++pos; continue; }
+            if (text[pos] != L'%') break;
+            while (pos < text.size() && text[pos] != L'\n') ++pos;
+        }
+    }
+    std::wstring command() {
+        if (pos == text.size() || text[pos++] != L'\\') { failed = true; return {}; }
+        size_t start = pos;
+        while (pos < text.size() && letter(text[pos])) ++pos;
+        if (start == pos && pos < text.size()) ++pos;
+        return text.substr(start, pos - start);
+    }
+    std::wstring group(wchar_t open = L'{', wchar_t close = L'}') {
+        whitespace();
+        if (pos == text.size() || text[pos++] != open) { failed = true; return {}; }
+        size_t start = pos;
+        int depth = 1, braces = 0;
+        while (pos < text.size()) {
+            wchar_t c = text[pos++];
+            if (c == L'\\') { if (pos < text.size()) ++pos; continue; }
+            if (c == L'%') { while (pos < text.size() && text[pos] != L'\n') ++pos; continue; }
+            if (open == L'[') {
+                if (c == L'{') ++braces;
+                if (c == L'}') --braces;
+                if (braces) continue;
+            }
+            if (c == open) ++depth;
+            if (c == close && --depth == 0) return text.substr(start, pos - start - 1);
+        }
+        failed = true; return {};
+    }
+    std::wstring argument() {
+        whitespace();
+        if (pos == text.size()) { failed = true; return {}; }
+        if (text[pos] == L'{') return group();
+        size_t start = pos;
+        if (text[pos] == L'\\') command(); else ++pos;
+        return text.substr(start, pos - start);
+    }
+    void replace(size_t start, const std::wstring& replacement) {
+        std::wstring result = text.substr(0, start);
+        joinTokens(result, replacement);
+        size_t resume = start;
+        joinTokens(result, text.substr(pos));
+        if (result.size() > 32768) { failed = true; return; }
+        text = std::move(result); pos = resume;
+    }
+    std::wstring name(bool braced) {
+        whitespace();
+        if (braced && pos < text.size() && text[pos] == L'{') {
+            std::wstring value = group();
+            if (value.size() < 2 || value[0] != L'\\') { failed = true; return {}; }
+            for (size_t i = 1; i < value.size(); ++i) if (!letter(value[i])) failed = true;
+            return value.substr(1);
+        }
+        auto value = command();
+        if (value.empty() || !letter(value[0])) failed = true;
+        return value;
+    }
+    void define(const std::wstring& kind, size_t start) {
+        if (++expansions > 512) { failed = true; return; }
+        bool starred = pos < text.size() && text[pos] == L'*';
+        if (starred) ++pos;
+        std::wstring key = name(kind != L"def");
+        Macro macro;
+        whitespace();
+        if (kind == L"def") {
+            while (pos < text.size() && text[pos] == L'#') {
+                ++pos; ++macro.arguments;
+                if (macro.arguments > 9 || pos == text.size() || text[pos++] != L'0' + macro.arguments) {
+                    failed = true; return;
+                }
+                whitespace();
+            }
+        } else if (kind != L"DeclareMathOperator" && pos < text.size() && text[pos] == L'[') {
+            auto count = group(L'[', L']');
+            if (count.size() != 1 || count[0] < L'0' || count[0] > L'9') { failed = true; return; }
+            macro.arguments = count[0] - L'0';
+            whitespace();
+            if (pos < text.size() && text[pos] == L'[') {
+                macro.defaultArgument = group(L'[', L']'); macro.hasDefault = true;
+                if (!macro.arguments) failed = true;
+            }
+        }
+        macro.body = group();
+        if (kind == L"DeclareMathOperator") macro.body = std::wstring(starred ? L"\\operatorname*{" : L"\\operatorname{") + macro.body + L"}";
+        bool exists = macros.find(key) != macros.end() || isBuiltinMathCommand(key);
+        if ((kind == L"newcommand" || kind == L"DeclareMathOperator") && exists) failed = true;
+        if (kind == L"renewcommand" && !exists) failed = true;
+        if (failed) return;
+        if (kind != L"providecommand" || !exists) macros[key] = std::move(macro);
+        replace(start, L"");
+    }
+    bool run() {
+        while (pos < text.size() && !failed) {
+            wchar_t c = text[pos];
+            if (c == L'%') { whitespace(); continue; }
+            if (c == L'{') {
+                if (scopes.size() >= 96) return false;
+                scopes.push_back(macros); ++pos; continue;
+            }
+            if (c == L'}') {
+                if (scopes.empty()) return false;
+                macros = std::move(scopes.back()); scopes.pop_back(); ++pos; continue;
+            }
+            if (c != L'\\') { ++pos; continue; }
+            size_t start = pos;
+            std::wstring cmd = command();
+            if (cmd == L"newcommand" || cmd == L"renewcommand" || cmd == L"providecommand" ||
+                cmd == L"def" || cmd == L"DeclareMathOperator") { define(cmd, start); continue; }
+            auto found = macros.find(cmd);
+            if (found == macros.end()) continue;
+            if (++expansions > 512) return false;
+            Macro macro = found->second;
+            std::vector<std::wstring> args;
+            whitespace();
+            if (macro.hasDefault) {
+                whitespace();
+                args.push_back(pos < text.size() && text[pos] == L'[' ? group(L'[', L']') : macro.defaultArgument);
+            }
+            while (!failed && args.size() < static_cast<size_t>(macro.arguments)) args.push_back(argument());
+            std::wstring replacement;
+            size_t chunkStart = 0;
+            for (size_t i = 0; i < macro.body.size() && !failed; ++i) {
+                if (macro.body[i] == L'\\' && i + 1 < macro.body.size()) { ++i; continue; }
+                if (macro.body[i] == L'#') {
+                    joinTokens(replacement, macro.body.substr(chunkStart, i - chunkStart));
+                    if (++i == macro.body.size()) { failed = true; break; }
+                    wchar_t digit = macro.body[i];
+                    if (digit == L'#') replacement += L'#';
+                    else if (digit >= L'1' && digit <= L'0' + macro.arguments) joinTokens(replacement, args[digit - L'1']);
+                    else failed = true;
+                    chunkStart = i + 1;
+                }
+                if (replacement.size() > 32768) failed = true;
+            }
+            joinTokens(replacement, macro.body.substr(chunkStart));
+            if (!failed) replace(start, replacement);
+        }
+        return !failed && scopes.empty();
+    }
+};
+}
+
+bool expandLatexMacros(const std::wstring& source, std::wstring& expanded) {
+    if (source.size() > 32768) return false;
+    if (source.find(L"\\newcommand") == std::wstring::npos && source.find(L"\\def") == std::wstring::npos &&
+        source.find(L"\\renewcommand") == std::wstring::npos && source.find(L"\\providecommand") == std::wstring::npos &&
+        source.find(L"\\DeclareMathOperator") == std::wstring::npos) {
+        expanded = source; return true;
+    }
+    Expander expander;
+    expander.text = source;
+    if (!expander.run()) return false;
+    expanded = std::move(expander.text);
+    return true;
+}
+}

--- a/src/math_macros.h
+++ b/src/math_macros.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <string>
+
+namespace tinta_math {
+// Expand equation-local macros. No state is shared between equations/documents.
+bool expandLatexMacros(const std::wstring& source, std::wstring& expanded);
+bool isBuiltinMathCommand(const std::wstring& command);
+}

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cwctype>
+#include <climits>
 
 namespace tinta_math {
 
@@ -20,13 +21,15 @@ struct CmdSym { const wchar_t* name; const wchar_t* text; };
 // Symbols and greek letters mapped straight to Unicode text runs
 const CmdSym kSymbols[] = {
     {L"alpha", L"\u03B1"}, {L"beta", L"\u03B2"}, {L"gamma", L"\u03B3"},
-    {L"delta", L"\u03B4"}, {L"epsilon", L"\u03B5"}, {L"varepsilon", L"\u03B5"},
+    {L"delta", L"\u03B4"}, {L"epsilon", L"\u03F5"}, {L"varepsilon", L"\u03B5"},
     {L"zeta", L"\u03B6"}, {L"eta", L"\u03B7"}, {L"theta", L"\u03B8"},
     {L"vartheta", L"\u03D1"}, {L"iota", L"\u03B9"}, {L"kappa", L"\u03BA"},
     {L"lambda", L"\u03BB"}, {L"mu", L"\u03BC"}, {L"nu", L"\u03BD"},
     {L"xi", L"\u03BE"}, {L"pi", L"\u03C0"}, {L"rho", L"\u03C1"},
     {L"sigma", L"\u03C3"}, {L"tau", L"\u03C4"}, {L"upsilon", L"\u03C5"},
-    {L"phi", L"\u03C6"}, {L"varphi", L"\u03C6"}, {L"chi", L"\u03C7"},
+    {L"phi", L"\u03D5"}, {L"varphi", L"\u03C6"}, {L"chi", L"\u03C7"},
+    {L"varrho", L"\u03F1"}, {L"varpi", L"\u03D6"}, {L"varsigma", L"\u03C2"},
+    {L"varkappa", L"\u03F0"}, {L"digamma", L"\u03DD"}, {L"omicron", L"o"},
     {L"psi", L"\u03C8"}, {L"omega", L"\u03C9"},
     {L"Gamma", L"\u0393"}, {L"Delta", L"\u0394"}, {L"Theta", L"\u0398"},
     {L"Lambda", L"\u039B"}, {L"Xi", L"\u039E"}, {L"Pi", L"\u03A0"},
@@ -77,6 +80,39 @@ const CmdSym kSymbols[] = {
     {L"neg", L"\u00AC"}, {L"lnot", L"\u00AC"},
     {L"land", L"\u2227"}, {L"wedge", L"\u2227"},
     {L"lor", L"\u2228"}, {L"vee", L"\u2228"},
+    {L"iint", L"\u222C"}, {L"iiint", L"\u222D"}, {L"oiint", L"\u222F"},
+    {L"coprod", L"\u2210"}, {L"bigcup", L"\u22C3"}, {L"bigcap", L"\u22C2"},
+    {L"bigvee", L"\u22C1"}, {L"bigwedge", L"\u22C0"}, {L"bigoplus", L"\u2A01"},
+    {L"bigotimes", L"\u2A02"}, {L"biguplus", L"\u2A04"},
+    {L"gets", L"\u2190"}, {L"uparrow", L"\u2191"}, {L"downarrow", L"\u2193"},
+    {L"updownarrow", L"\u2195"}, {L"Uparrow", L"\u21D1"}, {L"Downarrow", L"\u21D3"},
+    {L"Updownarrow", L"\u21D5"}, {L"nearrow", L"\u2197"}, {L"searrow", L"\u2198"},
+    {L"nwarrow", L"\u2196"}, {L"swarrow", L"\u2199"},
+    {L"hookrightarrow", L"\u21AA"}, {L"hookleftarrow", L"\u21A9"},
+    {L"rightharpoonup", L"\u21C0"}, {L"rightharpoondown", L"\u21C1"},
+    {L"leftharpoonup", L"\u21BC"}, {L"leftharpoondown", L"\u21BD"},
+    {L"rightleftharpoons", L"\u21CC"}, {L"leftrightharpoons", L"\u21CB"},
+    {L"leadsto", L"\u21DD"}, {L"rightsquigarrow", L"\u21DD"},
+    {L"twoheadrightarrow", L"\u21A0"}, {L"twoheadleftarrow", L"\u219E"},
+    {L"ll", L"\u226A"}, {L"gg", L"\u226B"}, {L"simeq", L"\u2243"},
+    {L"cong", L"\u2245"}, {L"asymp", L"\u224D"}, {L"doteq", L"\u2250"},
+    {L"lesssim", L"\u2272"}, {L"gtrsim", L"\u2273"},
+    {L"leqslant", L"\u2A7D"}, {L"geqslant", L"\u2A7E"},
+    {L"prec", L"\u227A"}, {L"succ", L"\u227B"},
+    {L"preceq", L"\u2AAF"}, {L"succeq", L"\u2AB0"},
+    {L"nleq", L"\u2270"}, {L"ngeq", L"\u2271"}, {L"nless", L"\u226E"}, {L"ngtr", L"\u226F"},
+    {L"nsubseteq", L"\u2288"}, {L"nsupseteq", L"\u2289"}, {L"subsetneq", L"\u228A"},
+    {L"supsetneq", L"\u228B"}, {L"nexists", L"\u2204"},
+    {L"vdash", L"\u22A2"}, {L"dashv", L"\u22A3"}, {L"models", L"\u22A8"},
+    {L"vDash", L"\u22A8"}, {L"Vdash", L"\u22A9"},
+    {L"top", L"\u22A4"}, {L"bot", L"\u22A5"}, {L"complement", L"\u2201"},
+    {L"uplus", L"\u228E"}, {L"sqcup", L"\u2294"}, {L"sqcap", L"\u2293"},
+    {L"odot", L"\u2299"}, {L"ominus", L"\u2296"}, {L"oslash", L"\u2298"},
+    {L"circledast", L"\u229B"}, {L"ast", L"\u2217"}, {L"diamond", L"\u22C4"},
+    {L"ltimes", L"\u22C9"}, {L"rtimes", L"\u22CA"}, {L"wr", L"\u2240"},
+    {L"imath", L"\u0131"}, {L"jmath", L"\u0237"}, {L"ell", L"\u2113"},
+    {L"lparen", L"("}, {L"rparen", L")"}, {L"colon", L":"},
+    {L"dotsc", L"\u2026"}, {L"dotsb", L"\u22EF"}, {L"dotsm", L"\u22EF"},
 };
 
 // Function names rendered upright with a trailing thin space
@@ -85,6 +121,7 @@ const wchar_t* kFunctions[] = {
     L"arcsin", L"arccos", L"arctan", L"sinh", L"cosh", L"tanh", L"coth",
     L"lim", L"limsup", L"liminf", L"max", L"min", L"sup", L"inf",
     L"gcd", L"det", L"dim", L"ker", L"deg", L"arg", L"exp", L"mod", L"Pr",
+    L"argmax", L"argmin", L"hom", L"erf", L"sgn",
 };
 
 // \mathbb single letters -> double-struck
@@ -108,6 +145,68 @@ bool isFunctionName(const std::wstring& cmd) {
     return false;
 }
 
+std::wstring codepoint(unsigned cp) {
+#if WCHAR_MAX <= 0xFFFF
+    if (cp > 0xFFFF) {
+        cp -= 0x10000;
+        return {static_cast<wchar_t>(0xD800 + (cp >> 10)),
+                static_cast<wchar_t>(0xDC00 + (cp & 0x3FF))};
+    }
+#endif
+    return std::wstring(1, static_cast<wchar_t>(cp));
+}
+
+void mathAlphabet(const MNodePtr& node, const std::wstring& command) {
+    if (!node) return;
+    node->roman = true;
+    if (node->kind == MNode::Sym) {
+        std::wstring mapped;
+        for (wchar_t c : node->text) {
+            unsigned cp = c;
+            bool upper = c >= L'A' && c <= L'Z', lower = c >= L'a' && c <= L'z';
+            if (command == L"mathbb") {
+                if (upper) cp = 0x1D538 + c - L'A';
+                if (lower) cp = 0x1D552 + c - L'a';
+                if (c >= L'0' && c <= L'9') cp = 0x1D7D8 + c - L'0';
+                switch (c) {
+                    case L'C': cp = 0x2102; break; case L'H': cp = 0x210D; break;
+                    case L'N': cp = 0x2115; break; case L'P': cp = 0x2119; break;
+                    case L'Q': cp = 0x211A; break; case L'R': cp = 0x211D; break;
+                    case L'Z': cp = 0x2124; break;
+                }
+            } else if (command == L"mathcal" || command == L"mathscr") {
+                if (upper) cp = 0x1D49C + c - L'A';
+                if (lower) cp = 0x1D4B6 + c - L'a';
+                switch (c) {
+                    case L'B': cp = 0x212C; break; case L'E': cp = 0x2130; break;
+                    case L'F': cp = 0x2131; break; case L'H': cp = 0x210B; break;
+                    case L'I': cp = 0x2110; break; case L'L': cp = 0x2112; break;
+                    case L'M': cp = 0x2133; break; case L'R': cp = 0x211B; break;
+                    case L'e': cp = 0x212F; break; case L'g': cp = 0x210A; break;
+                    case L'o': cp = 0x2134; break;
+                }
+            } else if (command == L"mathfrak") {
+                if (upper) cp = 0x1D504 + c - L'A';
+                if (lower) cp = 0x1D51E + c - L'a';
+                switch (c) {
+                    case L'C': cp = 0x212D; break; case L'H': cp = 0x210C; break;
+                    case L'I': cp = 0x2111; break; case L'R': cp = 0x211C; break;
+                    case L'Z': cp = 0x2128; break;
+                }
+            } else {
+                unsigned base = command == L"mathsf" ? 0x1D5A0 : 0x1D670;
+                if (upper) cp = base + c - L'A';
+                if (lower) cp = base + 26 + c - L'a';
+                if (c >= L'0' && c <= L'9') cp = (command == L"mathsf" ? 0x1D7E2 : 0x1D7F6) + c - L'0';
+            }
+            mapped += codepoint(cp);
+        }
+        node->text = std::move(mapped);
+    }
+    for (const auto& kid : node->kids) mathAlphabet(kid, command);
+    for (const auto& row : node->cells) for (const auto& cell : row) mathAlphabet(cell, command);
+}
+
 // Spacing classes for row layout (fractions of an em on each side)
 float symbolSpacing(const std::wstring& t, bool roman) {
     if (t.size() != 1) {
@@ -124,6 +223,10 @@ float symbolSpacing(const std::wstring& t, bool roman) {
         return 0.0f;
     }
     wchar_t c = t[0];
+    if ((c >= 0x2190 && c <= 0x21FF) || (c >= 0x27F0 && c <= 0x27FF) ||
+        (c >= 0x223C && c <= 0x223D) || (c >= 0x2243 && c <= 0x228D) ||
+        (c >= 0x22A2 && c <= 0x22AF) || c == 0x2A7D || c == 0x2A7E ||
+        c == 0x2AAF || c == 0x2AB0) return 0.26f;
     switch (c) {
         case L'=': case L'<': case L'>':
         case 0x2264: case 0x2265: case 0x2260: case 0x2261: case 0x2248:
@@ -136,7 +239,9 @@ float symbolSpacing(const std::wstring& t, bool roman) {
             return 0.26f;   // relations
         case L'+': case 0x2212: case 0x00B1: case 0x2213: case 0x00D7:
         case 0x00F7: case 0x22C5: case 0x222A: case 0x2229: case 0x2227:
-        case 0x2228: case 0x2216:
+        case 0x2228: case 0x2216: case 0x2295: case 0x2296: case 0x2297:
+        case 0x2298: case 0x2299: case 0x229B: case 0x228E: case 0x2293:
+        case 0x2294: case 0x22C9: case 0x22CA:
             return 0.2f;    // binary operators
         case L',': case L';':
             return 0.12f;   // punctuation (space after only, approximated)
@@ -189,6 +294,46 @@ struct Parser {
         if (peek() != L'}') failed = true;
         else ++pos;
         return value;
+    }
+
+    MNodePtr textGroup() {
+        Nest nest(depth);
+        if (depth > 96) { failed = true; return nullptr; }
+        skipWs();
+        if (peek() != L'{') { failed = true; return nullptr; }
+        ++pos;
+        auto row = mk(MNode::Row);
+        row->literalText = true;
+        std::wstring text;
+        auto flush = [&]() {
+            if (text.empty()) return;
+            auto run = mk(MNode::Sym);
+            run->text = std::move(text); text.clear();
+            run->roman = run->literalText = true;
+            row->kids.push_back(run);
+        };
+        while (!eof() && !failed && peek() != L'}') {
+            if (peek() == L'{') { flush(); row->kids.push_back(textGroup()); continue; }
+            wchar_t c = src[pos++];
+            if (c == L'%') { while (!eof() && peek() != L'\n') ++pos; continue; }
+            if (c == L'\\') {
+                std::wstring cmd = readCommand();
+                if (cmd.size() == 1 && std::wstring(L"{}$%&#_ ").find(cmd[0]) != std::wstring::npos) {
+                    text += cmd; continue;
+                }
+                if (cmd == L"textbf" || cmd == L"textit" || cmd == L"text" || cmd == L"textrm") {
+                    flush(); auto child = textGroup();
+                    if (child && cmd == L"textbf") markBold(child);
+                    if (child && cmd == L"textit") markItalic(child);
+                    row->kids.push_back(child); continue;
+                }
+                failed = true; break;
+            }
+            text += c == L'~' || iswspace(c) ? L' ' : c;
+        }
+        flush();
+        if (peek() != L'}') failed = true; else ++pos;
+        return row;
     }
 
     MNodePtr parseEnvironment() {
@@ -262,7 +407,9 @@ struct Parser {
             else failed = true;
             return row;
         }
-        return parseAtom();
+        auto atom = parseAtom();
+        if (!atom) failed = true;
+        return atom;
     }
 
     MNodePtr parseAtom() {
@@ -299,6 +446,19 @@ struct Parser {
         std::wstring cmd = readCommand();
         if (cmd.empty()) { failed = true; return nullptr; }
         if (cmd == L"begin") return parseEnvironment();
+        if (cmd == L"text" || cmd == L"textrm" || cmd == L"textbf" || cmd == L"textit") {
+            auto text = textGroup();
+            if (text && cmd == L"textbf") markBold(text);
+            if (text && cmd == L"textit") markItalic(text);
+            return text;
+        }
+        if (cmd == L"operatorname") {
+            bool limits = peek() == L'*';
+            if (limits) ++pos;
+            auto op = textGroup();
+            if (op) { op->spacing = 0.16f; op->limitOp = limits; }
+            return op;
+        }
 
         // Escapes and explicit spacing
         if (cmd == L"{" || cmd == L"}" || cmd == L"$" || cmd == L"%" ||
@@ -313,31 +473,107 @@ struct Parser {
             return s;
         }
         if (cmd == L"," || cmd == L":" || cmd == L";" || cmd == L" " ||
-            cmd == L"quad" || cmd == L"qquad" || cmd == L"!") {
+            cmd == L"quad" || cmd == L"qquad" || cmd == L"!" || cmd == L">" ||
+            cmd == L"thinspace" || cmd == L"medspace" || cmd == L"thickspace" ||
+            cmd == L"enspace" || cmd == L"negthinspace") {
             MNodePtr s = mk(MNode::Space);
-            if (cmd == L",") s->space = 0.17f;
-            else if (cmd == L":") s->space = 0.22f;
-            else if (cmd == L";") s->space = 0.28f;
+            if (cmd == L"," || cmd == L"thinspace") s->space = 3.0f / 18;
+            else if (cmd == L":" || cmd == L">" || cmd == L"medspace") s->space = 4.0f / 18;
+            else if (cmd == L";" || cmd == L"thickspace") s->space = 5.0f / 18;
             else if (cmd == L" ") s->space = 0.33f;
             else if (cmd == L"quad") s->space = 1.0f;
             else if (cmd == L"qquad") s->space = 2.0f;
-            else s->space = 0.0f;  // \! ignored (negative space)
+            else if (cmd == L"enspace") s->space = 0.5f;
+            else s->space = -3.0f / 18;
             return s;
         }
 
-        if (cmd == L"frac" || cmd == L"dfrac" || cmd == L"tfrac") {
+        if (cmd == L"frac" || cmd == L"dfrac" || cmd == L"tfrac" || cmd == L"cfrac" ||
+            cmd == L"binom" || cmd == L"dbinom" || cmd == L"tbinom") {
             MNodePtr f = mk(MNode::Frac);
+            if (cmd == L"dfrac" || cmd == L"dbinom" || cmd == L"cfrac") f->style = 0;
+            if (cmd == L"tfrac" || cmd == L"tbinom") f->style = 1;
             f->kids.push_back(parseArg());
             f->kids.push_back(parseArg());
             if (!f->kids[0] || !f->kids[1]) failed = true;
+            if (cmd == L"binom" || cmd == L"dbinom" || cmd == L"tbinom") {
+                f->noBar = true;
+                auto d = mk(MNode::Delim);
+                d->open = L'('; d->close = L')'; d->kids = {f};
+                return d;
+            }
             return f;
         }
         if (cmd == L"sqrt") {
             MNodePtr d = mk(MNode::Deco);
             d->decoKind = 3;
+            skipWs();
+            MNodePtr index;
+            if (peek() == L'[') {
+                ++pos; index = parseRow(L']');
+                if (peek() != L']') failed = true; else ++pos;
+            }
             d->kids.push_back(parseArg());
+            d->kids.push_back(index);
             if (!d->kids[0]) failed = true;
             return d;
+        }
+        if (cmd == L"overset" || cmd == L"underset" || cmd == L"stackrel") {
+            auto annotation = parseArg();
+            auto base = parseArg();
+            if (!annotation || !base) failed = true;
+            auto stack = mk(MNode::Stack);
+            stack->kids = {base, cmd == L"underset" ? annotation : nullptr,
+                                cmd != L"underset" ? annotation : nullptr};
+            return stack;
+        }
+        if (cmd == L"xrightarrow" || cmd == L"xleftarrow") {
+            auto stack = mk(MNode::Stack);
+            stack->decoKind = cmd == L"xrightarrow" ? 1 : 2;
+            stack->spacing = 0.26f;
+            skipWs(); MNodePtr below;
+            if (peek() == L'[') {
+                ++pos; below = parseRow(L']');
+                if (peek() != L']') failed = true; else ++pos;
+            }
+            auto above = parseArg();
+            if (!above) failed = true;
+            stack->kids = {nullptr, below, above};
+            return stack;
+        }
+        if (cmd == L"substack") {
+            skipWs();
+            if (peek() != L'{') { failed = true; return nullptr; }
+            ++pos; auto grid = mk(MNode::Grid);
+            // The surrounding script already supplies the smaller math style.
+            do {
+                grid->cells.push_back({parseRow(L'}', false, true)});
+                if (grid->cells.size() > 64) { failed = true; break; }
+                if (src.compare(pos, 2, L"\\\\") != 0) break;
+                pos += 2;
+            } while (!failed);
+            if (peek() != L'}') failed = true; else ++pos;
+            return grid;
+        }
+        const std::pair<const wchar_t*, int> decorations[] = {
+            {L"dot", 5}, {L"ddot", 6}, {L"tilde", 7}, {L"widetilde", 7},
+            {L"underline", 8}, {L"boxed", 9}, {L"cancel", 10}, {L"bcancel", 11},
+            {L"overbrace", 12}, {L"underbrace", 13}, {L"acute", 14}, {L"grave", 15},
+            {L"breve", 16}, {L"check", 17}, {L"not", 18}, {L"xcancel", 19},
+        };
+        for (const auto& deco : decorations) if (cmd == deco.first) {
+            auto d = mk(MNode::Deco);
+            d->decoKind = deco.second; d->kids = {parseArg()};
+            d->limitOp = d->decoKind == 12 || d->decoKind == 13;
+            if (!d->kids[0]) failed = true;
+            return d;
+        }
+        if (cmd == L"phantom" || cmd == L"hphantom" || cmd == L"vphantom" || cmd == L"smash") {
+            auto p = mk(MNode::Phantom);
+            p->decoKind = cmd == L"hphantom" ? 1 : cmd == L"vphantom" ? 2 : cmd == L"smash" ? 3 : 0;
+            p->kids = {parseArg()};
+            if (!p->kids[0]) failed = true;
+            return p;
         }
         if (cmd == L"overline" || cmd == L"bar") {
             MNodePtr d = mk(MNode::Deco);
@@ -397,47 +633,48 @@ struct Parser {
             d->kids.push_back(content ? content : mk(MNode::Row));
             return d;
         }
-        if (cmd == L"mathrm" || cmd == L"text" || cmd == L"operatorname" ||
-            cmd == L"textrm") {
+        if (cmd == L"mathrm") {
             MNodePtr arg = parseArg();
             if (arg) arg = markRoman(arg);
             return arg;
         }
-        if (cmd == L"mathbf" || cmd == L"boldsymbol" || cmd == L"bm" ||
-            cmd == L"textbf") {
+        if (cmd == L"mathbf" || cmd == L"boldsymbol" || cmd == L"bm") {
             MNodePtr arg = parseArg();
             if (arg) arg = markBold(arg);
+            if (arg && cmd == L"mathbf") markRoman(arg);
             return arg;
         }
-        if (cmd == L"mathbb") {
+        if (cmd == L"mathbb" || cmd == L"mathcal" || cmd == L"mathscr" ||
+            cmd == L"mathfrak" || cmd == L"mathsf" || cmd == L"mathtt") {
             MNodePtr arg = parseArg();
-            // single-letter blackboard bold via Unicode double-struck
-            if (arg && arg->kind == MNode::Sym && arg->text.size() == 1) {
-                for (const auto& b : kBlackboard) {
-                    if (arg->text == b.name) {
-                        arg->text = b.text;
-                        break;
-                    }
-                }
-            }
+            mathAlphabet(arg, cmd);
             return arg;
         }
-        if (cmd == L"mathcal" || cmd == L"mathscr" || cmd == L"mathit") {
-            return parseArg();  // rendered as regular italic
-        }
-        if (cmd == L"displaystyle" || cmd == L"textstyle" || cmd == L"nolimits" ||
-            cmd == L"limits" || cmd == L"middle") {
-            return parseAtom();  // pass-through niladics: render what follows
+        if (cmd == L"mathit") {
+            auto arg = parseArg();
+            if (arg) markItalic(arg);
+            return arg;
         }
         if (isFunctionName(cmd)) {
             MNodePtr f = mk(MNode::Sym);
             f->text = cmd;
             f->roman = true;
+            f->spacing = 0.16f;
+            f->limitOp = cmd == L"lim" || cmd == L"limsup" || cmd == L"liminf" ||
+                         cmd == L"max" || cmd == L"min" || cmd == L"sup" || cmd == L"inf" ||
+                         cmd == L"argmax" || cmd == L"argmin";
             return f;
         }
         if (const wchar_t* sym = lookupSymbol(cmd)) {
             MNodePtr s = mk(MNode::Sym);
             s->text = sym;
+            s->largeOp = cmd == L"sum" || cmd == L"prod" || cmd == L"coprod" ||
+                         cmd == L"int" || cmd == L"iint" || cmd == L"iiint" ||
+                         cmd == L"oint" || cmd == L"oiint" || cmd == L"bigcup" ||
+                         cmd == L"bigcap" || cmd == L"bigvee" || cmd == L"bigwedge" ||
+                         cmd == L"bigoplus" || cmd == L"bigotimes" || cmd == L"biguplus";
+            s->limitOp = s->largeOp && cmd.find(L"int") == std::wstring::npos;
+            if (s->largeOp) s->spacing = 0.16f;
             return s;
         }
 
@@ -455,27 +692,49 @@ struct Parser {
     }
     static MNodePtr markBold(MNodePtr n) {
         n->bold = true;
-        n->roman = true;
         for (auto& k : n->kids) {
             if (k) markBold(k);
         }
         for (auto& row : n->cells) for (auto& cell : row) if (cell) markBold(cell);
         return n;
     }
+    static void markItalic(const MNodePtr& n) {
+        if (!n) return;
+        n->forceItalic = true;
+        for (const auto& k : n->kids) markItalic(k);
+        for (const auto& row : n->cells) for (const auto& cell : row) markItalic(cell);
+    }
 
     MNodePtr parseRow(wchar_t terminator, bool stopAtRight = false, bool cell = false) {
         Nest nest(depth);
         if (depth > 96) { failed = true; return nullptr; }
         MNodePtr row = mk(MNode::Row);
+        int activeStyle = -1;
         while (!eof() && !failed) {
             skipWs();
             if (eof()) break;
             if (terminator && peek() == terminator) break;
             if (cell && (peek() == L'&' || src.compare(pos, 2, L"\\\\") == 0 ||
                          atCommand(L"\\cr") || atCommand(L"\\end"))) break;
-            if (stopAtRight && peek() == L'\\' &&
-                src.compare(pos, 6, L"\\right") == 0) {
+            if (stopAtRight && atCommand(L"\\right")) {
                 break;
+            }
+            const wchar_t* styles[] = {L"\\displaystyle", L"\\textstyle", L"\\scriptstyle", L"\\scriptscriptstyle"};
+            bool directive = false;
+            for (int style = 0; style < 4; ++style) if (atCommand(styles[style])) {
+                pos += std::char_traits<wchar_t>::length(styles[style]);
+                activeStyle = style; directive = true; break;
+            }
+            if (directive) continue;
+            if (atCommand(L"\\limits") || atCommand(L"\\nolimits")) {
+                bool limits = atCommand(L"\\limits");
+                pos += limits ? 7 : 9;
+                if (row->kids.empty()) { failed = true; break; }
+                auto base = row->kids.back();
+                if (base->kind == MNode::Script) base = base->kids[0];
+                if (!base->largeOp && !base->limitOp) { failed = true; break; }
+                base->limits = limits ? 1 : 0;
+                continue;
             }
             if (peek() == L'^' || peek() == L'_') {
                 // Attach scripts to the previous atom (or an empty base)
@@ -488,20 +747,25 @@ struct Parser {
                 } else {
                     script = mk(MNode::Script);
                     script->kids = {base, nullptr, nullptr};
+                    script->style = activeStyle;
                 }
                 while (!eof() && (peek() == L'^' || peek() == L'_')) {
                     wchar_t which = src[pos++];
                     MNodePtr arg = parseArg();
                     if (!arg) { failed = true; break; }
-                    if (which == L'^') script->kids[2] = arg;
-                    else script->kids[1] = arg;
+                    int slot = which == L'^' ? 2 : 1;
+                    if (script->kids[slot]) { failed = true; break; }
+                    script->kids[slot] = arg;
                     skipWs();
                 }
                 row->kids.push_back(script);
                 continue;
             }
             MNodePtr atom = parseAtom();
-            if (atom) row->kids.push_back(atom);
+            if (atom) {
+                if (atom->style < 0) atom->style = activeStyle;
+                row->kids.push_back(atom);
+            }
         }
         return row;
     }

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -1,8 +1,11 @@
 #include "math_parser.h"
+#include "math_macros.h"
 
 #include <algorithm>
 #include <cwctype>
 #include <climits>
+#include <cstdlib>
+#include <cmath>
 
 namespace tinta_math {
 
@@ -121,14 +124,7 @@ const wchar_t* kFunctions[] = {
     L"arcsin", L"arccos", L"arctan", L"sinh", L"cosh", L"tanh", L"coth",
     L"lim", L"limsup", L"liminf", L"max", L"min", L"sup", L"inf",
     L"gcd", L"det", L"dim", L"ker", L"deg", L"arg", L"exp", L"mod", L"Pr",
-    L"argmax", L"argmin", L"hom", L"erf", L"sgn",
-};
-
-// \mathbb single letters -> double-struck
-const CmdSym kBlackboard[] = {
-    {L"R", L"\u211D"}, {L"N", L"\u2115"}, {L"Z", L"\u2124"},
-    {L"Q", L"\u211A"}, {L"C", L"\u2102"}, {L"P", L"\u2119"},
-    {L"E", L"\U0001D53C"}, {L"F", L"\U0001D53D"},
+    L"hom", L"erf", L"sgn",
 };
 
 const wchar_t* lookupSymbol(const std::wstring& cmd) {
@@ -260,6 +256,7 @@ struct Parser {
     bool failed = false;
     int depth = 0;
     size_t atoms = 0;
+    int delimiterDepth = 0;
 
     struct Nest {
         int& depth;
@@ -294,6 +291,50 @@ struct Parser {
         if (peek() != L'}') failed = true;
         else ++pos;
         return value;
+    }
+
+    wchar_t readDelimiter() {
+        skipWs();
+        if (eof()) { failed = true; return 0; }
+        wchar_t value = src[pos++];
+        if (value == L'\\') {
+            std::wstring name = readCommand();
+            if (name == L"{" || name == L"}") value = name[0];
+            else if (name == L"|") value = L'\u2016';
+            else {
+                const wchar_t* symbol = lookupSymbol(name);
+                if (!symbol || !symbol[0] || symbol[1]) { failed = true; return 0; }
+                value = symbol[0];
+            }
+        }
+        if (std::wstring(L".()[]{}|/\\\u2016\u2223\u2225\u2308\u2309\u230A\u230B\u27E8\u27E9\u2191\u2193\u2195\u21D1\u21D3\u21D5").find(value) == std::wstring::npos)
+            failed = true;
+        return value == L'.' ? 0 : value;
+    }
+
+    MNodePtr dimension() {
+        skipWs();
+        bool group = peek() == L'{';
+        if (group) ++pos;
+        const wchar_t* start = src.c_str() + pos;
+        wchar_t* end = nullptr;
+        double number = std::wcstod(start, &end);
+        if (start == end || !std::isfinite(number) || std::abs(number) > 1000) {
+            failed = true; return nullptr;
+        }
+        pos += static_cast<size_t>(end - start);
+        skipWs(); size_t unitStart = pos;
+        while (!eof() && iswalpha(peek())) ++pos;
+        std::wstring unit = src.substr(unitStart, pos - unitStart);
+        auto space = mk(MNode::Space);
+        space->space = static_cast<float>(number);
+        if (unit == L"ex") space->space *= 0.5f;
+        else if (unit == L"mu") space->space /= 18;
+        else if (unit == L"pt" || unit == L"px") space->text = unit;
+        else if (unit != L"em") failed = true;
+        skipWs();
+        if (group) { if (peek() != L'}') failed = true; else ++pos; }
+        return space;
     }
 
     MNodePtr textGroup() {
@@ -338,6 +379,9 @@ struct Parser {
 
     MNodePtr parseEnvironment() {
         std::wstring name = literalGroup();
+        std::wstring endName = name;
+        bool starred = !name.empty() && name.back() == L'*';
+        if (starred) name.pop_back();
         auto grid = mk(MNode::Grid);
         wchar_t open = 0, close = 0;
         if (name == L"pmatrix") { open = L'('; close = L')'; }
@@ -351,15 +395,38 @@ struct Parser {
         } else if (name == L"aligned" || name == L"split") grid->aligned = true;
         else if (name == L"smallmatrix") grid->compact = true;
         else if (name == L"array") {
-            grid->alignment = literalGroup();
-            if (grid->alignment.empty() || grid->alignment.size() > 64 ||
-                grid->alignment.find_first_not_of(L"lcr") != std::wstring::npos)
-                failed = true;
+            auto spec = literalGroup();
+            for (wchar_t c : spec) {
+                if (c == L'|') grid->verticalRules.push_back(grid->alignment.size());
+                else if (c == L'l' || c == L'c' || c == L'r') grid->alignment += c;
+                else if (!iswspace(c)) failed = true;
+            }
+            if (grid->alignment.empty() || grid->alignment.size() > 64) failed = true;
         } else if (name != L"matrix" && name != L"gathered") failed = true;
+        if (starred) {
+            if (name.find(L"matrix") == std::wstring::npos || name == L"smallmatrix") failed = true;
+            skipWs();
+            if (peek() == L'[') {
+                ++pos; skipWs();
+                wchar_t align = peek(); if (!eof()) ++pos;
+                skipWs();
+                if ((align != L'l' && align != L'c' && align != L'r') || peek() != L']') failed = true;
+                else ++pos;
+                grid->alignment.assign(1, align); grid->uniformAlignment = true;
+            }
+        }
         if (failed) return nullptr;
 
         grid->cells.emplace_back();
         while (!failed) {
+            skipWs();
+            while (name == L"array" && grid->cells.back().empty() && atCommand(L"\\hline")) {
+                grid->horizontalRules.push_back(grid->cells.size() - 1);
+                pos += 6; skipWs();
+            }
+            if (atCommand(L"\\end") && grid->cells.back().empty() && grid->cells.size() > 1) {
+                grid->cells.pop_back(); break;
+            }
             if (grid->cells.size() > 64 || grid->cells.back().size() >= 64) {
                 failed = true; break;
             }
@@ -377,9 +444,9 @@ struct Parser {
         }
         if (!atCommand(L"\\end")) { failed = true; return nullptr; }
         pos += 4;
-        if (literalGroup() != name) failed = true;
+        if (literalGroup() != endName) failed = true;
         for (const auto& row : grid->cells) {
-            if ((!grid->alignment.empty() && row.size() > grid->alignment.size()) ||
+            if ((!grid->uniformAlignment && !grid->alignment.empty() && row.size() > grid->alignment.size()) ||
                 (name == L"gathered" && row.size() != 1) ||
                 (name == L"split" && row.size() > 2)) failed = true;
         }
@@ -446,6 +513,40 @@ struct Parser {
         std::wstring cmd = readCommand();
         if (cmd.empty()) { failed = true; return nullptr; }
         if (cmd == L"begin") return parseEnvironment();
+        if (cmd == L"hspace" || cmd == L"kern" || cmd == L"mkern") {
+            if (cmd == L"hspace" && peek() == L'*') ++pos;
+            return dimension();
+        }
+        if (cmd == L"pmod" || cmd == L"bmod" || cmd == L"pod") {
+            auto row = mk(MNode::Row);
+            row->spacing = cmd == L"bmod" ? 0.2f : 0.3f;
+            if (cmd != L"pod") {
+                auto mod = mk(MNode::Sym); mod->roman = true; mod->text = L"mod";
+                row->kids.push_back(mod);
+                auto space = mk(MNode::Space); space->space = 0.33f; row->kids.push_back(space);
+            }
+            if (cmd != L"bmod") {
+                row->kids.push_back(parseArg());
+                auto delim = mk(MNode::Delim); delim->open = L'('; delim->close = L')';
+                delim->kids = {row}; delim->spacing = 0.3f; return delim;
+            }
+            return row;
+        }
+        const std::pair<const wchar_t*, float> sizes[] = {{L"big", 1.2f}, {L"Big", 1.6f}, {L"bigg", 2.0f}, {L"Bigg", 2.4f}};
+        for (const auto& entry : sizes) {
+            std::wstring name = entry.first;
+            if (cmd == name || cmd == name + L"l" || cmd == name + L"r" || cmd == name + L"m") {
+                auto delimiter = mk(MNode::Middle);
+                delimiter->open = readDelimiter(); delimiter->delimiterSize = entry.second;
+                return delimiter;
+            }
+        }
+        if (cmd == L"middle") {
+            if (!delimiterDepth) { failed = true; return nullptr; }
+            auto delimiter = mk(MNode::Middle); delimiter->open = readDelimiter();
+            delimiter->spacing = 0.26f;
+            return delimiter;
+        }
         if (cmd == L"text" || cmd == L"textrm" || cmd == L"textbf" || cmd == L"textit") {
             auto text = textGroup();
             if (text && cmd == L"textbf") markBold(text);
@@ -594,43 +695,15 @@ struct Parser {
             return d;
         }
         if (cmd == L"left") {
-            skipWs();
-            wchar_t open = 0;
-            if (peek() == L'\\') {
-                pos++;
-                std::wstring dc = readCommand();
-                const wchar_t* mapped = lookupSymbol(dc);
-                open = mapped && mapped[0] ? mapped[0] : 0;
-                if (dc == L"{") open = L'{';
-                if (dc == L"}") open = L'}';
-            } else {
-                open = peek();
-                if (!eof()) pos++;
-            }
-            MNodePtr content = parseRow(0, /*stopAtRight=*/true);
-            // consume \right and its delimiter
+            Nest delimiter(delimiterDepth);
+            wchar_t open = readDelimiter();
+            auto content = parseRow(0, true);
             wchar_t close = 0;
-            if (pos + 5 < src.size() && src.compare(pos, 6, L"\\right") == 0) {
-                pos += 6;
-                skipWs();
-                if (peek() == L'\\') {
-                    pos++;
-                    std::wstring dc = readCommand();
-                    const wchar_t* mapped = lookupSymbol(dc);
-                    close = mapped && mapped[0] ? mapped[0] : 0;
-                    if (dc == L"{") close = L'{';
-                    if (dc == L"}") close = L'}';
-                } else {
-                    close = peek();
-                    if (!eof()) pos++;
-                }
-            } else {
-                failed = true;
-            }
-            MNodePtr d = mk(MNode::Delim);
-            d->open = open == L'.' ? 0 : open;
-            d->close = close == L'.' ? 0 : close;
-            d->kids.push_back(content ? content : mk(MNode::Row));
+            if (!atCommand(L"\\right")) failed = true;
+            else { pos += 6; close = readDelimiter(); }
+            auto d = mk(MNode::Delim);
+            d->open = open; d->close = close;
+            d->kids = {content ? content : mk(MNode::Row)};
             return d;
         }
         if (cmd == L"mathrm") {
@@ -655,7 +728,9 @@ struct Parser {
             if (arg) markItalic(arg);
             return arg;
         }
-        if (isFunctionName(cmd)) {
+        // Convenience spellings remain definable with DeclareMathOperator,
+        // as they are not predefined operators in amsmath.
+        if (isFunctionName(cmd) || cmd == L"argmax" || cmd == L"argmin") {
             MNodePtr f = mk(MNode::Sym);
             f->text = cmd;
             f->roman = true;
@@ -774,9 +849,25 @@ struct Parser {
 
 MNodePtr parseLatex(const std::wstring& source) {
     if (source.size() > 32768) return nullptr;
-    Parser parser(source);
+    std::wstring expanded;
+    if (!expandLatexMacros(source, expanded)) return nullptr;
+    Parser parser(expanded);
     auto root = parser.parseRow(0);
     return parser.failed || !root || root->kids.empty() ? nullptr : root;
+}
+
+bool isBuiltinMathCommand(const std::wstring& command) {
+    if (lookupSymbol(command) || isFunctionName(command)) return true;
+    const std::wstring names = L" begin end frac dfrac tfrac cfrac binom dbinom tbinom sqrt "
+        L"left right middle big Big bigg Bigg bigl bigr Bigl Bigr biggl biggr Biggl Biggr "
+        L"text textrm textbf textit operatorname mathrm mathit mathbb mathcal mathscr mathfrak mathsf mathtt "
+        L"mathbf boldsymbol bm displaystyle textstyle scriptstyle scriptscriptstyle limits nolimits "
+        L"overline bar overrightarrow vec hat widehat dot ddot tilde widetilde underline boxed "
+        L"cancel bcancel xcancel overbrace underbrace acute grave breve check not "
+        L"phantom hphantom vphantom smash hspace kern mkern quad qquad thinspace medspace thickspace enspace "
+        L"overset underset stackrel substack xrightarrow xleftarrow pmod bmod pod newcommand renewcommand "
+        L"providecommand def DeclareMathOperator ";
+    return names.find(L" " + command + L" ") != std::wstring::npos;
 }
 
 } // namespace tinta_math

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -323,9 +323,9 @@ struct Parser {
             failed = true; return nullptr;
         }
         pos += static_cast<size_t>(end - start);
-        skipWs(); size_t unitStart = pos;
-        while (!eof() && iswalpha(peek())) ++pos;
-        std::wstring unit = src.substr(unitStart, pos - unitStart);
+        skipWs();
+        std::wstring unit = src.substr(pos, 2);
+        if (unit.size() == 2) pos += 2;
         auto space = mk(MNode::Space);
         space->space = static_cast<float>(number);
         if (unit == L"ex") space->space *= 0.5f;

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -1,0 +1,518 @@
+#include "math_parser.h"
+
+#include <algorithm>
+#include <cwctype>
+
+namespace tinta_math {
+
+MNodePtr mk(MNode::Kind k) {
+    auto n = std::make_shared<MNode>();
+    n->kind = k;
+    return n;
+}
+
+// ---------------------------------------------------------------------------
+// Command tables
+// ---------------------------------------------------------------------------
+
+struct CmdSym { const wchar_t* name; const wchar_t* text; };
+
+// Symbols and greek letters mapped straight to Unicode text runs
+const CmdSym kSymbols[] = {
+    {L"alpha", L"\u03B1"}, {L"beta", L"\u03B2"}, {L"gamma", L"\u03B3"},
+    {L"delta", L"\u03B4"}, {L"epsilon", L"\u03B5"}, {L"varepsilon", L"\u03B5"},
+    {L"zeta", L"\u03B6"}, {L"eta", L"\u03B7"}, {L"theta", L"\u03B8"},
+    {L"vartheta", L"\u03D1"}, {L"iota", L"\u03B9"}, {L"kappa", L"\u03BA"},
+    {L"lambda", L"\u03BB"}, {L"mu", L"\u03BC"}, {L"nu", L"\u03BD"},
+    {L"xi", L"\u03BE"}, {L"pi", L"\u03C0"}, {L"rho", L"\u03C1"},
+    {L"sigma", L"\u03C3"}, {L"tau", L"\u03C4"}, {L"upsilon", L"\u03C5"},
+    {L"phi", L"\u03C6"}, {L"varphi", L"\u03C6"}, {L"chi", L"\u03C7"},
+    {L"psi", L"\u03C8"}, {L"omega", L"\u03C9"},
+    {L"Gamma", L"\u0393"}, {L"Delta", L"\u0394"}, {L"Theta", L"\u0398"},
+    {L"Lambda", L"\u039B"}, {L"Xi", L"\u039E"}, {L"Pi", L"\u03A0"},
+    {L"Sigma", L"\u03A3"}, {L"Upsilon", L"\u03A5"}, {L"Phi", L"\u03A6"},
+    {L"Psi", L"\u03A8"}, {L"Omega", L"\u03A9"},
+    {L"in", L"\u2208"}, {L"notin", L"\u2209"}, {L"ni", L"\u220B"},
+    {L"cup", L"\u222A"}, {L"cap", L"\u2229"},
+    {L"subset", L"\u2282"}, {L"supset", L"\u2283"},
+    {L"subseteq", L"\u2286"}, {L"supseteq", L"\u2287"},
+    {L"geq", L"\u2265"}, {L"ge", L"\u2265"}, {L"leq", L"\u2264"},
+    {L"le", L"\u2264"}, {L"neq", L"\u2260"}, {L"ne", L"\u2260"},
+    {L"equiv", L"\u2261"}, {L"approx", L"\u2248"}, {L"sim", L"\u223C"},
+    {L"propto", L"\u221D"}, {L"pm", L"\u00B1"}, {L"mp", L"\u2213"},
+    {L"times", L"\u00D7"}, {L"div", L"\u00F7"}, {L"cdot", L"\u22C5"},
+    {L"cdots", L"\u22EF"}, {L"ldots", L"\u2026"}, {L"dots", L"\u2026"},
+    {L"vdots", L"\u22EE"}, {L"ddots", L"\u22F1"},
+    {L"mid", L"\u2223"}, {L"parallel", L"\u2225"}, {L"perp", L"\u22A5"},
+    {L"angle", L"\u2220"}, {L"triangle", L"\u25B3"},
+    {L"bigtriangleup", L"\u25B3"}, {L"square", L"\u25A1"},
+    {L"infty", L"\u221E"}, {L"partial", L"\u2202"}, {L"nabla", L"\u2207"},
+    {L"forall", L"\u2200"}, {L"exists", L"\u2203"},
+    {L"emptyset", L"\u2205"}, {L"varnothing", L"\u2205"},
+    {L"because", L"\u2235"}, {L"therefore", L"\u2234"},
+    {L"to", L"\u2192"}, {L"rightarrow", L"\u2192"},
+    {L"longrightarrow", L"\u27F6"}, {L"longleftarrow", L"\u27F5"},
+    {L"longleftrightarrow", L"\u27F7"}, {L"Longrightarrow", L"\u27F9"},
+    {L"Longleftarrow", L"\u27F8"}, {L"Longleftrightarrow", L"\u27FA"},
+    {L"implies", L"\u27F9"}, {L"impliedby", L"\u27F8"}, {L"iff", L"\u27FA"},
+    {L"longmapsto", L"\u27FC"},
+    {L"leftarrow", L"\u2190"}, {L"Rightarrow", L"\u21D2"},
+    {L"Leftarrow", L"\u21D0"}, {L"Leftrightarrow", L"\u21D4"},
+    {L"leftrightarrow", L"\u2194"}, {L"mapsto", L"\u21A6"},
+    {L"circ", L"\u2218"}, {L"bullet", L"\u2219"}, {L"star", L"\u22C6"},
+    {L"oplus", L"\u2295"}, {L"otimes", L"\u2297"},
+    {L"sum", L"\u2211"}, {L"prod", L"\u220F"}, {L"int", L"\u222B"},
+    {L"oint", L"\u222E"}, {L"sqrt", nullptr},  // structural, handled apart
+    {L"prime", L"\u2032"}, {L"degree", L"\u00B0"},
+    {L"lfloor", L"\u230A"}, {L"rfloor", L"\u230B"},
+    {L"lceil", L"\u2308"}, {L"rceil", L"\u2309"},
+    {L"langle", L"\u27E8"}, {L"rangle", L"\u27E9"},
+    {L"lbrack", L"["}, {L"rbrack", L"]"},
+    {L"lbrace", L"{"}, {L"rbrace", L"}"},
+    {L"lvert", L"|"}, {L"rvert", L"|"}, {L"vert", L"|"},
+    {L"lVert", L"\u2016"}, {L"rVert", L"\u2016"}, {L"Vert", L"\u2016"},
+    {L"backslash", L"\\"}, {L"setminus", L"\u2216"},
+    {L"hbar", L"\u210F"}, {L"ell", L"\u2113"}, {L"Re", L"\u211C"},
+    {L"Im", L"\u2111"}, {L"aleph", L"\u2135"}, {L"wp", L"\u2118"},
+    {L"neg", L"\u00AC"}, {L"lnot", L"\u00AC"},
+    {L"land", L"\u2227"}, {L"wedge", L"\u2227"},
+    {L"lor", L"\u2228"}, {L"vee", L"\u2228"},
+};
+
+// Function names rendered upright with a trailing thin space
+const wchar_t* kFunctions[] = {
+    L"log", L"ln", L"lg", L"sin", L"cos", L"tan", L"cot", L"sec", L"csc",
+    L"arcsin", L"arccos", L"arctan", L"sinh", L"cosh", L"tanh", L"coth",
+    L"lim", L"limsup", L"liminf", L"max", L"min", L"sup", L"inf",
+    L"gcd", L"det", L"dim", L"ker", L"deg", L"arg", L"exp", L"mod", L"Pr",
+};
+
+// \mathbb single letters -> double-struck
+const CmdSym kBlackboard[] = {
+    {L"R", L"\u211D"}, {L"N", L"\u2115"}, {L"Z", L"\u2124"},
+    {L"Q", L"\u211A"}, {L"C", L"\u2102"}, {L"P", L"\u2119"},
+    {L"E", L"\U0001D53C"}, {L"F", L"\U0001D53D"},
+};
+
+const wchar_t* lookupSymbol(const std::wstring& cmd) {
+    for (const auto& s : kSymbols) {
+        if (cmd == s.name) return s.text;
+    }
+    return nullptr;
+}
+
+bool isFunctionName(const std::wstring& cmd) {
+    for (const auto* f : kFunctions) {
+        if (cmd == f) return true;
+    }
+    return false;
+}
+
+// Spacing classes for row layout (fractions of an em on each side)
+float symbolSpacing(const std::wstring& t, bool roman) {
+    if (t.size() != 1) {
+        if (t == L"\u22EF" || t == L"\u2026") return 0.16f;
+        // Upright function names (sin, log, ...) take thin spaces so
+        // \sin m\alpha reads "sin m\u03B1" rather than "sinm\u03B1"
+        if (roman) {
+            bool allAlpha = true;
+            for (wchar_t c : t) {
+                if (!iswalpha(c)) { allAlpha = false; break; }
+            }
+            if (allAlpha) return 0.16f;
+        }
+        return 0.0f;
+    }
+    wchar_t c = t[0];
+    switch (c) {
+        case L'=': case L'<': case L'>':
+        case 0x2264: case 0x2265: case 0x2260: case 0x2261: case 0x2248:
+        case 0x2208: case 0x2209: case 0x2282: case 0x2283: case 0x2286:
+        case 0x2287: case 0x2192: case 0x21D2: case 0x2194: case 0x21D4:
+        case 0x223C: case 0x221D: case 0x2223: case 0x2225:
+        case 0x2190: case 0x21D0: case 0x21A6:
+        case 0x27F5: case 0x27F6: case 0x27F7: case 0x27F8:
+        case 0x27F9: case 0x27FA: case 0x27FC:
+            return 0.26f;   // relations
+        case L'+': case 0x2212: case 0x00B1: case 0x2213: case 0x00D7:
+        case 0x00F7: case 0x22C5: case 0x222A: case 0x2229: case 0x2227:
+        case 0x2228: case 0x2216:
+            return 0.2f;    // binary operators
+        case L',': case L';':
+            return 0.12f;   // punctuation (space after only, approximated)
+        default:
+            return 0.0f;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tokenizer + parser
+// ---------------------------------------------------------------------------
+
+struct Parser {
+    const std::wstring& src;
+    size_t pos = 0;
+    bool failed = false;
+    int depth = 0;
+    size_t atoms = 0;
+
+    struct Nest {
+        int& depth;
+        explicit Nest(int& d) : depth(d) { ++depth; }
+        ~Nest() { --depth; }
+    };
+
+    explicit Parser(const std::wstring& s) : src(s) {}
+
+    void skipWs() {
+        while (pos < src.size()) {
+            if (iswspace(src[pos])) { ++pos; continue; }
+            if (src[pos] != L'%') break;
+            while (pos < src.size() && src[pos] != L'\n') ++pos;
+        }
+    }
+    bool eof() { return pos >= src.size(); }
+    wchar_t peek() { return pos < src.size() ? src[pos] : 0; }
+
+    bool atCommand(const wchar_t* cmd) const {
+        size_t n = std::char_traits<wchar_t>::length(cmd);
+        return src.compare(pos, n, cmd) == 0 &&
+               (pos + n == src.size() || !iswalpha(src[pos + n]));
+    }
+
+    std::wstring literalGroup() {
+        skipWs();
+        if (peek() != L'{') { failed = true; return {}; }
+        size_t start = ++pos;
+        while (!eof() && peek() != L'}' && peek() != L'{' && peek() != L'\\') ++pos;
+        std::wstring value = src.substr(start, pos - start);
+        if (peek() != L'}') failed = true;
+        else ++pos;
+        return value;
+    }
+
+    MNodePtr parseEnvironment() {
+        std::wstring name = literalGroup();
+        auto grid = mk(MNode::Grid);
+        wchar_t open = 0, close = 0;
+        if (name == L"pmatrix") { open = L'('; close = L')'; }
+        else if (name == L"bmatrix") { open = L'['; close = L']'; }
+        else if (name == L"Bmatrix") { open = L'{'; close = L'}'; }
+        else if (name == L"vmatrix") open = close = L'|';
+        else if (name == L"Vmatrix") open = close = L'\u2016';
+        else if (name == L"cases" || name == L"rcases") {
+            if (name == L"cases") open = L'{'; else close = L'}';
+            grid->alignment = L"ll";
+        } else if (name == L"aligned" || name == L"split") grid->aligned = true;
+        else if (name == L"smallmatrix") grid->compact = true;
+        else if (name == L"array") {
+            grid->alignment = literalGroup();
+            if (grid->alignment.empty() || grid->alignment.size() > 64 ||
+                grid->alignment.find_first_not_of(L"lcr") != std::wstring::npos)
+                failed = true;
+        } else if (name != L"matrix" && name != L"gathered") failed = true;
+        if (failed) return nullptr;
+
+        grid->cells.emplace_back();
+        while (!failed) {
+            if (grid->cells.size() > 64 || grid->cells.back().size() >= 64) {
+                failed = true; break;
+            }
+            grid->cells.back().push_back(parseRow(0, false, true));
+            skipWs();
+            if (peek() == L'&') { ++pos; continue; }
+            if (src.compare(pos, 2, L"\\\\") == 0 || atCommand(L"\\cr")) {
+                pos += peek() == L'\\' && pos + 1 < src.size() && src[pos + 1] == L'\\' ? 2 : 3;
+                skipWs();
+                if (atCommand(L"\\end")) break; // optional final row separator
+                grid->cells.emplace_back();
+                continue;
+            }
+            break;
+        }
+        if (!atCommand(L"\\end")) { failed = true; return nullptr; }
+        pos += 4;
+        if (literalGroup() != name) failed = true;
+        for (const auto& row : grid->cells) {
+            if ((!grid->alignment.empty() && row.size() > grid->alignment.size()) ||
+                (name == L"gathered" && row.size() != 1) ||
+                (name == L"split" && row.size() > 2)) failed = true;
+        }
+        if (!open && !close) return grid;
+        auto delim = mk(MNode::Delim);
+        delim->open = open; delim->close = close;
+        delim->kids = {grid};
+        return delim;
+    }
+
+    std::wstring readCommand() {  // after the backslash
+        std::wstring cmd;
+        while (pos < src.size() && iswalpha(src[pos])) cmd += src[pos++];
+        if (cmd.empty() && pos < src.size()) cmd += src[pos++];  // \{ \, etc.
+        return cmd;
+    }
+
+    // One brace group or a single atom (TeX: \frac ab == \frac{a}{b})
+    MNodePtr parseArg() {
+        skipWs();
+        if (peek() == L'{') {
+            pos++;
+            MNodePtr row = parseRow(L'}');
+            if (peek() == L'}') pos++;
+            else failed = true;
+            return row;
+        }
+        return parseAtom();
+    }
+
+    MNodePtr parseAtom() {
+        Nest nest(depth);
+        if (depth > 96 || ++atoms > 4096) { failed = true; return nullptr; }
+        skipWs();
+        if (eof()) return nullptr;
+        wchar_t c = src[pos];
+        if (c == L'}' || c == L'&' || c == L'^' || c == L'_') {
+            failed = true; return nullptr;
+        }
+
+        if (c == L'{') {
+            pos++;
+            MNodePtr row = parseRow(L'}');
+            if (peek() == L'}') pos++;
+            else failed = true;
+            return row;
+        }
+        if (c == L'\\') {
+            pos++;
+            return parseCommand();
+        }
+        pos++;
+        MNodePtr sym = mk(MNode::Sym);
+        if (c == L'-') sym->text = L"\u2212";       // proper minus
+        else if (c == L'\'') sym->text = L"\u2032"; // prime
+        else if (c == L'*') sym->text = L"\u2217";
+        else sym->text.assign(1, c);
+        return sym;
+    }
+
+    MNodePtr parseCommand() {
+        std::wstring cmd = readCommand();
+        if (cmd.empty()) { failed = true; return nullptr; }
+        if (cmd == L"begin") return parseEnvironment();
+
+        // Escapes and explicit spacing
+        if (cmd == L"{" || cmd == L"}" || cmd == L"$" || cmd == L"%" ||
+            cmd == L"&" || cmd == L"#" || cmd == L"_") {
+            MNodePtr s = mk(MNode::Sym);
+            s->text = cmd;
+            return s;
+        }
+        if (cmd == L"|") {
+            MNodePtr s = mk(MNode::Sym);
+            s->text = L"\u2016";
+            return s;
+        }
+        if (cmd == L"," || cmd == L":" || cmd == L";" || cmd == L" " ||
+            cmd == L"quad" || cmd == L"qquad" || cmd == L"!") {
+            MNodePtr s = mk(MNode::Space);
+            if (cmd == L",") s->space = 0.17f;
+            else if (cmd == L":") s->space = 0.22f;
+            else if (cmd == L";") s->space = 0.28f;
+            else if (cmd == L" ") s->space = 0.33f;
+            else if (cmd == L"quad") s->space = 1.0f;
+            else if (cmd == L"qquad") s->space = 2.0f;
+            else s->space = 0.0f;  // \! ignored (negative space)
+            return s;
+        }
+
+        if (cmd == L"frac" || cmd == L"dfrac" || cmd == L"tfrac") {
+            MNodePtr f = mk(MNode::Frac);
+            f->kids.push_back(parseArg());
+            f->kids.push_back(parseArg());
+            if (!f->kids[0] || !f->kids[1]) failed = true;
+            return f;
+        }
+        if (cmd == L"sqrt") {
+            MNodePtr d = mk(MNode::Deco);
+            d->decoKind = 3;
+            d->kids.push_back(parseArg());
+            if (!d->kids[0]) failed = true;
+            return d;
+        }
+        if (cmd == L"overline" || cmd == L"bar") {
+            MNodePtr d = mk(MNode::Deco);
+            d->decoKind = 1;
+            d->kids.push_back(parseArg());
+            return d;
+        }
+        if (cmd == L"overrightarrow" || cmd == L"vec") {
+            MNodePtr d = mk(MNode::Deco);
+            d->decoKind = 2;
+            d->kids.push_back(parseArg());
+            return d;
+        }
+        if (cmd == L"hat" || cmd == L"widehat") {
+            MNodePtr d = mk(MNode::Deco);
+            d->decoKind = 4;
+            d->kids.push_back(parseArg());
+            return d;
+        }
+        if (cmd == L"left") {
+            skipWs();
+            wchar_t open = 0;
+            if (peek() == L'\\') {
+                pos++;
+                std::wstring dc = readCommand();
+                const wchar_t* mapped = lookupSymbol(dc);
+                open = mapped && mapped[0] ? mapped[0] : 0;
+                if (dc == L"{") open = L'{';
+                if (dc == L"}") open = L'}';
+            } else {
+                open = peek();
+                if (!eof()) pos++;
+            }
+            MNodePtr content = parseRow(0, /*stopAtRight=*/true);
+            // consume \right and its delimiter
+            wchar_t close = 0;
+            if (pos + 5 < src.size() && src.compare(pos, 6, L"\\right") == 0) {
+                pos += 6;
+                skipWs();
+                if (peek() == L'\\') {
+                    pos++;
+                    std::wstring dc = readCommand();
+                    const wchar_t* mapped = lookupSymbol(dc);
+                    close = mapped && mapped[0] ? mapped[0] : 0;
+                    if (dc == L"{") close = L'{';
+                    if (dc == L"}") close = L'}';
+                } else {
+                    close = peek();
+                    if (!eof()) pos++;
+                }
+            } else {
+                failed = true;
+            }
+            MNodePtr d = mk(MNode::Delim);
+            d->open = open == L'.' ? 0 : open;
+            d->close = close == L'.' ? 0 : close;
+            d->kids.push_back(content ? content : mk(MNode::Row));
+            return d;
+        }
+        if (cmd == L"mathrm" || cmd == L"text" || cmd == L"operatorname" ||
+            cmd == L"textrm") {
+            MNodePtr arg = parseArg();
+            if (arg) arg = markRoman(arg);
+            return arg;
+        }
+        if (cmd == L"mathbf" || cmd == L"boldsymbol" || cmd == L"bm" ||
+            cmd == L"textbf") {
+            MNodePtr arg = parseArg();
+            if (arg) arg = markBold(arg);
+            return arg;
+        }
+        if (cmd == L"mathbb") {
+            MNodePtr arg = parseArg();
+            // single-letter blackboard bold via Unicode double-struck
+            if (arg && arg->kind == MNode::Sym && arg->text.size() == 1) {
+                for (const auto& b : kBlackboard) {
+                    if (arg->text == b.name) {
+                        arg->text = b.text;
+                        break;
+                    }
+                }
+            }
+            return arg;
+        }
+        if (cmd == L"mathcal" || cmd == L"mathscr" || cmd == L"mathit") {
+            return parseArg();  // rendered as regular italic
+        }
+        if (cmd == L"displaystyle" || cmd == L"textstyle" || cmd == L"nolimits" ||
+            cmd == L"limits" || cmd == L"middle") {
+            return parseAtom();  // pass-through niladics: render what follows
+        }
+        if (isFunctionName(cmd)) {
+            MNodePtr f = mk(MNode::Sym);
+            f->text = cmd;
+            f->roman = true;
+            return f;
+        }
+        if (const wchar_t* sym = lookupSymbol(cmd)) {
+            MNodePtr s = mk(MNode::Sym);
+            s->text = sym;
+            return s;
+        }
+
+        failed = true;  // unknown command: whole span falls back to source
+        return nullptr;
+    }
+
+    static MNodePtr markRoman(MNodePtr n) {
+        n->roman = true;
+        for (auto& k : n->kids) {
+            if (k) markRoman(k);
+        }
+        for (auto& row : n->cells) for (auto& cell : row) if (cell) markRoman(cell);
+        return n;
+    }
+    static MNodePtr markBold(MNodePtr n) {
+        n->bold = true;
+        n->roman = true;
+        for (auto& k : n->kids) {
+            if (k) markBold(k);
+        }
+        for (auto& row : n->cells) for (auto& cell : row) if (cell) markBold(cell);
+        return n;
+    }
+
+    MNodePtr parseRow(wchar_t terminator, bool stopAtRight = false, bool cell = false) {
+        Nest nest(depth);
+        if (depth > 96) { failed = true; return nullptr; }
+        MNodePtr row = mk(MNode::Row);
+        while (!eof() && !failed) {
+            skipWs();
+            if (eof()) break;
+            if (terminator && peek() == terminator) break;
+            if (cell && (peek() == L'&' || src.compare(pos, 2, L"\\\\") == 0 ||
+                         atCommand(L"\\cr") || atCommand(L"\\end"))) break;
+            if (stopAtRight && peek() == L'\\' &&
+                src.compare(pos, 6, L"\\right") == 0) {
+                break;
+            }
+            if (peek() == L'^' || peek() == L'_') {
+                // Attach scripts to the previous atom (or an empty base)
+                MNodePtr base = row->kids.empty() ? mk(MNode::Row)
+                                                  : row->kids.back();
+                if (!row->kids.empty()) row->kids.pop_back();
+                MNodePtr script;
+                if (base->kind == MNode::Script) {
+                    script = base;  // x_1^m: add the second script
+                } else {
+                    script = mk(MNode::Script);
+                    script->kids = {base, nullptr, nullptr};
+                }
+                while (!eof() && (peek() == L'^' || peek() == L'_')) {
+                    wchar_t which = src[pos++];
+                    MNodePtr arg = parseArg();
+                    if (!arg) { failed = true; break; }
+                    if (which == L'^') script->kids[2] = arg;
+                    else script->kids[1] = arg;
+                    skipWs();
+                }
+                row->kids.push_back(script);
+                continue;
+            }
+            MNodePtr atom = parseAtom();
+            if (atom) row->kids.push_back(atom);
+        }
+        return row;
+    }
+};
+
+
+MNodePtr parseLatex(const std::wstring& source) {
+    if (source.size() > 32768) return nullptr;
+    Parser parser(source);
+    auto root = parser.parseRow(0);
+    return parser.failed || !root || root->kids.empty() ? nullptr : root;
+}
+
+} // namespace tinta_math

--- a/src/math_parser.h
+++ b/src/math_parser.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+// Internal, platform-independent math syntax tree.
+namespace tinta_math {
+
+struct MNode;
+using MNodePtr = std::shared_ptr<MNode>;
+
+struct MNode {
+    enum Kind {
+        Row,     // kids in sequence
+        Sym,     // text (variable, number, operator, mapped symbol)
+        Frac,    // kids = {num, den}
+        Script,  // kids = {base, sub-or-null, sup-or-null}
+        Delim,   // \left..\right, kids = {content}
+        Deco,    // kids = {content}; decoKind below
+        Space,   // explicit spacing; scale in "space"
+        Grid,    // cells by row; each cell is a complete expression
+    } kind = Row;
+
+    std::wstring text;
+    std::vector<MNodePtr> kids;
+    wchar_t open = 0, close = 0;   // Delim
+    int decoKind = 0;              // 1 overline/bar 2 overrightarrow/vec 3 sqrt 4 hat
+    bool roman = false;            // upright (functions, \mathrm, \text)
+    bool bold = false;             // \mathbf
+    float space = 0.0f;            // Space: width in em
+    std::vector<std::vector<MNodePtr>> cells;
+    std::wstring alignment;        // Grid: l/c/r per column (empty = centered)
+    bool aligned = false;          // Grid: alternating right/left equation columns
+    bool compact = false;            // Grid: smallmatrix / substack
+};
+
+
+MNodePtr parseLatex(const std::wstring& source);
+float symbolSpacing(const std::wstring& text, bool roman);
+
+} // namespace tinta_math

--- a/src/math_parser.h
+++ b/src/math_parser.h
@@ -20,6 +20,8 @@ struct MNode {
         Deco,    // kids = {content}; decoKind below
         Space,   // explicit spacing; scale in "space"
         Grid,    // cells by row; each cell is a complete expression
+        Stack,   // kids = base, below-or-null, above-or-null
+        Phantom, // invisible width/height (decoKind: 0 both, 1 horizontal, 2 vertical)
     } kind = Row;
 
     std::wstring text;
@@ -28,6 +30,15 @@ struct MNode {
     int decoKind = 0;              // 1 overline/bar 2 overrightarrow/vec 3 sqrt 4 hat
     bool roman = false;            // upright (functions, \mathrm, \text)
     bool bold = false;             // \mathbf
+    bool literalText = false;      // Preserve text-mode whitespace and punctuation
+    bool forceItalic = false;
+    float spacing = -1;            // Explicit atom spacing, otherwise inferred
+    bool largeOp = false;
+    bool limitOp = false;          // Above/below limits by default in display style
+    int limits = -1;               // -1 automatic, 0 side scripts, 1 above/below
+    int style = -1;                // -1 inherited; 0 display, 1 text, 2 script, 3 scriptscript
+    bool noBar = false;            // Frac: binomial coefficient
+    float delimiterSize = 0;       // Explicit \big family, in em
     float space = 0.0f;            // Space: width in em
     std::vector<std::vector<MNodePtr>> cells;
     std::wstring alignment;        // Grid: l/c/r per column (empty = centered)

--- a/src/math_parser.h
+++ b/src/math_parser.h
@@ -22,6 +22,7 @@ struct MNode {
         Grid,    // cells by row; each cell is a complete expression
         Stack,   // kids = base, below-or-null, above-or-null
         Phantom, // invisible width/height (decoKind: 0 both, 1 horizontal, 2 vertical)
+        Middle,  // delimiter sized by an enclosing \left ... \right
     } kind = Row;
 
     std::wstring text;
@@ -44,6 +45,9 @@ struct MNode {
     std::wstring alignment;        // Grid: l/c/r per column (empty = centered)
     bool aligned = false;          // Grid: alternating right/left equation columns
     bool compact = false;            // Grid: smallmatrix / substack
+    bool uniformAlignment = false;
+    std::vector<size_t> verticalRules;
+    std::vector<size_t> horizontalRules;
 };
 
 

--- a/src/math_render.cpp
+++ b/src/math_render.cpp
@@ -41,6 +41,7 @@ struct MathBox {
     std::vector<MathRule> rules;
     std::vector<MathLine> lines;
     float width = 0, height = 0, baseline = 0;
+    std::wstring fontFamily;
     ~MathBox() {
         for (auto& r : runs) {
             if (r.layout) r.layout->Release();
@@ -70,15 +71,34 @@ struct LayoutCtx {
     MathBox& box;
     // TeX text style vs display style: inline fractions use near-script
     // sizes so they fit the surrounding line
-    bool display = false;
+    int style = 1; // display, text, script, scriptscript
 };
+
+float styleScale(int style) {
+    return style < 2 ? 1.0f : style == 2 ? 0.7f : 0.5f;
+}
+
+std::wstring g_mathFontFamily;
+const wchar_t* mathFontFamily(App& app) {
+    if (g_mathFontFamily.empty()) {
+        g_mathFontFamily = app.theme.fontFamily ? app.theme.fontFamily : L"Segoe UI";
+        IDWriteFontCollection* fonts = nullptr;
+        if (SUCCEEDED(app.dwriteFactory->GetSystemFontCollection(&fonts))) {
+            UINT32 index = 0; BOOL exists = FALSE;
+            if (SUCCEEDED(fonts->FindFamilyName(L"Cambria Math", &index, &exists)) && exists)
+                g_mathFontFamily = L"Cambria Math";
+            fonts->Release();
+        }
+    }
+    return g_mathFontFamily.c_str();
+}
 
 IDWriteTextLayout* makeRunLayout(App& app, const std::wstring& text,
                                  float size, bool italic, bool bold,
                                  float& outBaseline, Metrics& m) {
     IDWriteTextFormat* fmt = nullptr;
     app.dwriteFactory->CreateTextFormat(
-        app.theme.fontFamily, nullptr,
+        mathFontFamily(app), nullptr,
         bold ? DWRITE_FONT_WEIGHT_SEMI_BOLD : DWRITE_FONT_WEIGHT_NORMAL,
         italic ? DWRITE_FONT_STYLE_ITALIC : DWRITE_FONT_STYLE_NORMAL,
         DWRITE_FONT_STRETCH_NORMAL, size, L"en-us", &fmt);
@@ -136,16 +156,31 @@ Metrics emitRun(LayoutCtx& ctx, const std::wstring& text, float size,
 }
 
 bool isMathVariableChar(wchar_t c) {
-    return (c >= L'a' && c <= L'z') || (c >= L'A' && c <= L'Z');
+    return (c >= L'a' && c <= L'z') || (c >= L'A' && c <= L'Z') ||
+           (c >= 0x03B1 && c <= 0x03D6) || c == 0x03F0 || c == 0x03F1 || c == 0x03F5;
+}
+
+float nodeSpacing(const MNodePtr& node) {
+    if (!node) return 0;
+    if (node->spacing >= 0) return node->spacing;
+    if (node->literalText) return 0;
+    if (node->kind == MNode::Sym) return symbolSpacing(node->text, node->roman);
+    if ((node->kind == MNode::Script || node->kind == MNode::Stack) && !node->kids.empty())
+        return nodeSpacing(node->kids[0]);
+    return 0;
 }
 
 // The workhorse: recursively lay out `node` with the baseline at
 // `baselineY`, starting at `x`. Returns the node's metrics. When
 // record=false (measure pass), nothing is emitted.
-Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
+Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
                        float x, float baselineY, bool record) {
     Metrics m;
     if (!node) return m;
+    if (node->style >= 0) {
+        size *= styleScale(node->style) / styleScale(ctx.style);
+        ctx.style = node->style;
+    }
     float em = size;
 
     switch (node->kind) {
@@ -156,10 +191,10 @@ Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
             return m;
         }
         case MNode::Sym: {
-            bool italic = !node->roman && node->text.size() >= 1 &&
-                          isMathVariableChar(node->text[0]) &&
-                          !(node->text.size() > 1 && node->roman);
-            Metrics rm = emitRun(ctx, node->text, size, italic, node->bold,
+            bool italic = node->forceItalic || (!node->roman && !node->text.empty() &&
+                          isMathVariableChar(node->text[0]));
+            float runSize = size * (node->largeOp && ctx.style == 0 ? 1.45f : 1);
+            Metrics rm = emitRun(ctx, node->text, runSize, italic, node->bold,
                                  x, baselineY, record);
             return rm;
         }
@@ -169,10 +204,9 @@ Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
             bool first = true;
             for (const auto& kid : node->kids) {
                 if (!kid) continue;
-                float kidSpace = 0.0f;
-                if (kid->kind == MNode::Sym) {
-                    kidSpace = symbolSpacing(kid->text, kid->roman) * em;
-                }
+                float kidSpace = nodeSpacing(kid) * em;
+                // A leading sign (or a sign after another operator) is unary.
+                if (nodeSpacing(kid) == 0.2f && (first || prevSpace >= em * 0.2f)) kidSpace = 0;
                 if (!first) cx += std::max(prevSpace, kidSpace);
                 Metrics km = layoutNodeImpl(ctx, kid, size, cx, baselineY, record);
                 cx += km.width;
@@ -231,11 +265,72 @@ Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
             }
             return m;
         }
+        case MNode::Phantom: {
+            m = layoutNodeImpl(ctx, node->kids[0], size, x, baselineY,
+                               record && node->decoKind == 3);
+            if (node->decoKind == 1 || node->decoKind == 3) m.ascent = m.descent = 0;
+            if (node->decoKind == 2) m.width = 0;
+            return m;
+        }
+        case MNode::Stack: {
+            LayoutCtx child = ctx;
+            child.style = std::min(3, std::max(2, ctx.style + 1));
+            float annotationSize = size * styleScale(child.style) / styleScale(ctx.style);
+            Metrics base = measureNode(ctx, node->kids[0], size);
+            Metrics below = measureNode(child, node->kids[1], annotationSize);
+            Metrics above = measureNode(child, node->kids[2], annotationSize);
+            if (node->decoKind) {
+                base.width = std::max(em * 1.6f, std::max(below.width, above.width) + em * 0.6f);
+                base.ascent = em * 0.45f; base.descent = 0;
+            }
+            m.width = std::max(base.width, std::max(below.width, above.width));
+            float gap = em * 0.12f;
+            m.ascent = base.ascent + (node->kids[2] ? gap + above.height() : 0);
+            m.descent = base.descent + (node->kids[1] ? gap + below.height() : 0);
+            if (record) {
+                if (node->decoKind) {
+                    float ay = baselineY - em * 0.26f, head = em * 0.22f;
+                    float tip = node->decoKind == 1 ? x + m.width : x;
+                    float tail = tip + (node->decoKind == 1 ? -head : head);
+                    float stroke = std::max(1.0f, em * 0.055f);
+                    ctx.box.lines.push_back({x, ay, x + m.width, ay, stroke});
+                    ctx.box.lines.push_back({tail, ay - head * 0.6f, tip, ay, stroke});
+                    ctx.box.lines.push_back({tail, ay + head * 0.6f, tip, ay, stroke});
+                } else layoutNodeImpl(ctx, node->kids[0], size, x + (m.width - base.width) / 2, baselineY, true);
+                if (node->kids[2]) layoutNodeImpl(child, node->kids[2], annotationSize,
+                    x + (m.width - above.width) / 2, baselineY - base.ascent - gap - above.descent, true);
+                if (node->kids[1]) layoutNodeImpl(child, node->kids[1], annotationSize,
+                    x + (m.width - below.width) / 2, baselineY + base.descent + gap + below.ascent, true);
+            }
+            return m;
+        }
         case MNode::Script: {
             const MNodePtr& base = node->kids[0];
             const MNodePtr& sub = node->kids[1];
             const MNodePtr& sup = node->kids[2];
-            float scriptSize = std::max(8.0f, size * 0.68f);
+            LayoutCtx child = ctx;
+            child.style = std::min(3, std::max(2, ctx.style + 1));
+            float scriptSize = size * styleScale(child.style) / styleScale(ctx.style);
+
+            bool centered = base->limits == 1 || (base->limits < 0 && base->limitOp &&
+                             (ctx.style == 0 || base->kind == MNode::Deco));
+            if (centered) {
+                Metrics bm = measureNode(ctx, base, size);
+                Metrics sm = measureNode(child, sub, scriptSize);
+                Metrics tm = measureNode(child, sup, scriptSize);
+                m.width = std::max(bm.width, std::max(sm.width, tm.width));
+                float gap = em * 0.16f;
+                m.ascent = bm.ascent + (sup ? gap + tm.height() : 0);
+                m.descent = bm.descent + (sub ? gap + sm.height() : 0);
+                if (record) {
+                    layoutNodeImpl(ctx, base, size, x + (m.width - bm.width) / 2, baselineY, true);
+                    if (sup) layoutNodeImpl(child, sup, scriptSize, x + (m.width - tm.width) / 2,
+                                            baselineY - bm.ascent - gap - tm.descent, true);
+                    if (sub) layoutNodeImpl(child, sub, scriptSize, x + (m.width - sm.width) / 2,
+                                            baselineY + bm.descent + gap + sm.ascent, true);
+                }
+                return m;
+            }
 
             Metrics bm = layoutNodeImpl(ctx, base, size, x, baselineY, record);
             float sx = x + bm.width + em * 0.03f;
@@ -244,11 +339,11 @@ Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
 
             Metrics supM, subM;
             if (sup) {
-                supM = layoutNodeImpl(ctx, sup, scriptSize, sx,
+                supM = layoutNodeImpl(child, sup, scriptSize, sx,
                                       baselineY - supShift, record);
             }
             if (sub) {
-                subM = layoutNodeImpl(ctx, sub, scriptSize, sx,
+                subM = layoutNodeImpl(child, sub, scriptSize, sx,
                                       baselineY + subShift, record);
             }
             m.width = bm.width + em * 0.03f + std::max(supM.width, subM.width);
@@ -257,25 +352,27 @@ Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
             return m;
         }
         case MNode::Frac: {
-            float inner = std::max(8.0f, size * (ctx.display ? 0.92f : 0.72f));
-            Metrics num = measureNode(ctx, node->kids[0], inner);
-            Metrics den = measureNode(ctx, node->kids[1], inner);
+            LayoutCtx child = ctx;
+            child.style = std::min(3, ctx.style + 1);
+            float inner = size * styleScale(child.style) / styleScale(ctx.style);
+            Metrics num = measureNode(child, node->kids[0], inner);
+            Metrics den = measureNode(child, node->kids[1], inner);
             float pad = em * 0.12f;
             float ruleW = std::max(num.width, den.width) + pad * 2;
-            float ruleH = std::max(1.0f, em * 0.055f);
+            float ruleH = node->noBar ? 0 : std::max(1.0f, em * 0.055f);
             float axis = em * 0.26f;   // fraction line sits on the math axis
-            float gap = em * (ctx.display ? 0.14f : 0.1f);
+            float gap = em * (ctx.style == 0 ? 0.14f : 0.1f);
 
             float ruleY = baselineY - axis - ruleH / 2;
             if (record) {
                 // numerator baseline so its descent clears the rule
-                layoutNodeImpl(ctx, node->kids[0], inner,
+                layoutNodeImpl(child, node->kids[0], inner,
                                x + pad + (ruleW - 2 * pad - num.width) / 2,
                                ruleY - gap - num.descent, true);
-                layoutNodeImpl(ctx, node->kids[1], inner,
+                layoutNodeImpl(child, node->kids[1], inner,
                                x + pad + (ruleW - 2 * pad - den.width) / 2,
                                ruleY + ruleH + gap + den.ascent, true);
-                ctx.box.rules.push_back({x, ruleY, ruleW, ruleH});
+                if (!node->noBar) ctx.box.rules.push_back({x, ruleY, ruleW, ruleH});
             }
             m.width = ruleW;
             m.ascent = axis + ruleH / 2 + gap + num.height();
@@ -383,39 +480,94 @@ Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
         case MNode::Deco: {
             if (node->decoKind == 3) {  // sqrt
                 Metrics cm = measureNode(ctx, node->kids[0], size);
-                float radSize = size * std::min(
-                    3.0f, std::max(1.0f, cm.height() / em));
-                Metrics rm;
-                float bl = 0;
-                float gap = em * 0.1f;
-                float ruleH = std::max(1.0f, em * 0.05f);
-                IDWriteTextLayout* rad = makeRunLayout(
-                    ctx.app, L"\u221A", radSize, false, false, bl, rm);
-                float cx = x;
-                if (rad) {
-                    if (record) {
-                        float radTop = baselineY - cm.ascent - gap - ruleH -
-                                       (rm.height() - (cm.height() + gap + ruleH)) * 0.5f;
-                        // anchor: radical bottom near content bottom
-                        radTop = baselineY + cm.descent - rm.height();
-                        ctx.box.runs.push_back({rad, cx, radTop,
-                                                std::wstring(L"\u221A"),
-                                                radSize, false, false, bl});
-                    } else {
-                        rad->Release();
-                    }
-                    cx += rm.width * 0.95f;
-                }
-                Metrics inner = layoutNodeImpl(ctx, node->kids[0], size, cx,
-                                               baselineY, record);
+                LayoutCtx child = ctx; child.style = 3;
+                float indexSize = size * styleScale(3) / styleScale(ctx.style);
+                MNodePtr index = node->kids.size() > 1 ? node->kids[1] : nullptr;
+                Metrics im = measureNode(child, index, indexSize);
+                float indexWidth = index ? std::max(0.0f, im.width - em * 0.15f) : 0;
+                float start = x + indexWidth;
+                float cx = start + em * 0.65f;
+                float top = baselineY - cm.ascent - em * 0.14f;
+                float bottom = baselineY + cm.descent;
+                float stroke = std::max(1.0f, em * 0.055f);
+                float indexBaseline = top + em * 0.25f;
                 if (record) {
-                    ctx.box.rules.push_back(
-                        {cx - em * 0.05f, baselineY - cm.ascent - gap - ruleH,
-                         inner.width + em * 0.15f, ruleH});
+                    layoutNodeImpl(ctx, node->kids[0], size, cx, baselineY, true);
+                    if (index) layoutNodeImpl(child, index, indexSize, x, indexBaseline, true);
+                    float shoulder = bottom - std::min(cm.height() * 0.4f, em * 0.45f);
+                    ctx.box.lines.push_back({start, shoulder + em * 0.06f, start + em * 0.16f, shoulder, stroke});
+                    ctx.box.lines.push_back({start + em * 0.16f, shoulder, start + em * 0.33f, bottom, stroke});
+                    ctx.box.lines.push_back({start + em * 0.33f, bottom, cx - em * 0.06f, top, stroke});
+                    ctx.box.lines.push_back({cx - em * 0.06f, top, cx + cm.width + em * 0.1f, top, stroke});
                 }
-                m.width = (cx - x) + inner.width + em * 0.15f;
-                m.ascent = cm.ascent + gap + ruleH + em * 0.05f;
-                m.descent = cm.descent;
+                m.width = cx - x + cm.width + em * 0.1f;
+                m.ascent = std::max(baselineY - top + stroke / 2,
+                                    index ? baselineY - indexBaseline + im.ascent : 0);
+                m.descent = cm.descent + stroke / 2;
+                return m;
+            }
+            if (node->decoKind >= 5) {
+                Metrics cm = measureNode(ctx, node->kids[0], size);
+                int kind = node->decoKind;
+                float pad = kind == 9 ? em * 0.2f : 0;
+                m = cm; m.width += 2 * pad;
+                float stroke = std::max(1.0f, em * 0.055f);
+                float top = baselineY - cm.ascent, bottom = baselineY + cm.descent;
+                bool under = kind == 8 || kind == 13;
+                bool overlay = kind == 10 || kind == 11 || kind == 18 || kind == 19;
+                float extra = overlay ? 0 : (kind == 12 || kind == 13 ? em * 0.45f : em * 0.3f);
+                if (under) m.descent += extra; else m.ascent += extra;
+                if (kind == 9) m.descent += extra;
+                if (record) {
+                    layoutNodeImpl(ctx, node->kids[0], size, x + pad, baselineY, true);
+                    auto line = [&](float x1, float y1, float x2, float y2) {
+                        ctx.box.lines.push_back({x1, y1, x2, y2, stroke});
+                    };
+                    float center = x + m.width / 2;
+                    if (kind == 5 || kind == 6) {
+                        float dot = em * 0.1f, y = top - em * 0.2f;
+                        if (kind == 5) ctx.box.rules.push_back({center - dot / 2, y, dot, dot});
+                        else {
+                            ctx.box.rules.push_back({center - em * 0.16f, y, dot, dot});
+                            ctx.box.rules.push_back({center + em * 0.06f, y, dot, dot});
+                        }
+                    } else if (kind == 7 || kind == 16) {
+                        float w = kind == 16 ? std::min(cm.width, em * 0.55f) : cm.width;
+                        float prevX = center - w / 2;
+                        float prevY = top - em * 0.17f;
+                        for (int i = 1; i <= 16; ++i) {
+                            float t = static_cast<float>(i) / 16;
+                            float nx = center - w / 2 + w * t;
+                            float ny = top - em * 0.17f + em * 0.07f * std::sin(t * (kind == 7 ? -6.2831853f : 3.14159265f));
+                            line(prevX, prevY, nx, ny); prevX = nx; prevY = ny;
+                        }
+                    } else if (kind == 8) line(x, bottom + em * 0.12f, x + cm.width, bottom + em * 0.12f);
+                    else if (kind == 9) {
+                        float y1 = top - pad, y2 = bottom + pad;
+                        line(x, y1, x + m.width, y1); line(x, y2, x + m.width, y2);
+                        line(x, y1, x, y2); line(x + m.width, y1, x + m.width, y2);
+                    } else if (overlay) {
+                        if (kind != 11) line(x, bottom, x + cm.width, top);
+                        if (kind == 11 || kind == 19) line(x, top, x + cm.width, bottom);
+                    } else if (kind == 12 || kind == 13) {
+                        float sign = under ? 1.0f : -1.0f;
+                        float y = under ? bottom + em * 0.12f : top - em * 0.12f;
+                        float h = em * 0.18f;
+                        line(x, y, x + em * 0.15f, y + sign * h);
+                        line(x + em * 0.15f, y + sign * h, center - em * 0.15f, y + sign * h);
+                        line(center - em * 0.15f, y + sign * h, center, y + sign * h * 1.5f);
+                        line(center, y + sign * h * 1.5f, center + em * 0.15f, y + sign * h);
+                        line(center + em * 0.15f, y + sign * h, x + cm.width - em * 0.15f, y + sign * h);
+                        line(x + cm.width - em * 0.15f, y + sign * h, x + cm.width, y);
+                    } else if (kind == 17) {
+                        line(center - em * 0.18f, top - em * 0.25f, center, top - em * 0.1f);
+                        line(center, top - em * 0.1f, center + em * 0.18f, top - em * 0.25f);
+                    } else {
+                        float sign = kind == 14 ? 1.0f : -1.0f;
+                        line(center - sign * em * 0.1f, top - em * 0.1f,
+                             center + sign * em * 0.1f, top - em * 0.27f);
+                    }
+                }
                 return m;
             }
             // overline / overrightarrow / hat
@@ -485,9 +637,10 @@ MathBoxPtr mathParse(App& app, const std::wstring& latex, float fontSize,
     }
 
     auto box = std::make_shared<MathBox>();
-    LayoutCtx ctx{app, *box, display};
+    box->fontFamily = mathFontFamily(app);
+    LayoutCtx ctx{app, *box, display ? 0 : 1};
     Metrics probe = measureNode(ctx, root, fontSize);
-    float pad = display ? fontSize * 0.15f : 0.0f;
+    float pad = fontSize * (display ? 0.15f : 0.08f);
     float baseline = probe.ascent + pad;
     Metrics final = layoutNode(ctx, root, fontSize, pad, baseline);
     box->width = final.width + pad * 2;
@@ -563,6 +716,7 @@ void mathBoxRetain(App& app, const MathBoxPtr& box, float x, float y,
 
 void mathClearCache() {
     g_mathCache.clear();
+    g_mathFontFamily.clear();
 }
 
 // --- SVG export (#export_as) ---
@@ -623,8 +777,8 @@ std::string mathBoxSvg(const MathBoxPtr& box, const std::string& colorCss,
     for (const auto& r : box->runs) {
         s += "<text x=\"" + svgNum(r.x) + "\" y=\"" +
              svgNum(r.y + r.baseline) + "\" font-size=\"" + svgNum(r.size) +
-             "\" font-family=\"" + fontFamilyCss + "\" fill=\"" + colorCss +
-             "\"";
+             "\" font-family=\"" + (box->fontFamily.empty() ? fontFamilyCss : svgEscape(svgUtf8(box->fontFamily))) +
+             "\" fill=\"" + colorCss + "\" xml:space=\"preserve\"";
         if (r.italic) s += " font-style=\"italic\"";
         if (r.bold) s += " font-weight=\"bold\"";
         s += ">" + svgEscape(svgUtf8(r.text)) + "</text>";

--- a/src/math_render.cpp
+++ b/src/math_render.cpp
@@ -72,6 +72,7 @@ struct LayoutCtx {
     // TeX text style vs display style: inline fractions use near-script
     // sizes so they fit the surrounding line
     int style = 1; // display, text, script, scriptscript
+    float delimiterHeight = 0;
 };
 
 float styleScale(int style) {
@@ -185,7 +186,7 @@ Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
 
     switch (node->kind) {
         case MNode::Space: {
-            m.width = node->space * em;
+            m.width = node->space * (node->text == L"pt" ? 96.0f / 72 : node->text == L"px" ? 1.0f : em);
             m.ascent = 0;
             m.descent = 0;
             return m;
@@ -218,8 +219,34 @@ Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
             m.width = cx - x;
             return m;
         }
+        case MNode::Middle: {
+            if (!node->open) return m;
+            float height = node->delimiterSize > 0 ? node->delimiterSize * em : std::max(em, ctx.delimiterHeight);
+            float center = baselineY - em * 0.26f;
+            if (node->open == L'|' || node->open == L'\u2016' || node->open == L'\u2223' || node->open == L'\u2225') {
+                m.width = em * 0.3f;
+                m.ascent = height / 2 + em * 0.26f; m.descent = height / 2 - em * 0.26f;
+                if (record) {
+                    float stroke = std::max(1.0f, em * 0.055f);
+                    ctx.box.lines.push_back({x + em * 0.1f, center - height / 2, x + em * 0.1f, center + height / 2, stroke});
+                    if (node->open != L'|' && node->open != L'\u2223')
+                        ctx.box.lines.push_back({x + em * 0.25f, center - height / 2, x + em * 0.25f, center + height / 2, stroke});
+                }
+                return m;
+            }
+            std::wstring text(1, node->open);
+            Metrics glyph = emitRun(ctx, text, height, false, false, 0, 0, false);
+            m.width = glyph.width;
+            m.ascent = glyph.height() / 2 + em * 0.26f;
+            m.descent = std::max(0.0f, glyph.height() / 2 - em * 0.26f);
+            if (record) emitRun(ctx, text, height, false, false, x,
+                                center + (glyph.ascent - glyph.descent) / 2, true);
+            return m;
+        }
         case MNode::Grid: {
-            float cellSize = node->compact ? size * 0.7f : size;
+            LayoutCtx cellCtx = ctx;
+            cellCtx.style = node->compact ? std::max(2, ctx.style) : std::max(1, ctx.style);
+            float cellSize = size * styleScale(cellCtx.style) / styleScale(ctx.style);
             size_t columns = node->alignment.size();
             for (const auto& row : node->cells) columns = std::max(columns, row.size());
             if (!columns || node->cells.empty()) return m;
@@ -231,7 +258,7 @@ Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
                 float ascent = cellSize * 0.8f, descent = cellSize * 0.2f;
                 std::vector<Metrics> measured;
                 for (size_t col = 0; col < row.size(); ++col) {
-                    Metrics cm = measureNode(ctx, row[col], cellSize);
+                    Metrics cm = measureNode(cellCtx, row[col], cellSize);
                     widths[col] = std::max(widths[col], cm.width);
                     ascent = std::max(ascent, cm.ascent);
                     descent = std::max(descent, cm.descent);
@@ -242,6 +269,8 @@ Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
                 cells.push_back(std::move(measured));
             }
             totalHeight += rowGap * static_cast<float>(cells.size() - 1);
+            float cellPadding = node->verticalRules.empty() ? 0 : cellSize * 0.2f;
+            for (auto& width : widths) width += cellPadding * 2;
             m.ascent = totalHeight / 2 + em * 0.26f;
             m.descent = totalHeight - m.ascent;
             float top = baselineY - m.ascent;
@@ -249,11 +278,12 @@ Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
                 float cx = x;
                 for (size_t col = 0; col < columns; ++col) {
                     wchar_t align = node->aligned ? (col % 2 ? L'l' : L'r') : L'c';
-                    if (col < node->alignment.size()) align = node->alignment[col];
+                    if (node->uniformAlignment) align = node->alignment.front();
+                    else if (col < node->alignment.size()) align = node->alignment[col];
                     if (col < cells[row].size() && record) {
-                        float extra = widths[col] - cells[row][col].width;
-                        float offset = align == L'r' ? extra : align == L'c' ? extra / 2 : 0;
-                        layoutNodeImpl(ctx, node->cells[row][col], cellSize,
+                        float extra = widths[col] - cells[row][col].width - 2 * cellPadding;
+                        float offset = cellPadding + (align == L'r' ? extra : align == L'c' ? extra / 2 : 0);
+                        layoutNodeImpl(cellCtx, node->cells[row][col], cellSize,
                                        cx + offset, top + ascents[row], true);
                     }
                     cx += widths[col];
@@ -262,6 +292,26 @@ Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
                 }
                 m.width = std::max(m.width, cx - x);
                 top += ascents[row] + descents[row] + rowGap;
+            }
+            if (record) {
+                float stroke = std::max(1.0f, em * 0.045f);
+                float y1 = baselineY - m.ascent, y2 = baselineY + m.descent;
+                for (size_t boundary : node->verticalRules) {
+                    float dx = x;
+                    for (size_t col = 0; col < boundary && col < columns; ++col) {
+                        dx += widths[col];
+                        if (col + 1 < columns) dx += cellSize * (col + 1 == boundary ? 0.5f : 1.0f);
+                    }
+                    ctx.box.lines.push_back({dx, y1, dx, y2, stroke});
+                }
+                for (size_t boundary : node->horizontalRules) {
+                    float dy = y1;
+                    for (size_t row = 0; row < boundary && row < cells.size(); ++row) {
+                        dy += ascents[row] + descents[row];
+                        if (row + 1 < cells.size()) dy += rowGap * (row + 1 == boundary ? 0.5f : 1.0f);
+                    }
+                    ctx.box.lines.push_back({x, dy, x + m.width, dy, stroke});
+                }
             }
             return m;
         }
@@ -381,7 +431,9 @@ Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
             return m;
         }
         case MNode::Delim: {
+            ctx.delimiterHeight = 0;
             Metrics cm = measureNode(ctx, node->kids[0], size);
+            ctx.delimiterHeight = cm.height();
             // Tall common delimiters use native strokes at a constant width.
             // Increasing the font size also widens glyphs, and used to cap
             // brackets at 3.5 em, leaving large matrices unenclosed.

--- a/src/math_render.cpp
+++ b/src/math_render.cpp
@@ -637,16 +637,16 @@ Metrics layoutNodeImpl(LayoutCtx ctx, const MNodePtr& node, float size,
                     float ay = topY + ruleH / 2;
                     ctx.box.rules.push_back({x, topY, cm.width, ruleH});
                     ctx.box.lines.push_back(
-                        {x + cm.width - aw, ay - aw * 0.6f, x + cm.width, ay});
+                        {x + cm.width - aw, ay - aw * 0.6f, x + cm.width, ay, ruleH});
                     ctx.box.lines.push_back(
-                        {x + cm.width - aw, ay + aw * 0.6f, x + cm.width, ay});
+                        {x + cm.width - aw, ay + aw * 0.6f, x + cm.width, ay, ruleH});
                 } else if (node->decoKind == 4) {
                     float cxm = x + cm.width / 2;
                     float hw = std::min(cm.width / 2, em * 0.28f);
                     ctx.box.lines.push_back(
-                        {cxm - hw, topY + ruleH + em * 0.08f, cxm, topY});
+                        {cxm - hw, topY + ruleH + em * 0.08f, cxm, topY, ruleH});
                     ctx.box.lines.push_back(
-                        {cxm, topY, cxm + hw, topY + ruleH + em * 0.08f});
+                        {cxm, topY, cxm + hw, topY + ruleH + em * 0.08f, ruleH});
                 }
             }
             m.width = std::max(inner.width, cm.width);
@@ -706,6 +706,13 @@ MathBoxPtr mathParse(App& app, const std::wstring& latex, float fontSize,
 float mathBoxWidth(const MathBoxPtr& box) { return box ? box->width : 0; }
 float mathBoxHeight(const MathBoxPtr& box) { return box ? box->height : 0; }
 float mathBoxBaseline(const MathBoxPtr& box) { return box ? box->baseline : 0; }
+
+void mathExpandLine(const MathBoxPtr& box, float textBaseline, float lineHeight,
+                    float& above, float& below) {
+    if (!box) return;
+    above = std::max(above, box->baseline - textBaseline);
+    below = std::max(below, box->height - box->baseline + textBaseline - lineHeight);
+}
 
 void mathBoxDrawTo(ID2D1RenderTarget* target, ID2D1SolidColorBrush* brush,
                    const MathBoxPtr& box, float x, float y,

--- a/src/math_render.cpp
+++ b/src/math_render.cpp
@@ -1,4 +1,5 @@
 #include "math_render.h"
+#include "math_parser.h"
 
 #include <algorithm>
 #include <cmath>
@@ -30,6 +31,7 @@ struct MathRule {   // fraction bars, overlines, radical bars
 
 struct MathLine {   // arrowheads
     float x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+    float thickness = 1.2f;
 };
 
 } // namespace
@@ -52,427 +54,7 @@ namespace {
 // Parse tree
 // ---------------------------------------------------------------------------
 
-struct MNode;
-using MNodePtr = std::shared_ptr<MNode>;
-
-struct MNode {
-    enum Kind {
-        Row,     // kids in sequence
-        Sym,     // text (variable, number, operator, mapped symbol)
-        Frac,    // kids = {num, den}
-        Script,  // kids = {base, sub-or-null, sup-or-null}
-        Delim,   // \left..\right, kids = {content}
-        Deco,    // kids = {content}; decoKind below
-        Space,   // explicit spacing; scale in "space"
-    } kind = Row;
-
-    std::wstring text;
-    std::vector<MNodePtr> kids;
-    wchar_t open = 0, close = 0;   // Delim
-    int decoKind = 0;              // 1 overline/bar 2 overrightarrow/vec 3 sqrt 4 hat
-    bool roman = false;            // upright (functions, \mathrm, \text)
-    bool bold = false;             // \mathbf
-    float space = 0.0f;            // Space: width in em
-};
-
-MNodePtr mk(MNode::Kind k) {
-    auto n = std::make_shared<MNode>();
-    n->kind = k;
-    return n;
-}
-
-// ---------------------------------------------------------------------------
-// Command tables
-// ---------------------------------------------------------------------------
-
-struct CmdSym { const wchar_t* name; const wchar_t* text; };
-
-// Symbols and greek letters mapped straight to Unicode text runs
-const CmdSym kSymbols[] = {
-    {L"alpha", L"\u03B1"}, {L"beta", L"\u03B2"}, {L"gamma", L"\u03B3"},
-    {L"delta", L"\u03B4"}, {L"epsilon", L"\u03B5"}, {L"varepsilon", L"\u03B5"},
-    {L"zeta", L"\u03B6"}, {L"eta", L"\u03B7"}, {L"theta", L"\u03B8"},
-    {L"vartheta", L"\u03D1"}, {L"iota", L"\u03B9"}, {L"kappa", L"\u03BA"},
-    {L"lambda", L"\u03BB"}, {L"mu", L"\u03BC"}, {L"nu", L"\u03BD"},
-    {L"xi", L"\u03BE"}, {L"pi", L"\u03C0"}, {L"rho", L"\u03C1"},
-    {L"sigma", L"\u03C3"}, {L"tau", L"\u03C4"}, {L"upsilon", L"\u03C5"},
-    {L"phi", L"\u03C6"}, {L"varphi", L"\u03C6"}, {L"chi", L"\u03C7"},
-    {L"psi", L"\u03C8"}, {L"omega", L"\u03C9"},
-    {L"Gamma", L"\u0393"}, {L"Delta", L"\u0394"}, {L"Theta", L"\u0398"},
-    {L"Lambda", L"\u039B"}, {L"Xi", L"\u039E"}, {L"Pi", L"\u03A0"},
-    {L"Sigma", L"\u03A3"}, {L"Upsilon", L"\u03A5"}, {L"Phi", L"\u03A6"},
-    {L"Psi", L"\u03A8"}, {L"Omega", L"\u03A9"},
-    {L"in", L"\u2208"}, {L"notin", L"\u2209"}, {L"ni", L"\u220B"},
-    {L"cup", L"\u222A"}, {L"cap", L"\u2229"},
-    {L"subset", L"\u2282"}, {L"supset", L"\u2283"},
-    {L"subseteq", L"\u2286"}, {L"supseteq", L"\u2287"},
-    {L"geq", L"\u2265"}, {L"ge", L"\u2265"}, {L"leq", L"\u2264"},
-    {L"le", L"\u2264"}, {L"neq", L"\u2260"}, {L"ne", L"\u2260"},
-    {L"equiv", L"\u2261"}, {L"approx", L"\u2248"}, {L"sim", L"\u223C"},
-    {L"propto", L"\u221D"}, {L"pm", L"\u00B1"}, {L"mp", L"\u2213"},
-    {L"times", L"\u00D7"}, {L"div", L"\u00F7"}, {L"cdot", L"\u22C5"},
-    {L"cdots", L"\u22EF"}, {L"ldots", L"\u2026"}, {L"dots", L"\u2026"},
-    {L"vdots", L"\u22EE"}, {L"ddots", L"\u22F1"},
-    {L"mid", L"\u2223"}, {L"parallel", L"\u2225"}, {L"perp", L"\u22A5"},
-    {L"angle", L"\u2220"}, {L"triangle", L"\u25B3"},
-    {L"bigtriangleup", L"\u25B3"}, {L"square", L"\u25A1"},
-    {L"infty", L"\u221E"}, {L"partial", L"\u2202"}, {L"nabla", L"\u2207"},
-    {L"forall", L"\u2200"}, {L"exists", L"\u2203"},
-    {L"emptyset", L"\u2205"}, {L"varnothing", L"\u2205"},
-    {L"because", L"\u2235"}, {L"therefore", L"\u2234"},
-    {L"to", L"\u2192"}, {L"rightarrow", L"\u2192"},
-    {L"leftarrow", L"\u2190"}, {L"Rightarrow", L"\u21D2"},
-    {L"Leftarrow", L"\u21D0"}, {L"Leftrightarrow", L"\u21D4"},
-    {L"leftrightarrow", L"\u2194"}, {L"mapsto", L"\u21A6"},
-    {L"circ", L"\u2218"}, {L"bullet", L"\u2219"}, {L"star", L"\u22C6"},
-    {L"oplus", L"\u2295"}, {L"otimes", L"\u2297"},
-    {L"sum", L"\u2211"}, {L"prod", L"\u220F"}, {L"int", L"\u222B"},
-    {L"oint", L"\u222E"}, {L"sqrt", nullptr},  // structural, handled apart
-    {L"prime", L"\u2032"}, {L"degree", L"\u00B0"},
-    {L"lfloor", L"\u230A"}, {L"rfloor", L"\u230B"},
-    {L"lceil", L"\u2308"}, {L"rceil", L"\u2309"},
-    {L"langle", L"\u27E8"}, {L"rangle", L"\u27E9"},
-    {L"lbrack", L"["}, {L"rbrack", L"]"},
-    {L"lbrace", L"{"}, {L"rbrace", L"}"},
-    {L"lvert", L"|"}, {L"rvert", L"|"}, {L"vert", L"|"},
-    {L"lVert", L"\u2016"}, {L"rVert", L"\u2016"}, {L"Vert", L"\u2016"},
-    {L"backslash", L"\\"}, {L"setminus", L"\u2216"},
-    {L"hbar", L"\u210F"}, {L"ell", L"\u2113"}, {L"Re", L"\u211C"},
-    {L"Im", L"\u2111"}, {L"aleph", L"\u2135"}, {L"wp", L"\u2118"},
-    {L"neg", L"\u00AC"}, {L"lnot", L"\u00AC"},
-    {L"land", L"\u2227"}, {L"wedge", L"\u2227"},
-    {L"lor", L"\u2228"}, {L"vee", L"\u2228"},
-};
-
-// Function names rendered upright with a trailing thin space
-const wchar_t* kFunctions[] = {
-    L"log", L"ln", L"lg", L"sin", L"cos", L"tan", L"cot", L"sec", L"csc",
-    L"arcsin", L"arccos", L"arctan", L"sinh", L"cosh", L"tanh", L"coth",
-    L"lim", L"limsup", L"liminf", L"max", L"min", L"sup", L"inf",
-    L"gcd", L"det", L"dim", L"ker", L"deg", L"arg", L"exp", L"mod", L"Pr",
-};
-
-// \mathbb single letters -> double-struck
-const CmdSym kBlackboard[] = {
-    {L"R", L"\u211D"}, {L"N", L"\u2115"}, {L"Z", L"\u2124"},
-    {L"Q", L"\u211A"}, {L"C", L"\u2102"}, {L"P", L"\u2119"},
-    {L"E", L"\U0001D53C"}, {L"F", L"\U0001D53D"},
-};
-
-const wchar_t* lookupSymbol(const std::wstring& cmd) {
-    for (const auto& s : kSymbols) {
-        if (cmd == s.name) return s.text;
-    }
-    return nullptr;
-}
-
-bool isFunctionName(const std::wstring& cmd) {
-    for (const auto* f : kFunctions) {
-        if (cmd == f) return true;
-    }
-    return false;
-}
-
-// Spacing classes for row layout (fractions of an em on each side)
-float symbolSpacing(const std::wstring& t, bool roman) {
-    if (t.size() != 1) {
-        if (t == L"\u22EF" || t == L"\u2026") return 0.16f;
-        // Upright function names (sin, log, ...) take thin spaces so
-        // \sin m\alpha reads "sin m\u03B1" rather than "sinm\u03B1"
-        if (roman) {
-            bool allAlpha = true;
-            for (wchar_t c : t) {
-                if (!iswalpha(c)) { allAlpha = false; break; }
-            }
-            if (allAlpha) return 0.16f;
-        }
-        return 0.0f;
-    }
-    wchar_t c = t[0];
-    switch (c) {
-        case L'=': case L'<': case L'>':
-        case 0x2264: case 0x2265: case 0x2260: case 0x2261: case 0x2248:
-        case 0x2208: case 0x2209: case 0x2282: case 0x2283: case 0x2286:
-        case 0x2287: case 0x2192: case 0x21D2: case 0x2194: case 0x21D4:
-        case 0x223C: case 0x221D: case 0x2223: case 0x2225:
-            return 0.26f;   // relations
-        case L'+': case 0x2212: case 0x00B1: case 0x2213: case 0x00D7:
-        case 0x00F7: case 0x22C5: case 0x222A: case 0x2229: case 0x2227:
-        case 0x2228: case 0x2216:
-            return 0.2f;    // binary operators
-        case L',': case L';':
-            return 0.12f;   // punctuation (space after only, approximated)
-        default:
-            return 0.0f;
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Tokenizer + parser
-// ---------------------------------------------------------------------------
-
-struct Parser {
-    const std::wstring& src;
-    size_t pos = 0;
-    bool failed = false;
-
-    explicit Parser(const std::wstring& s) : src(s) {}
-
-    void skipWs() {
-        while (pos < src.size() && iswspace(src[pos])) pos++;
-    }
-    bool eof() { return pos >= src.size(); }
-    wchar_t peek() { return pos < src.size() ? src[pos] : 0; }
-
-    std::wstring readCommand() {  // after the backslash
-        std::wstring cmd;
-        while (pos < src.size() && iswalpha(src[pos])) cmd += src[pos++];
-        if (cmd.empty() && pos < src.size()) cmd += src[pos++];  // \{ \, etc.
-        return cmd;
-    }
-
-    // One brace group or a single atom (TeX: \frac ab == \frac{a}{b})
-    MNodePtr parseArg() {
-        skipWs();
-        if (peek() == L'{') {
-            pos++;
-            MNodePtr row = parseRow(L'}');
-            if (peek() == L'}') pos++;
-            else failed = true;
-            return row;
-        }
-        return parseAtom();
-    }
-
-    MNodePtr parseAtom() {
-        skipWs();
-        if (eof()) return nullptr;
-        wchar_t c = src[pos];
-
-        if (c == L'{') {
-            pos++;
-            MNodePtr row = parseRow(L'}');
-            if (peek() == L'}') pos++;
-            else failed = true;
-            return row;
-        }
-        if (c == L'\\') {
-            pos++;
-            return parseCommand();
-        }
-        pos++;
-        MNodePtr sym = mk(MNode::Sym);
-        if (c == L'-') sym->text = L"\u2212";       // proper minus
-        else if (c == L'\'') sym->text = L"\u2032"; // prime
-        else if (c == L'*') sym->text = L"\u2217";
-        else sym->text.assign(1, c);
-        return sym;
-    }
-
-    MNodePtr parseCommand() {
-        std::wstring cmd = readCommand();
-        if (cmd.empty()) { failed = true; return nullptr; }
-
-        // Escapes and explicit spacing
-        if (cmd == L"{" || cmd == L"}" || cmd == L"$" || cmd == L"%" ||
-            cmd == L"&" || cmd == L"#" || cmd == L"_") {
-            MNodePtr s = mk(MNode::Sym);
-            s->text = cmd;
-            return s;
-        }
-        if (cmd == L"|") {
-            MNodePtr s = mk(MNode::Sym);
-            s->text = L"\u2016";
-            return s;
-        }
-        if (cmd == L"," || cmd == L":" || cmd == L";" || cmd == L" " ||
-            cmd == L"quad" || cmd == L"qquad" || cmd == L"!") {
-            MNodePtr s = mk(MNode::Space);
-            if (cmd == L",") s->space = 0.17f;
-            else if (cmd == L":") s->space = 0.22f;
-            else if (cmd == L";") s->space = 0.28f;
-            else if (cmd == L" ") s->space = 0.33f;
-            else if (cmd == L"quad") s->space = 1.0f;
-            else if (cmd == L"qquad") s->space = 2.0f;
-            else s->space = 0.0f;  // \! ignored (negative space)
-            return s;
-        }
-
-        if (cmd == L"frac" || cmd == L"dfrac" || cmd == L"tfrac") {
-            MNodePtr f = mk(MNode::Frac);
-            f->kids.push_back(parseArg());
-            f->kids.push_back(parseArg());
-            if (!f->kids[0] || !f->kids[1]) failed = true;
-            return f;
-        }
-        if (cmd == L"sqrt") {
-            MNodePtr d = mk(MNode::Deco);
-            d->decoKind = 3;
-            d->kids.push_back(parseArg());
-            if (!d->kids[0]) failed = true;
-            return d;
-        }
-        if (cmd == L"overline" || cmd == L"bar") {
-            MNodePtr d = mk(MNode::Deco);
-            d->decoKind = 1;
-            d->kids.push_back(parseArg());
-            return d;
-        }
-        if (cmd == L"overrightarrow" || cmd == L"vec") {
-            MNodePtr d = mk(MNode::Deco);
-            d->decoKind = 2;
-            d->kids.push_back(parseArg());
-            return d;
-        }
-        if (cmd == L"hat" || cmd == L"widehat") {
-            MNodePtr d = mk(MNode::Deco);
-            d->decoKind = 4;
-            d->kids.push_back(parseArg());
-            return d;
-        }
-        if (cmd == L"left") {
-            skipWs();
-            wchar_t open = 0;
-            if (peek() == L'\\') {
-                pos++;
-                std::wstring dc = readCommand();
-                const wchar_t* mapped = lookupSymbol(dc);
-                open = mapped && mapped[0] ? mapped[0] : 0;
-                if (dc == L"{") open = L'{';
-                if (dc == L"}") open = L'}';
-            } else {
-                open = peek();
-                if (!eof()) pos++;
-            }
-            MNodePtr content = parseRow(0, /*stopAtRight=*/true);
-            // consume \right and its delimiter
-            wchar_t close = 0;
-            if (pos + 5 < src.size() && src.compare(pos, 6, L"\\right") == 0) {
-                pos += 6;
-                skipWs();
-                if (peek() == L'\\') {
-                    pos++;
-                    std::wstring dc = readCommand();
-                    const wchar_t* mapped = lookupSymbol(dc);
-                    close = mapped && mapped[0] ? mapped[0] : 0;
-                    if (dc == L"{") close = L'{';
-                    if (dc == L"}") close = L'}';
-                } else {
-                    close = peek();
-                    if (!eof()) pos++;
-                }
-            } else {
-                failed = true;
-            }
-            MNodePtr d = mk(MNode::Delim);
-            d->open = open == L'.' ? 0 : open;
-            d->close = close == L'.' ? 0 : close;
-            d->kids.push_back(content ? content : mk(MNode::Row));
-            return d;
-        }
-        if (cmd == L"mathrm" || cmd == L"text" || cmd == L"operatorname" ||
-            cmd == L"textrm") {
-            MNodePtr arg = parseArg();
-            if (arg) arg = markRoman(arg);
-            return arg;
-        }
-        if (cmd == L"mathbf" || cmd == L"boldsymbol" || cmd == L"bm" ||
-            cmd == L"textbf") {
-            MNodePtr arg = parseArg();
-            if (arg) arg = markBold(arg);
-            return arg;
-        }
-        if (cmd == L"mathbb") {
-            MNodePtr arg = parseArg();
-            // single-letter blackboard bold via Unicode double-struck
-            if (arg && arg->kind == MNode::Sym && arg->text.size() == 1) {
-                for (const auto& b : kBlackboard) {
-                    if (arg->text == b.name) {
-                        arg->text = b.text;
-                        break;
-                    }
-                }
-            }
-            return arg;
-        }
-        if (cmd == L"mathcal" || cmd == L"mathscr" || cmd == L"mathit") {
-            return parseArg();  // rendered as regular italic
-        }
-        if (cmd == L"displaystyle" || cmd == L"textstyle" || cmd == L"nolimits" ||
-            cmd == L"limits" || cmd == L"middle") {
-            return parseAtom();  // pass-through niladics: render what follows
-        }
-        if (isFunctionName(cmd)) {
-            MNodePtr f = mk(MNode::Sym);
-            f->text = cmd;
-            f->roman = true;
-            return f;
-        }
-        if (const wchar_t* sym = lookupSymbol(cmd)) {
-            MNodePtr s = mk(MNode::Sym);
-            s->text = sym;
-            return s;
-        }
-
-        failed = true;  // unknown command: whole span falls back to source
-        return nullptr;
-    }
-
-    static MNodePtr markRoman(MNodePtr n) {
-        n->roman = true;
-        for (auto& k : n->kids) {
-            if (k) markRoman(k);
-        }
-        return n;
-    }
-    static MNodePtr markBold(MNodePtr n) {
-        n->bold = true;
-        n->roman = true;
-        for (auto& k : n->kids) {
-            if (k) markBold(k);
-        }
-        return n;
-    }
-
-    MNodePtr parseRow(wchar_t terminator, bool stopAtRight = false) {
-        MNodePtr row = mk(MNode::Row);
-        while (!eof() && !failed) {
-            skipWs();
-            if (eof()) break;
-            if (terminator && peek() == terminator) break;
-            if (stopAtRight && peek() == L'\\' &&
-                src.compare(pos, 6, L"\\right") == 0) {
-                break;
-            }
-            if (peek() == L'^' || peek() == L'_') {
-                // Attach scripts to the previous atom (or an empty base)
-                MNodePtr base = row->kids.empty() ? mk(MNode::Row)
-                                                  : row->kids.back();
-                if (!row->kids.empty()) row->kids.pop_back();
-                MNodePtr script;
-                if (base->kind == MNode::Script) {
-                    script = base;  // x_1^m: add the second script
-                } else {
-                    script = mk(MNode::Script);
-                    script->kids = {base, nullptr, nullptr};
-                }
-                while (!eof() && (peek() == L'^' || peek() == L'_')) {
-                    wchar_t which = src[pos++];
-                    MNodePtr arg = parseArg();
-                    if (!arg) { failed = true; break; }
-                    if (which == L'^') script->kids[2] = arg;
-                    else script->kids[1] = arg;
-                    skipWs();
-                }
-                row->kids.push_back(script);
-                continue;
-            }
-            MNodePtr atom = parseAtom();
-            if (atom) row->kids.push_back(atom);
-        }
-        return row;
-    }
-};
+using namespace tinta_math;
 
 // ---------------------------------------------------------------------------
 // Layout
@@ -602,6 +184,53 @@ Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
             m.width = cx - x;
             return m;
         }
+        case MNode::Grid: {
+            float cellSize = node->compact ? size * 0.7f : size;
+            size_t columns = node->alignment.size();
+            for (const auto& row : node->cells) columns = std::max(columns, row.size());
+            if (!columns || node->cells.empty()) return m;
+            std::vector<float> widths(columns, 0), ascents, descents;
+            std::vector<std::vector<Metrics>> cells;
+            float totalHeight = 0;
+            float rowGap = cellSize * 0.35f;
+            for (const auto& row : node->cells) {
+                float ascent = cellSize * 0.8f, descent = cellSize * 0.2f;
+                std::vector<Metrics> measured;
+                for (size_t col = 0; col < row.size(); ++col) {
+                    Metrics cm = measureNode(ctx, row[col], cellSize);
+                    widths[col] = std::max(widths[col], cm.width);
+                    ascent = std::max(ascent, cm.ascent);
+                    descent = std::max(descent, cm.descent);
+                    measured.push_back(cm);
+                }
+                ascents.push_back(ascent); descents.push_back(descent);
+                totalHeight += ascent + descent;
+                cells.push_back(std::move(measured));
+            }
+            totalHeight += rowGap * static_cast<float>(cells.size() - 1);
+            m.ascent = totalHeight / 2 + em * 0.26f;
+            m.descent = totalHeight - m.ascent;
+            float top = baselineY - m.ascent;
+            for (size_t row = 0; row < cells.size(); ++row) {
+                float cx = x;
+                for (size_t col = 0; col < columns; ++col) {
+                    wchar_t align = node->aligned ? (col % 2 ? L'l' : L'r') : L'c';
+                    if (col < node->alignment.size()) align = node->alignment[col];
+                    if (col < cells[row].size() && record) {
+                        float extra = widths[col] - cells[row][col].width;
+                        float offset = align == L'r' ? extra : align == L'c' ? extra / 2 : 0;
+                        layoutNodeImpl(ctx, node->cells[row][col], cellSize,
+                                       cx + offset, top + ascents[row], true);
+                    }
+                    cx += widths[col];
+                    if (col + 1 < columns)
+                        cx += cellSize * (node->aligned && col % 2 == 0 ? 0.26f : 1.0f);
+                }
+                m.width = std::max(m.width, cx - x);
+                top += ascents[row] + descents[row] + rowGap;
+            }
+            return m;
+        }
         case MNode::Script: {
             const MNodePtr& base = node->kids[0];
             const MNodePtr& sub = node->kids[1];
@@ -656,12 +285,66 @@ Metrics layoutNodeImpl(LayoutCtx& ctx, const MNodePtr& node, float size,
         }
         case MNode::Delim: {
             Metrics cm = measureNode(ctx, node->kids[0], size);
+            // Tall common delimiters use native strokes at a constant width.
+            // Increasing the font size also widens glyphs, and used to cap
+            // brackets at 3.5 em, leaving large matrices unenclosed.
+            if (cm.height() > em * 1.4f &&
+                (!node->open || std::wstring(L"()[]{}|\u2016").find(node->open) != std::wstring::npos) &&
+                (!node->close || std::wstring(L"()[]{}|\u2016").find(node->close) != std::wstring::npos)) {
+                float top = baselineY - cm.ascent - em * 0.08f;
+                float height = cm.height() + em * 0.16f;
+                float width = em * 0.38f, pad = em * 0.12f;
+                float stroke = std::max(1.0f, em * 0.055f);
+                auto line = [&](float x1, float y1, float x2, float y2) {
+                    if (record) ctx.box.lines.push_back({x1, y1, x2, y2, stroke});
+                };
+                auto draw = [&](wchar_t d, float dx) {
+                    if (!d) return;
+                    float bottom = top + height;
+                    bool right = d == L')' || d == L']' || d == L'}';
+                    if (d == L'[' || d == L']') {
+                        float edge = dx + (right ? width : 0);
+                        line(edge, top, edge, bottom);
+                        line(dx, top, dx + width, top);
+                        line(dx, bottom, dx + width, bottom);
+                    } else if (d == L'|' || d == L'\u2016') {
+                        line(dx + width * 0.4f, top, dx + width * 0.4f, bottom);
+                        if (d == L'\u2016')
+                            line(dx + width * 0.8f, top, dx + width * 0.8f, bottom);
+                    } else {
+                        auto point = [&](float t) {
+                            float u;
+                            if (d == L'{' || d == L'}') {
+                                // Shoulder, waist, shoulder of a curly brace.
+                                float v = std::abs(t - 0.5f) * 2;
+                                u = 0.5f + 0.5f * (2 * v - 1) * (2 * v - 1) * (2 * v - 1);
+                            } else u = 1 - std::sin(t * 3.14159265f);
+                            return D2D1::Point2F(dx + width * (right ? 1 - u : u), top + t * height);
+                        };
+                        auto prev = point(0);
+                        for (int step = 1; step <= 32; ++step) {
+                            auto next = point(static_cast<float>(step) / 32);
+                            line(prev.x, prev.y, next.x, next.y);
+                            prev = next;
+                        }
+                    }
+                };
+                float leftWidth = node->open ? width + pad : 0;
+                float rightWidth = node->close ? width + pad : 0;
+                draw(node->open, x);
+                layoutNodeImpl(ctx, node->kids[0], size, x + leftWidth, baselineY, record);
+                draw(node->close, x + leftWidth + cm.width + pad);
+                m.width = leftWidth + cm.width + rightWidth;
+                m.ascent = cm.ascent + em * 0.08f + stroke / 2;
+                m.descent = cm.descent + em * 0.08f + stroke / 2;
+                return m;
+            }
             // Delimiters stretch to the content: scale the glyph size so a
             // paren grows with a fraction inside it
             float contentH = std::max(cm.height(), em);
             float glyphSize = size;
             if (contentH > em * 1.15f) {
-                glyphSize = size * std::min(3.5f, contentH / em);
+                glyphSize = contentH;
             }
             float cx = x;
             auto emitDelim = [&](wchar_t d) -> float {
@@ -795,9 +478,8 @@ MathBoxPtr mathParse(App& app, const std::wstring& latex, float fontSize,
     auto it = g_mathCache.find(key);
     if (it != g_mathCache.end()) return it->second;
 
-    Parser parser(latex);
-    MNodePtr root = parser.parseRow(0);
-    if (parser.failed || !root || root->kids.empty()) {
+    MNodePtr root = parseLatex(latex);
+    if (!root) {
         g_mathCache[key] = nullptr;   // remember the failure too
         return nullptr;
     }
@@ -840,7 +522,7 @@ void mathBoxDrawTo(ID2D1RenderTarget* target, ID2D1SolidColorBrush* brush,
         target->DrawLine(
             D2D1::Point2F(x + line.x1, y + line.y1),
             D2D1::Point2F(x + line.x2, y + line.y2), brush,
-            std::max(1.0f, mathBoxHeight(box) * 0.02f));
+            line.thickness);
     }
 }
 
@@ -875,7 +557,7 @@ void mathBoxRetain(App& app, const MathBoxPtr& box, float x, float y,
     for (const auto& line : box->lines) {
         app.layoutLines.push_back({D2D1::Point2F(x + line.x1, y + line.y1),
                                    D2D1::Point2F(x + line.x2, y + line.y2),
-                                   color, 1.2f});
+                                   color, line.thickness});
     }
 }
 
@@ -936,7 +618,7 @@ std::string mathBoxSvg(const MathBoxPtr& box, const std::string& colorCss,
     for (const auto& l : box->lines) {
         s += "<line x1=\"" + svgNum(l.x1) + "\" y1=\"" + svgNum(l.y1) +
              "\" x2=\"" + svgNum(l.x2) + "\" y2=\"" + svgNum(l.y2) +
-             "\" stroke=\"" + colorCss + "\" stroke-width=\"1.2\"/>";
+             "\" stroke=\"" + colorCss + "\" stroke-width=\"" + svgNum(l.thickness) + "\"/>";
     }
     for (const auto& r : box->runs) {
         s += "<text x=\"" + svgNum(r.x) + "\" y=\"" +

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -396,6 +396,8 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                                 const std::string& baseLinkUrl = {}, float customLineHeight = 0.0f) {
     float x = startX;
     float lineHeight = customLineHeight > 0 ? customLineHeight : baseFormat->GetFontSize() * 1.7f;
+    const float normalLineHeight = lineHeight;
+    float mathTextOffset = 0;
     float maxX = startX + maxWidth;
     float spaceWidth = getSpaceWidth(app, baseFormat);
 
@@ -404,15 +406,15 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
         if (lineEndX <= lineStartX) return;
         bool refLive = linkUrl.rfind("fileref-ok:", 0) == 0;
         bool refMissing = linkUrl.rfind("fileref-missing:", 0) == 0;
-        float underlineY = lineY + lineHeight - 2;
+        float underlineY = lineY + mathTextOffset + normalLineHeight - 2;
         if (refLive || refMissing) {
             // .md references underline dashed; a missing target keeps a
             // faint ghost of the same treatment, and its click offers to
             // create the file (#127)
             D2D1_COLOR_F dashColor = color;
             dashColor.a *= 0.55f;
-            float dash = lineHeight * 0.16f;
-            float gap = lineHeight * 0.12f;
+            float dash = normalLineHeight * 0.16f;
+            float gap = normalLineHeight * 0.12f;
             for (float sx = lineStartX; sx < lineEndX; sx += dash + gap) {
                 float ex = std::min(sx + dash, lineEndX);
                 app.layoutLines.push_back({D2D1::Point2F(sx, underlineY),
@@ -438,6 +440,32 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
     std::vector<StyledRun> runs;
     flattenInline(app, elements, rootStyle, lineHeight, runs);
 
+    // Reserve a common baseline and enough vertical room before retaining
+    // any runs. Uniform spacing within this paragraph keeps wrapping and
+    // selection consistent even when a tall inline matrix occurs mid-line.
+    std::vector<MathBoxPtr> mathBoxes(runs.size());
+    std::vector<float> mathBaselines(runs.size(), 0);
+    float mathBelow = 0;
+    for (size_t i = 0; i < runs.size(); ++i) {
+        const auto& run = runs[i];
+        if (run.elem->type != ElementType::MathInline && run.elem->type != ElementType::MathDisplay) continue;
+        IDWriteTextFormat* format = run.style.format ? run.style.format : baseFormat;
+        float size = format->GetFontSize();
+        mathBoxes[i] = mathParse(app, toWide(run.elem->text), size, false);
+        if (!mathBoxes[i]) continue;
+        float baseline = size * 0.8f;
+        IDWriteTextLayout* probe = nullptr;
+        if (SUCCEEDED(app.dwriteFactory->CreateTextLayout(L"Ag", 2, format, 1000, 1000, &probe))) {
+            DWRITE_LINE_METRICS metrics{};
+            UINT32 count = 1;
+            if (SUCCEEDED(probe->GetLineMetrics(&metrics, 1, &count))) baseline = metrics.baseline;
+            probe->Release();
+        }
+        mathBaselines[i] = baseline;
+        mathExpandLine(mathBoxes[i], baseline + run.style.drawYOffset, normalLineHeight, mathTextOffset, mathBelow);
+    }
+    lineHeight += mathTextOffset + mathBelow;
+
     for (size_t runIndex = 0; runIndex < runs.size(); runIndex++) {
         const auto& run = runs[runIndex];
         const ElementPtr& elem = run.elem;
@@ -448,7 +476,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
         bool hasBg = run.style.hasBg;
         bool hasStrike = run.style.hasStrike;
         D2D1_COLOR_F bgColor = run.style.bgColor;
-        float drawYOffset = run.style.drawYOffset;
+        float drawYOffset = run.style.drawYOffset + mathTextOffset;
 
         std::wstring text;
 
@@ -475,13 +503,13 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                     y += lineHeight;
                 }
 
-                app.layoutRects.push_back({D2D1::RectF(x - 2, y,
+                app.layoutRects.push_back({D2D1::RectF(x - 2, y + mathTextOffset,
                                                       x + textWidth + kCodeSpanPadding,
-                                                      y + lineHeight),
+                                                      y + mathTextOffset + normalLineHeight),
                                            app.theme.codeBackground});
 
                 float codeFontHeight = format->GetFontSize() * 1.2f;
-                float verticalOffset = (lineHeight - codeFontHeight) / 2.0f;
+                float verticalOffset = mathTextOffset + (normalLineHeight - codeFontHeight) / 2.0f;
                 D2D1_POINT_2F pos = D2D1::Point2F(x, y + verticalOffset);
                 D2D1_RECT_F bounds = D2D1::RectF(x, y, x + textWidth, y + lineHeight);
                 addTextRun(app, std::move(info), pos, bounds, color,
@@ -501,9 +529,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                 // Native inline math (#80): an atomic measured box in the
                 // text flow, baseline-aligned with the surrounding line
                 std::wstring latex = toWide(elem->text);
-                float mathSize = format ? format->GetFontSize()
-                                        : app.textFormat->GetFontSize();
-                MathBoxPtr box = mathParse(app, latex, mathSize, false);
+                MathBoxPtr box = mathBoxes[runIndex];
                 if (!box) {
                     // Unsupported TeX: show the raw source in code style
                     format = inlineCodeFormat(app, run.style.bold, run.style.italic);
@@ -517,20 +543,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                     y += lineHeight;
                 }
                 // Align the box baseline with the surrounding text baseline
-                float textBaseline = mathSize * 0.8f;
-                {
-                    IDWriteTextLayout* probe = nullptr;
-                    app.dwriteFactory->CreateTextLayout(
-                        L"Ag", 2, format ? format : app.textFormat,
-                        1000.0f, 1000.0f, &probe);
-                    if (probe) {
-                        DWRITE_LINE_METRICS lm{};
-                        UINT32 n = 1;
-                        probe->GetLineMetrics(&lm, 1, &n);
-                        textBaseline = lm.baseline;
-                        probe->Release();
-                    }
-                }
+                float textBaseline = mathBaselines[runIndex];
                 float boxTop = y + drawYOffset + textBaseline - mathBoxBaseline(box);
                 mathBoxRetain(app, box, x, boxTop, app.theme.text);
 
@@ -615,7 +628,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                 float rubyAboveOffset = rubyLineHeight;
                 // If we're at the start of a line, push y down to make room for annotation
                 // For simplicity, always reserve space above
-                float baseY = y + rubyAboveOffset;
+                float baseY = y + mathTextOffset + rubyAboveOffset;
 
                 // Center the narrower one under the wider one
                 float basePosX = x + (totalWidth - baseWidth) / 2.0f;
@@ -625,8 +638,8 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                 if (rubyInfo.layout) {
                     D2D1_COLOR_F rubyColor = baseColor;
                     rubyColor.a *= 0.7f;
-                    D2D1_POINT_2F rubyPos = D2D1::Point2F(rubyPosX, y);
-                    D2D1_RECT_F rubyBounds = D2D1::RectF(rubyPosX, y, rubyPosX + rubyWidth, y + rubyLineHeight);
+                    D2D1_POINT_2F rubyPos = D2D1::Point2F(rubyPosX, y + mathTextOffset);
+                    D2D1_RECT_F rubyBounds = D2D1::RectF(rubyPosX, y + mathTextOffset, rubyPosX + rubyWidth, y + mathTextOffset + rubyLineHeight);
                     addTextRun(app, std::move(rubyInfo), rubyPos, rubyBounds, rubyColor, 0, 0, false);
                 }
 
@@ -726,11 +739,12 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
             float segWidth = widthOf(segStart, segEnd);
             if (hasBg) {
                 app.layoutRects.push_back({
-                    D2D1::RectF(segX - 2, y + 1, segX + segWidth + 2, y + lineHeight - 1),
+                    D2D1::RectF(segX - 2, y + mathTextOffset + 1, segX + segWidth + 2,
+                                y + mathTextOffset + normalLineHeight - 1),
                     bgColor});
             }
             if (hasStrike) {
-                float strikeY = y + lineHeight * 0.55f;
+                float strikeY = y + mathTextOffset + normalLineHeight * 0.55f;
                 app.layoutLines.push_back({D2D1::Point2F(segX, strikeY),
                                            D2D1::Point2F(segX + segWidth, strikeY),
                                            color, 1.0f});

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -443,12 +443,16 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
     // Reserve a common baseline and enough vertical room before retaining
     // any runs. Uniform spacing within this paragraph keeps wrapping and
     // selection consistent even when a tall inline matrix occurs mid-line.
-    std::vector<MathBoxPtr> mathBoxes(runs.size());
-    std::vector<float> mathBaselines(runs.size(), 0);
+    std::vector<MathBoxPtr> mathBoxes;
+    std::vector<float> mathBaselines;
     float mathBelow = 0;
     for (size_t i = 0; i < runs.size(); ++i) {
         const auto& run = runs[i];
         if (run.elem->type != ElementType::MathInline && run.elem->type != ElementType::MathDisplay) continue;
+        if (mathBoxes.empty()) {
+            mathBoxes.resize(runs.size());
+            mathBaselines.resize(runs.size(), 0);
+        }
         IDWriteTextFormat* format = run.style.format ? run.style.format : baseFormat;
         float size = format->GetFontSize();
         mathBoxes[i] = mathParse(app, toWide(run.elem->text), size, false);

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -549,7 +549,19 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                 // Align the box baseline with the surrounding text baseline
                 float textBaseline = mathBaselines[runIndex];
                 float boxTop = y + drawYOffset + textBaseline - mathBoxBaseline(box);
-                mathBoxRetain(app, box, x, boxTop, app.theme.text);
+                if (hasBg) {
+                    app.layoutRects.push_back({D2D1::RectF(x - 2,
+                        std::min(boxTop, y + mathTextOffset + 1), x + w + 2,
+                        std::max(boxTop + mathBoxHeight(box), y + mathTextOffset + normalLineHeight - 1)),
+                        bgColor});
+                }
+                if (hasStrike) {
+                    float strikeY = y + mathTextOffset + normalLineHeight * 0.55f;
+                    app.layoutLines.push_back({D2D1::Point2F(x, strikeY),
+                                               D2D1::Point2F(x + w, strikeY), color, 1.0f});
+                }
+                mathBoxRetain(app, box, x, boxTop, color);
+                if (isLink) addLinkSegment(x, x + w, y, linkUrl, color);
 
                 size_t docStart = app.docText.size();
                 std::wstring source = L"$" + latex + L"$";

--- a/tests/fixtures/markdown-regression-control.md
+++ b/tests/fixtures/markdown-regression-control.md
@@ -1,0 +1,46 @@
+# Existing Markdown control
+
+This document intentionally contains no math nodes. Its rendering should match the pre-extension build.
+
+## Headings and inline styles
+
+Plain text, **bold text**, *italic text*, ***bold italic***, ~~strikethrough~~, ==highlight==, `inline code` and [a local link](math-compatibility.md) must keep their spacing and decoration. This paragraph is long enough to wrap in both a normal document and a narrower window.
+
+### Table
+
+| Left | Center | Right |
+| :--- | :---: | ---: |
+| **Bold** | *Italic* | 123 |
+| `a & b` | [Link](math-compatibility.md) | 456 |
+| Wrapped text with several words | Ordinary text | 789 |
+
+### Lists
+
+- First item with **emphasis**.
+  - Nested item with `code`.
+- Second item with a link [here](math-compatibility.md).
+
+1. First ordered item.
+2. Second ordered item.
+
+- [x] Completed task.
+- [ ] Remaining task.
+
+> A block quote with **bold** text.
+>
+> A second paragraph within the quote.
+
+> [!NOTE]
+> Existing callout text remains readable.
+
+---
+
+```cpp
+int sum(int a, int b) {
+    return a + b;
+}
+```
+
+Literal math in code: `$x^2$`.
+
+The final paragraph must remain visible.

--- a/tests/fixtures/math-compatibility.md
+++ b/tests/fixtures/math-compatibility.md
@@ -1,0 +1,53 @@
+# Native math compatibility samples
+
+## Issue 190
+
+$$
+\begin{bmatrix}1&2\\5&6\end{bmatrix}\longrightarrow 6,
+\qquad
+\begin{bmatrix}3&4\\7&8\end{bmatrix}\longrightarrow 8
+$$
+
+## Matrix variants and nesting
+
+$$\begin{pmatrix}\frac{1}{x^2}&\sqrt{y}\\z&\begin{bmatrix}1\\2\end{bmatrix}\end{pmatrix}$$
+
+$$\begin{Bmatrix}a&b\\c&d\end{Bmatrix}\quad\begin{vmatrix}a&b\\c&d\end{vmatrix}\quad\begin{Vmatrix}a&b\\c&d\end{Vmatrix}$$
+
+$$\begin{bmatrix*}[r]1&22\\333&4\end{bmatrix*}$$
+
+## Piecewise functions and derivations
+
+$$f(x)=\begin{cases}x^2&\text{if }x>0\\0&\text{if }x=0\\-x&\text{otherwise}\end{cases}$$
+
+$$\begin{aligned}a+b&=c\\x&=y+z\end{aligned}$$
+
+$$\begin{array}{r|l}\hline 1&22\\\hline 333&4\\\hline\end{array}$$
+
+## Calculus and combinatorics
+
+$$\sum_{i=1}^n x_i\quad\int_0^1 f(x)\,dx\quad\lim_{n\to\infty}\frac{1}{n}=0$$
+
+$$\sum_{\substack{i>0\\j>0}}a_{ij}\quad\dfrac{1}{2}+\tfrac{1}{2}\quad\binom{n}{k}\quad\sqrt[3]{\frac{x+1}{y}}$$
+
+## Text and annotations
+
+$$\text{for all }x\in\mathbb{R},\quad\mathcal{L}=\mathfrak{g}+\boldsymbol{\alpha}$$
+
+$$A\xrightarrow[n\to\infty]{f}B\quad\overset{!}{=}\quad\underbrace{a+b+c}_{\text{sum}}$$
+
+$$\widetilde{xyz}+\dot{x}+\ddot{x}+\underline{y}+\boxed{x=2}+\cancel{x}$$
+
+## Custom notation
+
+$$
+\newcommand{\norm}[1]{\left\lVert#1\right\rVert}
+\DeclareMathOperator*{\argmin}{arg min}
+\argmin_x\norm{x-b}^2
+$$
+
+## Inline flow
+
+An inline small matrix $\begin{smallmatrix}a&b\\c&d\end{smallmatrix}$ stays aligned with this sentence. Surrounding text should remain readable when this paragraph wraps onto another line in a narrow window.
+
+A taller inline matrix $\begin{bmatrix}1&2\\3&4\\5&6\end{bmatrix}$ reserves extra space above and below the surrounding text. The preceding and following lines should not overlap its entries or brackets.

--- a/tests/fixtures/math-inline-stress.md
+++ b/tests/fixtures/math-inline-stress.md
@@ -1,0 +1,21 @@
+# Inline math wrapping
+
+Before the tall paragraph: this line must remain visible.
+
+Start with ordinary text before $\begin{bmatrix}1&2\\3&4\\5&6\\7&8\\9&0\end{bmatrix}$ and continue with several words, **bold text**, *italic text*, `inline code`, ==highlighted text==, ~~deleted text~~ and [a link](math-compatibility.md). Keep reading this long sentence until it wraps onto several lines in a narrow window, then compare the smaller $\begin{smallmatrix}a&b\\c&d\end{smallmatrix}$ with a nested $\dfrac{1}{1+\dfrac{1}{x^2}}$ and a labelled $A\xrightarrow[n\to\infty]{f}B$ arrow. All baselines and decoration backgrounds should remain aligned.
+
+After the tall paragraph: this line must remain visible.
+
+| Tall cell | Neighboring cell |
+| --- | --- |
+| $\begin{pmatrix}1\\2\\3\\4\\5\end{pmatrix}$ | This cell contains enough plain text to wrap over multiple lines when the window is narrow. Its text must stay within the row. |
+| Following row | The border above this row must not cross the matrix. |
+
+## Following heading $\sqrt[3]{x}$
+
+> A tall inline case $\begin{cases}x^2&x>0\\0&x=0\\-x&x<0\end{cases}$ in a quote with more words to force wrapping near the right edge of the page.
+
+- An item with $\sum\limits_{i=1}^{n}x_i$ and $\underbrace{a+b+c}_{\text{sum}}$ should remain distinct from its neighbor.
+- The last item remains readable.
+
+End of the inline stress fixture.

--- a/tests/fixtures/math-mixed-layout.md
+++ b/tests/fixtures/math-mixed-layout.md
@@ -1,0 +1,69 @@
+# Matrices $A\longrightarrow B$
+
+This document checks new math inside existing Markdown. No formula should cover surrounding text, a table border, or the following block.
+
+## Heading with $\begin{bmatrix}1&2\\3&4\end{bmatrix}$ and text
+
+The paragraph after the heading must remain separate. **Bold** and *italic* text still work.
+
+### Fractions $\dfrac{1}{1+x^2}$ in a smaller heading
+
+## Tables and alignment
+
+| Left label | Centered math $x^2$ | Right result |
+| :--- | :---: | ---: |
+| **Matrix** | $\begin{bmatrix}1&2\\3&4\\5&6\end{bmatrix}$ | $\longrightarrow 6$ |
+| Fraction | $\dfrac{1}{1+\dfrac{1}{x}}$ | $\sqrt[3]{8}=2$ |
+| Norm with an escaped pipe | $\left\|x\right\|$ | $\mathbb{R}$ |
+| Plain following row | `a & b` and *text* | 42 |
+
+The paragraph after the table must not overlap its final row.
+
+## Lists, links and inline formatting
+
+- A matrix $\begin{pmatrix}a&b\\c&d\end{pmatrix}$ inside a list item, with enough surrounding words to wrap in a narrow window without crossing the next item.
+  - Nested item with $\binom{n}{k}$ and **bold text**.
+- The following item remains visible with [a local fixture link](math-compatibility.md).
+
+1. First compute $\sum_{\substack{i>0\\j>0}}a_{ij}$.
+2. Then compare $\boxed{x=2}$ with `x = 2`.
+
+- [x] Matrix example covered.
+- [ ] Inspect $\underbrace{a+b+c}_{\text{sum}}$ next to a checkbox.
+
+**Bold $\begin{bmatrix}1\\2\\3\end{bmatrix}$ continuation**, *italic $\dfrac{x}{y}$ continuation*, ~~old $x^2$ result~~, ==highlighted $\sqrt{x}$ result==, and [$\mathbb{R}$ link](math-compatibility.md) share a paragraph with `inline code`. The next wrapped line must remain readable, including its link underline and code background.
+
+## Quotes and display equations
+
+> A quoted derivation with $\alpha\leq\beta$.
+>
+> $$\begin{aligned}a+b&=c\\x&=y+z\end{aligned}$$
+>
+> The final quoted paragraph stays inside the quote.
+
+> [!NOTE]
+> A case distinction follows $f(x)$ without hiding this callout text.
+>
+> $$f(x)=\begin{cases}x^2&\text{if }x>0\\0&\text{otherwise}\end{cases}$$
+
+---
+
+## Code remains literal
+
+Inline code `$\begin{bmatrix}1&2\\3&4\end{bmatrix}$` must keep its dollar signs and backslashes.
+
+```latex
+$$\begin{bmatrix}1&2\\3&4\end{bmatrix}\longrightarrow 6$$
+\newcommand{\norm}[1]{\left\lVert#1\right\rVert}
+```
+
+## Diagram beside math
+
+```mermaid
+flowchart LR
+    A[Input matrix] --> B[Transform] --> C[Result]
+```
+
+$$\newcommand{\norm}[1]{\left\lVert#1\right\rVert}\norm{\frac{x}{y}}\geq0$$
+
+The final paragraph, **final emphasis**, and [final link](math-compatibility.md) must all survive after the diagram and equation.

--- a/tests/inline_style_tests.cpp
+++ b/tests/inline_style_tests.cpp
@@ -213,6 +213,36 @@ int main() {
         }
     }
 
+    // Math stays opaque to Markdown extensions while inheriting wrappers.
+    {
+        auto runs = flattenFirstBlock(app, parser,
+            "==before $\\text{a==b}+x^2$ after== and ~~old $x_1$ result~~\n");
+        size_t equations = 0;
+        for (const auto& run : runs) {
+            if (run.elem->type != ElementType::MathInline) continue;
+            ++equations;
+            if (equations == 1) {
+                check(run.style.hasBg && !run.style.hasStrike, "highlight includes math");
+                check(run.elem->text == "\\text{a==b}+x^2", "TeX delimiters remain literal within math");
+            } else {
+                check(run.style.hasStrike && !run.style.hasBg, "strikethrough includes math");
+            }
+        }
+        check(equations == 2, "both styled equations remain math nodes");
+        check(!runs.empty() && !runs.back().style.hasBg, "highlight does not leak into later text");
+    }
+    {
+        auto runs = flattenFirstBlock(app, parser, "[$x^2$](https://example.com)\n");
+        const auto* math = firstOfType(runs, ElementType::MathInline);
+        check(math && math->style.isLink && math->style.linkUrl == "https://example.com",
+              "math-only link retains its target");
+    }
+    {
+        auto runs = flattenFirstBlock(app, parser, "==unclosed $x$ and `~~$y$~~`\n");
+        for (const auto& run : runs)
+            check(!run.style.hasBg && !run.style.hasStrike, "unclosed markers and literal code stay untouched");
+    }
+
     // Leaves are emitted in document order, none dropped
     {
         auto runs = flattenFirstBlock(app, parser, "a **b `c` d** e\n");

--- a/tests/math_layout_tests.cpp
+++ b/tests/math_layout_tests.cpp
@@ -46,6 +46,20 @@ int main(int argc, char** argv) {
         auto svg = mathBoxSvg(tall, "#111111", "Segoe UI");
         check(svg.find("<line") != std::string::npos && svg.find("<text") != std::string::npos,
               "SVG exports tall bracket strokes and cells");
+        auto height = [&](const wchar_t* tex, bool display = true) {
+            return mathBoxHeight(mathParse(app, tex, 24, display));
+        };
+        check(height(LR"(\dfrac{1}{2})", false) > height(LR"(\tfrac{1}{2})", false) * 1.15f,
+              "dfrac and tfrac have distinct sizes even inline");
+        check(height(LR"(\sum_{i=1}^n x_i)") > height(LR"(\sum\nolimits_{i=1}^n x_i)"), "display limits are stacked");
+        check(height(LR"(\int\limits_0^1 x)") > height(LR"(\int_0^1 x)"), "integrals obey explicit limits");
+        check(height(LR"(\sum_{\substack{i>0\\j>0}}x)") > height(LR"(\sum_{i>0}x)"), "substack adds rows in limits");
+        auto width = [&](const wchar_t* tex) { return mathBoxWidth(mathParse(app, tex, 24, false)); };
+        check(width(LR"(x\!y)") < width(L"xy"), "negative spacing reduces width");
+        check(width(LR"(\sqrt[123]{x})") > width(LR"(\sqrt{x})"), "radical index reserves width");
+        auto textSvg = mathBoxSvg(mathParse(app, LR"(\text{for all }x\in\mathbb{R})", 24, true), "#111", "Segoe UI");
+        check(textSvg.find("for all ") != std::string::npos && textSvg.find("xml:space=\"preserve\"") != std::string::npos,
+              "SVG preserves text spaces");
         mathBoxRetain(app, tall, 5, 10, D2D1::ColorF(D2D1::ColorF::Black));
         check(!app.layoutTextRuns.empty() && !app.layoutLines.empty(), "retained viewer receives same primitives");
         app.clearLayoutCache();
@@ -57,7 +71,13 @@ int main(int argc, char** argv) {
                 LR"(\begin{bmatrix}1&2\\3&4\\5&6\\7&8\\9&0\end{bmatrix})",
                 LR"(\begin{pmatrix}\frac{1}{x^2}&\sqrt{y}\\z&\begin{bmatrix}1\\2\end{bmatrix}\end{pmatrix})",
                 LR"(f(x)=\begin{cases}x^2&x>0\\0&x=0\\-x&x<0\end{cases})",
-                LR"(\begin{aligned}a+b&=c\\x&=y+z\end{aligned})"}) {
+                LR"(\begin{aligned}a+b&=c\\x&=y+z\end{aligned})",
+                LR"(\sum_{i=1}^n x_i\qquad\int_0^1 f(x)\,dx\qquad\lim_{n\to\infty}\frac{1}{n}=0)",
+                LR"(\dfrac{1}{2}+\tfrac{1}{2}\qquad\binom{n}{k}\qquad\sqrt[3]{\frac{x+1}{y}})",
+                LR"(\text{for all }x\in\mathbb{R},\quad\mathcal{L}=\mathfrak{g}+\boldsymbol{\alpha})",
+                LR"(A\xrightarrow[n\to\infty]{f}B\qquad\overset{!}{=}\qquad\underbrace{a+b+c}_{\text{sum}})",
+                LR"(\widetilde{xyz}+\dot{x}+\ddot{x}+\underline{y}+\boxed{x=2}+\cancel{x})",
+                LR"(\sum_{\substack{i>0\\j>0}}a_{ij}\qquad x^{y^{z^2}})"}) {
                 out << "<section>" << mathBoxSvg(mathParse(app, tex, 24, true), "#17212b", "Segoe UI") << "</section>";
             }
         }

--- a/tests/math_layout_tests.cpp
+++ b/tests/math_layout_tests.cpp
@@ -57,6 +57,9 @@ int main(int argc, char** argv) {
         auto width = [&](const wchar_t* tex) { return mathBoxWidth(mathParse(app, tex, 24, false)); };
         check(width(LR"(x\!y)") < width(L"xy"), "negative spacing reduces width");
         check(width(LR"(\sqrt[123]{x})") > width(LR"(\sqrt{x})"), "radical index reserves width");
+        check(std::abs(width(LR"(x\hspace{1em}y)") - width(L"xy") - 24) < 0.01f, "em spacing uses current size");
+        check(std::abs(width(LR"(x\kern 3pt y)") - width(L"xy") - 4) < 0.01f, "point spacing uses logical pixels");
+        check(height(LR"(\Bigg(x\Bigg))") > height(LR"(\big(x\big))"), "explicit delimiter sizes differ");
         auto textSvg = mathBoxSvg(mathParse(app, LR"(\text{for all }x\in\mathbb{R})", 24, true), "#111", "Segoe UI");
         check(textSvg.find("for all ") != std::string::npos && textSvg.find("xml:space=\"preserve\"") != std::string::npos,
               "SVG preserves text spaces");
@@ -77,7 +80,10 @@ int main(int argc, char** argv) {
                 LR"(\text{for all }x\in\mathbb{R},\quad\mathcal{L}=\mathfrak{g}+\boldsymbol{\alpha})",
                 LR"(A\xrightarrow[n\to\infty]{f}B\qquad\overset{!}{=}\qquad\underbrace{a+b+c}_{\text{sum}})",
                 LR"(\widetilde{xyz}+\dot{x}+\ddot{x}+\underline{y}+\boxed{x=2}+\cancel{x})",
-                LR"(\sum_{\substack{i>0\\j>0}}a_{ij}\qquad x^{y^{z^2}})"}) {
+                LR"(\sum_{\substack{i>0\\j>0}}a_{ij}\qquad x^{y^{z^2}})",
+                LR"(\left\{\frac{x}{y}\middle|x>0\right\}\qquad\bigl(x\bigr)\Bigl(x\Bigr)\Biggl(x\Biggr))",
+                LR"(\begin{array}{r|l}\hline 1&22\\\hline 333&4\\\hline\end{array}\qquad a\equiv b\pmod{n})",
+                LR"(\newcommand{\norm}[1]{\left\lVert#1\right\rVert}\norm{\frac{x}{y}}\geq0)"}) {
                 out << "<section>" << mathBoxSvg(mathParse(app, tex, 24, true), "#17212b", "Segoe UI") << "</section>";
             }
         }

--- a/tests/math_layout_tests.cpp
+++ b/tests/math_layout_tests.cpp
@@ -7,11 +7,77 @@
 #include <algorithm>
 #include <vector>
 #include <functional>
+#include <filesystem>
+#include <map>
 
 namespace {
 int failures = 0;
 void check(bool condition, const char* message) {
     if (!condition) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+
+void checkMarkdownFixture(App& app, const char* filename, size_t minimumMath,
+                          bool mixed, int tableColumns = 0) {
+    using qmd::ElementType;
+    auto path = std::filesystem::path(TINTA_MATH_FIXTURE).parent_path() / filename;
+    std::ifstream file(path, std::ios::binary);
+    check(file.good(), "Markdown fixture is available");
+    std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    auto doc = app.parser.parse(source);
+    check(doc.success, "mixed Markdown parses");
+    std::map<ElementType, size_t> counts, mathWithin;
+    std::vector<ElementType> ancestors;
+    size_t equations = 0;
+    bool literalCode = false;
+    std::function<void(const qmd::ElementPtr&)> visit = [&](const qmd::ElementPtr& element) {
+        if (!element) return;
+        ++counts[element->type];
+        if (element->type == ElementType::TableRow && tableColumns > 0)
+            check(element->children.size() == static_cast<size_t>(tableColumns),
+                  "math separators do not split Markdown table cells");
+        if (element->type == ElementType::Text &&
+            std::find(ancestors.begin(), ancestors.end(), ElementType::Code) != ancestors.end() &&
+            element->text.find('$') != std::string::npos) literalCode = true;
+        if (element->type == ElementType::MathInline || element->type == ElementType::MathDisplay) {
+            ++equations;
+            for (auto ancestor : ancestors) ++mathWithin[ancestor];
+            int length = MultiByteToWideChar(CP_UTF8, 0, element->text.data(),
+                                            static_cast<int>(element->text.size()), nullptr, 0);
+            std::wstring tex(length, L'\0');
+            MultiByteToWideChar(CP_UTF8, 0, element->text.data(),
+                               static_cast<int>(element->text.size()), tex.data(), length);
+            if (!mathParse(app, tex, 24, element->type == ElementType::MathDisplay)) {
+                std::cerr << filename << ": unrendered equation: " << element->text << '\n';
+                check(false, "every mixed fixture equation renders");
+            }
+        }
+        ancestors.push_back(element->type);
+        for (const auto& child : element->children) visit(child);
+        ancestors.pop_back();
+    };
+    if (doc.success) visit(doc.root);
+    check(minimumMath ? equations >= minimumMath : equations == 0,
+          "fixture math spans are recognized without parsing literal code");
+    check(mathWithin[ElementType::Code] == 0 && mathWithin[ElementType::CodeBlock] == 0,
+          "inline and fenced code remain literal");
+    if (mixed) {
+        for (auto type : {ElementType::Heading, ElementType::TableCell,
+                          ElementType::ListItem, ElementType::BlockQuote})
+            check(mathWithin[type] > 0, "math survives inside existing block structures");
+        for (auto type : {ElementType::Strong, ElementType::Emphasis, ElementType::Code,
+                          ElementType::Link, ElementType::Highlight, ElementType::Strikethrough})
+            if (counts[type] == 0) {
+                std::cerr << filename << ": missing inline type " << static_cast<int>(type) << '\n';
+                check(false, "surrounding inline formatting survives");
+            }
+    }
+    if (std::string(filename) == "math-mixed-layout.md") {
+        check(mathWithin[ElementType::Link] > 0 && mathWithin[ElementType::Strong] > 0 &&
+              mathWithin[ElementType::Emphasis] > 0, "math preserves inline wrappers");
+        check(literalCode && counts[ElementType::CodeBlock] == 2,
+              "literal TeX and Mermaid fences survive mixed parsing");
+    }
+    std::cout << filename << ": " << equations << " equations\n";
 }
 
 bool rasterize(const std::vector<MathBoxPtr>& boxes, const wchar_t* path = nullptr) {
@@ -85,6 +151,9 @@ int main(int argc, char** argv) {
         };
         if (fixtureDoc.success) visit(fixtureDoc.root);
         check(equations >= 15, "all fixture equations were recognized by Markdown");
+        checkMarkdownFixture(app, "math-mixed-layout.md", 25, true, 3);
+        checkMarkdownFixture(app, "math-inline-stress.md", 9, true, 2);
+        checkMarkdownFixture(app, "markdown-regression-control.md", 0, false, 3);
         auto markdown = app.parser.parse("$$\n\\begin{bmatrix}1&2\\\\5&6\\end{bmatrix}\\longrightarrow 6\n$$");
         check(markdown.success && !markdown.root->children.empty(), "display math Markdown parses");
         if (markdown.success && !markdown.root->children.empty()) {

--- a/tests/math_layout_tests.cpp
+++ b/tests/math_layout_tests.cpp
@@ -1,0 +1,69 @@
+#include "math_render.h"
+
+#include <cmath>
+#include <fstream>
+#include <iostream>
+
+namespace {
+int failures = 0;
+void check(bool condition, const char* message) {
+    if (!condition) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+}
+
+int main(int argc, char** argv) {
+    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    {
+        App app;
+        HRESULT hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory),
+                                        reinterpret_cast<IUnknown**>(&app.dwriteFactory));
+        if (FAILED(hr)) return 2;
+        auto markdown = app.parser.parse("$$\n\\begin{bmatrix}1&2\\\\5&6\\end{bmatrix}\\longrightarrow 6\n$$");
+        check(markdown.success && !markdown.root->children.empty(), "display math Markdown parses");
+        if (markdown.success && !markdown.root->children.empty()) {
+            const auto& children = markdown.root->children.front()->children;
+            bool found = false;
+            for (const auto& child : children) {
+                if (child->type != qmd::ElementType::MathDisplay) continue;
+                found = true;
+                check(child->text.find("1&2\\\\5&6") != std::string::npos,
+                      "Markdown preserves TeX alignment and row separators");
+            }
+            check(found, "display math reaches native math element");
+        }
+        auto simple = mathParse(app, LR"(\begin{matrix}1&2\\3&4\end{matrix})", 24, true);
+        auto tall = mathParse(app, LR"(\begin{bmatrix}1&2\\3&4\\5&6\\7&8\\9&0\end{bmatrix})", 24, true);
+        auto nested = mathParse(app, LR"(\begin{pmatrix}\frac{1}{x^2}&\sqrt{y}\\z&\begin{bmatrix}1\\2\end{bmatrix}\end{pmatrix})", 24, true);
+        check(simple && tall && nested, "matrix layouts succeed");
+        check(mathBoxHeight(tall) > mathBoxHeight(simple) * 1.8f, "all matrix rows contribute height");
+        check(mathBoxWidth(tall) < mathBoxWidth(simple) * 2, "tall brackets retain modest width");
+        for (const auto& box : {simple, tall, nested}) {
+            check(std::isfinite(mathBoxWidth(box)) && mathBoxWidth(box) > 0 && mathBoxHeight(box) > 0,
+                  "finite nonempty layout");
+            check(mathBoxBaseline(box) > 0 && mathBoxBaseline(box) < mathBoxHeight(box), "baseline inside box");
+        }
+        check(!mathParse(app, LR"(\begin{bmatrix}1&2\end{matrix})", 24, true), "invalid matrix falls back in renderer");
+        auto svg = mathBoxSvg(tall, "#111111", "Segoe UI");
+        check(svg.find("<line") != std::string::npos && svg.find("<text") != std::string::npos,
+              "SVG exports tall bracket strokes and cells");
+        mathBoxRetain(app, tall, 5, 10, D2D1::ColorF(D2D1::ColorF::Black));
+        check(!app.layoutTextRuns.empty() && !app.layoutLines.empty(), "retained viewer receives same primitives");
+        app.clearLayoutCache();
+        if (argc > 1) {
+            std::ofstream out(argv[1]);
+            out << "<!doctype html><meta charset=utf-8><style>body{font:18px Segoe UI;padding:30px}section{margin:25px}</style>";
+            for (const auto* tex : {
+                LR"(\begin{bmatrix}1&2\\5&6\end{bmatrix}\longrightarrow 6,\qquad\begin{bmatrix}3&4\\7&8\end{bmatrix}\longrightarrow 8)",
+                LR"(\begin{bmatrix}1&2\\3&4\\5&6\\7&8\\9&0\end{bmatrix})",
+                LR"(\begin{pmatrix}\frac{1}{x^2}&\sqrt{y}\\z&\begin{bmatrix}1\\2\end{bmatrix}\end{pmatrix})",
+                LR"(f(x)=\begin{cases}x^2&x>0\\0&x=0\\-x&x<0\end{cases})",
+                LR"(\begin{aligned}a+b&=c\\x&=y+z\end{aligned})"}) {
+                out << "<section>" << mathBoxSvg(mathParse(app, tex, 24, true), "#17212b", "Segoe UI") << "</section>";
+            }
+        }
+        mathClearCache();
+    }
+    CoUninitialize();
+    std::cout << "Math layout: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/tests/math_layout_tests.cpp
+++ b/tests/math_layout_tests.cpp
@@ -3,11 +3,62 @@
 #include <cmath>
 #include <fstream>
 #include <iostream>
+#include <wrl/client.h>
+#include <algorithm>
+#include <vector>
+#include <functional>
 
 namespace {
 int failures = 0;
 void check(bool condition, const char* message) {
     if (!condition) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+
+bool rasterize(const std::vector<MathBoxPtr>& boxes, const wchar_t* path = nullptr) {
+    using Microsoft::WRL::ComPtr;
+    UINT width = 32, height = 16;
+    for (const auto& box : boxes) {
+        width = std::max(width, static_cast<UINT>(std::ceil(mathBoxWidth(box))) + 32);
+        height += static_cast<UINT>(std::ceil(mathBoxHeight(box))) + 24;
+    }
+    ComPtr<IWICImagingFactory> wic;
+    ComPtr<ID2D1Factory> d2d;
+    if (FAILED(CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
+                                IID_PPV_ARGS(&wic))) ||
+        FAILED(D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, d2d.GetAddressOf()))) return false;
+    ComPtr<IWICBitmap> bitmap;
+    if (FAILED(wic->CreateBitmap(width, height, GUID_WICPixelFormat32bppPBGRA, WICBitmapCacheOnLoad, &bitmap))) return false;
+    ComPtr<ID2D1RenderTarget> target;
+    auto props = D2D1::RenderTargetProperties(D2D1_RENDER_TARGET_TYPE_SOFTWARE);
+    if (FAILED(d2d->CreateWicBitmapRenderTarget(bitmap.Get(), props, &target))) return false;
+    ComPtr<ID2D1SolidColorBrush> brush;
+    if (FAILED(target->CreateSolidColorBrush(D2D1::ColorF(D2D1::ColorF::Black), &brush))) return false;
+    target->BeginDraw();
+    target->Clear(D2D1::ColorF(D2D1::ColorF::White));
+    float y = 16;
+    for (const auto& box : boxes) {
+        mathBoxDrawTo(target.Get(), brush.Get(), box, 16, y, D2D1::ColorF(0x17212B));
+        y += std::ceil(mathBoxHeight(box)) + 24;
+    }
+    if (FAILED(target->EndDraw())) return false;
+    std::vector<BYTE> pixels(static_cast<size_t>(width) * height * 4);
+    if (FAILED(bitmap->CopyPixels(nullptr, width * 4, static_cast<UINT>(pixels.size()), pixels.data()))) return false;
+    size_t dark = 0;
+    for (size_t i = 0; i < pixels.size(); i += 4) if (pixels[i] < 200) ++dark;
+    if (dark < 20) return false;
+    if (!path) return true;
+    ComPtr<IWICStream> stream;
+    ComPtr<IWICBitmapEncoder> encoder;
+    ComPtr<IWICBitmapFrameEncode> frame;
+    if (FAILED(wic->CreateStream(&stream)) || FAILED(stream->InitializeFromFilename(path, GENERIC_WRITE)) ||
+        FAILED(wic->CreateEncoder(GUID_ContainerFormatPng, nullptr, &encoder)) ||
+        FAILED(encoder->Initialize(stream.Get(), WICBitmapEncoderNoCache)) ||
+        FAILED(encoder->CreateNewFrame(&frame, nullptr)) || FAILED(frame->Initialize(nullptr)) ||
+        FAILED(frame->SetSize(width, height))) return false;
+    WICPixelFormatGUID format = GUID_WICPixelFormat32bppPBGRA;
+    if (FAILED(frame->SetPixelFormat(&format)) || FAILED(frame->WriteSource(bitmap.Get(), nullptr)) ||
+        FAILED(frame->Commit()) || FAILED(encoder->Commit())) return false;
+    return true;
 }
 }
 
@@ -18,6 +69,22 @@ int main(int argc, char** argv) {
         HRESULT hr = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED, __uuidof(IDWriteFactory),
                                         reinterpret_cast<IUnknown**>(&app.dwriteFactory));
         if (FAILED(hr)) return 2;
+        std::ifstream fixture(TINTA_MATH_FIXTURE, std::ios::binary);
+        std::string fixtureText((std::istreambuf_iterator<char>(fixture)), std::istreambuf_iterator<char>());
+        auto fixtureDoc = app.parser.parse(fixtureText);
+        size_t equations = 0;
+        std::function<void(const qmd::ElementPtr&)> visit = [&](const qmd::ElementPtr& element) {
+            if (!element) return;
+            if (element->type == qmd::ElementType::MathInline || element->type == qmd::ElementType::MathDisplay) {
+                ++equations;
+                std::wstring tex(element->text.begin(), element->text.end()); // fixture TeX is ASCII
+                check(mathParse(app, tex, 24, element->type == qmd::ElementType::MathDisplay) != nullptr,
+                      "Markdown compatibility fixture renders completely");
+            }
+            for (const auto& child : element->children) visit(child);
+        };
+        if (fixtureDoc.success) visit(fixtureDoc.root);
+        check(equations >= 15, "all fixture equations were recognized by Markdown");
         auto markdown = app.parser.parse("$$\n\\begin{bmatrix}1&2\\\\5&6\\end{bmatrix}\\longrightarrow 6\n$$");
         check(markdown.success && !markdown.root->children.empty(), "display math Markdown parses");
         if (markdown.success && !markdown.root->children.empty()) {
@@ -41,6 +108,15 @@ int main(int argc, char** argv) {
             check(std::isfinite(mathBoxWidth(box)) && mathBoxWidth(box) > 0 && mathBoxHeight(box) > 0,
                   "finite nonempty layout");
             check(mathBoxBaseline(box) > 0 && mathBoxBaseline(box) < mathBoxHeight(box), "baseline inside box");
+        }
+        float above = 0, below = 0;
+        constexpr float textBaseline = 19.2f, normalLineHeight = 40.8f;
+        for (const auto& box : {simple, tall, nested}) mathExpandLine(box, textBaseline, normalLineHeight, above, below);
+        check(above > 0 && below > 0, "tall inline math reserves space above and below text");
+        for (const auto& box : {simple, tall, nested}) {
+            float top = above + textBaseline - mathBoxBaseline(box);
+            check(top >= -0.01f && top + mathBoxHeight(box) <= normalLineHeight + above + below + 0.01f,
+                  "every inline box fits between neighboring lines with a shared text baseline");
         }
         check(!mathParse(app, LR"(\begin{bmatrix}1&2\end{matrix})", 24, true), "invalid matrix falls back in renderer");
         auto svg = mathBoxSvg(tall, "#111111", "Segoe UI");
@@ -66,9 +142,11 @@ int main(int argc, char** argv) {
         mathBoxRetain(app, tall, 5, 10, D2D1::ColorF(D2D1::ColorF::Black));
         check(!app.layoutTextRuns.empty() && !app.layoutLines.empty(), "retained viewer receives same primitives");
         app.clearLayoutCache();
+        check(rasterize({simple, tall, nested}), "native Direct2D offscreen drawing produces pixels");
         if (argc > 1) {
             std::ofstream out(argv[1]);
             out << "<!doctype html><meta charset=utf-8><style>body{font:18px Segoe UI;padding:30px}section{margin:25px}</style>";
+            std::vector<MathBoxPtr> samples;
             for (const auto* tex : {
                 LR"(\begin{bmatrix}1&2\\5&6\end{bmatrix}\longrightarrow 6,\qquad\begin{bmatrix}3&4\\7&8\end{bmatrix}\longrightarrow 8)",
                 LR"(\begin{bmatrix}1&2\\3&4\\5&6\\7&8\\9&0\end{bmatrix})",
@@ -84,7 +162,15 @@ int main(int argc, char** argv) {
                 LR"(\left\{\frac{x}{y}\middle|x>0\right\}\qquad\bigl(x\bigr)\Bigl(x\Bigr)\Biggl(x\Biggr))",
                 LR"(\begin{array}{r|l}\hline 1&22\\\hline 333&4\\\hline\end{array}\qquad a\equiv b\pmod{n})",
                 LR"(\newcommand{\norm}[1]{\left\lVert#1\right\rVert}\norm{\frac{x}{y}}\geq0)"}) {
-                out << "<section>" << mathBoxSvg(mathParse(app, tex, 24, true), "#17212b", "Segoe UI") << "</section>";
+                auto box = mathParse(app, tex, 24, true);
+                check(box != nullptr, "visual sample renders");
+                samples.push_back(box);
+                out << "<section>" << mathBoxSvg(box, "#17212b", "Segoe UI") << "</section>";
+            }
+            if (argc > 2) {
+                std::string filename = argv[2];
+                std::wstring path(filename.begin(), filename.end());
+                check(rasterize(samples, path.c_str()), "native sample sheet exports to PNG");
             }
         }
         mathClearCache();

--- a/tests/math_parser_tests.cpp
+++ b/tests/math_parser_tests.cpp
@@ -1,0 +1,45 @@
+#include "math_parser.h"
+
+#include <iostream>
+
+using namespace tinta_math;
+namespace {
+int failures = 0;
+void check(bool condition, const char* message) {
+    if (!condition) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+}
+
+int main() {
+    const std::wstring example = LR"(\begin{bmatrix}1&2\\5&6\end{bmatrix}\longrightarrow 6,
+        \qquad\begin{bmatrix}3&4\\7&8\end{bmatrix}\longrightarrow 8)";
+    auto root = parseLatex(example);
+    check(root != nullptr, "issue #190 example parses");
+    if (root) {
+        auto matrix = root->kids.front()->kids.front();
+        check(matrix->kind == MNode::Grid && matrix->cells.size() == 2 &&
+              matrix->cells[0].size() == 2 && matrix->cells[1][1]->kids[0]->text == L"6",
+              "matrix preserves cell boundaries and values");
+    }
+    for (const auto* env : {L"matrix", L"pmatrix", L"bmatrix", L"Bmatrix", L"vmatrix",
+                            L"Vmatrix", L"smallmatrix", L"cases", L"rcases", L"aligned", L"split"}) {
+        check(parseLatex(L"\\begin{" + std::wstring(env) + L"}x&y\\\\z&w\\end{" + env + L"}") != nullptr,
+              "supported grid environment parses");
+    }
+    check(parseLatex(LR"(\begin{array}{rl}x&y\\z&w\end{array})") != nullptr, "array alignment");
+    check(parseLatex(LR"(\begin{gathered}x=1\\y=2\end{gathered})") != nullptr, "gathered");
+    check(parseLatex(LR"(\begin{matrix}\frac{a}{b}&\begin{pmatrix}x\\y\end{pmatrix}\\z&\&\end{matrix})") != nullptr,
+          "nested matrices, fractions and escaped ampersand");
+    check(parseLatex(LR"(\begin{matrix}1&2\\\end{matrix})") != nullptr, "trailing row separator");
+    for (const auto* bad : {LR"(\begin{matrix}1&2)", LR"(\begin{matrix}1\end{pmatrix})",
+                           LR"(\begin{unknown}1\end{unknown})", LR"(a&b)", LR"(a\\b)",
+                           LR"(\begin{matrix}{a&b}\end{matrix})", LR"(a})", LR"(\frac{1})",
+                           LR"(\begin{array}{xx}a&b\end{array})", LR"(\end{matrix})"}) {
+        check(!parseLatex(bad), "malformed/unsupported input falls back");
+    }
+    check(!parseLatex(std::wstring(200, L'{') + L"x" + std::wstring(200, L'}')), "nesting is bounded");
+    check(!parseLatex(std::wstring(40000, L'x')), "input size is bounded");
+    check(parseLatex(L"x % ignored command \\unknown\n + y") != nullptr, "TeX comments");
+    std::cout << "Math parser: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/tests/math_parser_tests.cpp
+++ b/tests/math_parser_tests.cpp
@@ -1,6 +1,7 @@
 #include "math_parser.h"
 
 #include <iostream>
+#include <cstdint>
 
 using namespace tinta_math;
 namespace {
@@ -84,6 +85,32 @@ int main() {
     for (const auto* tex : {LR"(\left\bogus x\right))", LR"(\left(x\rightfoo))",
                             LR"(\middle|x)", LR"(x\hspace{huge}y)", LR"(\big q)"})
         check(!parseLatex(tex), "malformed delimiters and lengths fail");
+    check(textOf(parseLatex(LR"(\newcommand{\a}{x}\renewcommand{\a}{y}\providecommand{\a}{z}\a)")) == L"y",
+          "renew/provide semantics");
+    check(textOf(parseLatex(LR"(\newcommand{\a}[1]{\text{#1}}\a{two words})")) == L"two words",
+          "macro substitution preserves text whitespace");
+    check(textOf(parseLatex(LR"(\newcommand{\a}[1]{#1x}\a{\alpha})")) == L"\u03B1x", "argument token boundary");
+    std::wstring excessiveRows = L"\\begin{matrix}x";
+    for (int i = 0; i < 64; ++i) excessiveRows += L"\\\\x";
+    check(!parseLatex(excessiveRows + L"\\end{matrix}"), "matrix row count is bounded");
+    // Deterministic mutation smoke test: malformed input must terminate without
+    // crashes, including partially typed environments and macro definitions.
+    const std::vector<std::wstring> seeds = {example,
+        LR"(\newcommand{\v}[1]{\begin{pmatrix}#1\end{pmatrix}}\v{a\\b})",
+        LR"(\left\{\frac{x^2}{y}\middle|x>0\right\})",
+        LR"(\text{for all }x\in\mathbb{R})",
+        LR"(\sum_{\substack{i>0\\j>0}}a_{ij})"};
+    const std::wstring alphabet = L"{}[]\\&_^#% abc123";
+    uint32_t random = 190;
+    for (int i = 0; i < 2000; ++i) {
+        std::wstring input = seeds[static_cast<size_t>(i) % seeds.size()];
+        random = random * 1664525u + 1013904223u;
+        size_t at = random % input.size();
+        if (i % 3 == 0) input.erase(at, 1);
+        else if (i % 3 == 1) input.insert(at, 1, alphabet[random % alphabet.size()]);
+        else input.resize(at);
+        parseLatex(input);
+    }
     std::cout << "Math parser: " << failures << " failures\n";
     return failures ? 1 : 0;
 }

--- a/tests/math_parser_tests.cpp
+++ b/tests/math_parser_tests.cpp
@@ -64,6 +64,26 @@ int main() {
     for (const auto* tex : {LR"(\sqrt[3{x})", LR"(\text{unterminated)", LR"(x^2^3)",
                             LR"(\overset{a})", LR"(\limits x)", LR"(\overline)", LR"(\mathbf)"})
         check(!parseLatex(tex), "invalid extended notation fails cleanly");
+    check(textOf(parseLatex(LR"(\newcommand{\R}{\mathbb{R}}x\in\R)")) == L"x\u2208\u211D", "custom notation expands");
+    check(textOf(parseLatex(LR"(\newcommand{\f}[2][x]{#1+#2}\f{y}+\f[z]{w})")) == L"x+y+z+w", "optional macro arguments");
+    check(textOf(parseLatex(LR"(\def\f#1#2{#2+#1}\f{a}{b})")) == L"b+a", "basic def arguments");
+    check(textOf(parseLatex(LR"(\def\a{\alpha}\a x)")) == L"\u03B1x", "expanded control words keep token boundaries");
+    check(textOf(parseLatex(LR"(\def\a{x}{\def\a{y}\a}\a)")) == L"yx", "macro definitions respect group scope");
+    check(parseLatex(LR"(\DeclareMathOperator*{\argmin}{arg min}\argmin_x f(x))") != nullptr, "declared operators");
+    check(parseLatex(LR"(\newcommand{\v}[1]{\begin{pmatrix}#1\end{pmatrix}}\v{a\\b})") != nullptr, "macros may generate environments");
+    for (const auto* tex : {LR"(\def\a{\a}\a)", LR"(\newcommand{\a}[1]{#2}\a{x})",
+        LR"(\newcommand{\frac}{x}\frac)", LR"(\renewcommand{\unknown}{x}\unknown)",
+        LR"(\def\f#1{#1}\f)", LR"({\def\a{x}}\a)"})
+        check(!parseLatex(tex), "invalid/recursive macros fail without leaking definitions");
+    check(!parseLatex(LR"(\R)"), "definitions do not leak to another equation");
+    for (const auto* tex : {LR"(\left\{\frac{x}{y}\middle|x>0\right\})",
+        LR"(\bigl( x \Bigr])", LR"(x\hspace{1em}y\kern 2pt z\mkern-3mu w)",
+        LR"(a\equiv b\pmod{n})", LR"(\begin{bmatrix*}[r]1&22\\333&4\end{bmatrix*})",
+        LR"(\begin{array}{r|l}\hline x&y\\\hline z&w\\\hline\end{array})"})
+        check(parseLatex(tex) != nullptr, "spacing and delimiter compatibility");
+    for (const auto* tex : {LR"(\left\bogus x\right))", LR"(\left(x\rightfoo))",
+                            LR"(\middle|x)", LR"(x\hspace{huge}y)", LR"(\big q)"})
+        check(!parseLatex(tex), "malformed delimiters and lengths fail");
     std::cout << "Math parser: " << failures << " failures\n";
     return failures ? 1 : 0;
 }

--- a/tests/math_parser_tests.cpp
+++ b/tests/math_parser_tests.cpp
@@ -8,6 +8,13 @@ int failures = 0;
 void check(bool condition, const char* message) {
     if (!condition) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
 }
+std::wstring textOf(const MNodePtr& node) {
+    if (!node) return {};
+    std::wstring result = node->text;
+    for (const auto& child : node->kids) result += textOf(child);
+    for (const auto& row : node->cells) for (const auto& cell : row) result += textOf(cell);
+    return result;
+}
 }
 
 int main() {
@@ -40,6 +47,23 @@ int main() {
     check(!parseLatex(std::wstring(200, L'{') + L"x" + std::wstring(200, L'}')), "nesting is bounded");
     check(!parseLatex(std::wstring(40000, L'x')), "input size is bounded");
     check(parseLatex(L"x % ignored command \\unknown\n + y") != nullptr, "TeX comments");
+    check(textOf(parseLatex(LR"(\text{for all }x\text{ and }y)")) == L"for all x and y", "text spaces survive");
+    check(textOf(parseLatex(LR"(\text{a \textbf{bold} word \& \{x\}})")) == L"a bold word & {x}", "nested text and escapes");
+    check(textOf(parseLatex(LR"(\mathbb{RNCZ})")) == L"\u211D\u2115\u2102\u2124", "braced blackboard alphabet");
+    check(textOf(parseLatex(LR"(\mathcal{BL}\mathfrak{CH})")) == L"\u212C\u2112\u212D\u210C", "script and fraktur exceptions");
+    check(textOf(parseLatex(LR"(\epsilon\varepsilon\phi\varphi)")) == L"\u03F5\u03B5\u03D5\u03C6", "Greek variants remain distinct");
+    for (const auto* tex : {
+        LR"(\sqrt[3]{x+1})", LR"(\binom{n}{k}+\dbinom{n}{2})", LR"(\cfrac{1}{1+\cfrac{1}{x}})",
+        LR"(\sum\limits_{i=1}^n x_i)", LR"(\int\nolimits_0^1 f(x))", LR"(\operatorname*{arg max}_{x}f(x))",
+        LR"(\sum_{\substack{i>0\\j>0}}a_{ij})", LR"(\overset{!}{=}\underset{x}{y})",
+        LR"(A\xrightarrow[n\to\infty]{f}B)", LR"(\underbrace{a+b}_{\text{sum}})",
+        LR"(\widetilde{xy}+\dot{x}+\ddot{x}+\underline{y}+\boxed{x=2}+\cancel{x})",
+        LR"(\mathbb{ABCabc123}\mathsf{XYZ}\mathtt{abc}\boldsymbol{\alpha})"}) {
+        check(parseLatex(tex) != nullptr, "common extended notation parses");
+    }
+    for (const auto* tex : {LR"(\sqrt[3{x})", LR"(\text{unterminated)", LR"(x^2^3)",
+                            LR"(\overset{a})", LR"(\limits x)", LR"(\overline)", LR"(\mathbf)"})
+        check(!parseLatex(tex), "invalid extended notation fails cleanly");
     std::cout << "Math parser: " << failures << " failures\n";
     return failures ? 1 : 0;
 }

--- a/tests/render_math_fixtures.ps1
+++ b/tests/render_math_fixtures.ps1
@@ -1,0 +1,95 @@
+param(
+    [Parameter(Mandatory = $true)][string]$Binary,
+    [string]$BaselineBinary,
+    [string]$OutputDirectory
+)
+
+# Run on Windows with a graphics session. Outputs are review artifacts;
+# successful exports alone do not prove that the pages look correct.
+$ErrorActionPreference = 'Stop'
+$repo = Split-Path $PSScriptRoot -Parent
+$binaryPath = (Resolve-Path -LiteralPath $Binary).Path
+if (!$OutputDirectory) {
+    $OutputDirectory = Join-Path $repo ('out/math-fixtures-' + (Get-Date -Format 'yyyyMMdd-HHmmss-fff'))
+}
+if (Test-Path -LiteralPath $OutputDirectory) {
+    throw 'Use a new output directory so old pages cannot mask a missing export.'
+}
+$output = [IO.Directory]::CreateDirectory($OutputDirectory).FullName
+
+function New-PortableRunner([string]$Source, [string]$Name) {
+    $folder = [IO.Directory]::CreateDirectory((Join-Path $output $Name)).FullName
+    $exe = Join-Path $folder 'tinta.exe'
+    Copy-Item -LiteralPath $Source -Destination $exe
+    # Isolate settings, recent files and drafts from the user's installation.
+    @'
+[Settings]
+themeIndex=0
+followSystemTheme=0
+windowWidth=1050
+windowHeight=900
+windowMaximized=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+tocPinned=0
+browserPinned=0
+language=en
+'@ | Set-Content -LiteralPath (Join-Path $folder 'settings.ini') -Encoding ASCII
+    return $exe
+}
+
+function Invoke-Fixture([string]$Exe, [string]$Name, [string]$Destination) {
+    $inputPath = Join-Path $PSScriptRoot "fixtures/$Name.md"
+    [IO.Directory]::CreateDirectory($Destination) | Out-Null
+    foreach ($mode in @('printpages', 'exporthtml')) {
+        $target = if ($mode -eq 'printpages') { Join-Path $Destination 'pages' } else { Join-Path $Destination 'document.html' }
+        $process = Start-Process -FilePath $Exe -ArgumentList @('"' + $inputPath + '"', "--$mode", '"' + $target + '"') -WindowStyle Hidden -PassThru
+        if (!$process.WaitForExit(30000)) {
+            Stop-Process -Id $process.Id
+            throw "$Name --$mode timed out"
+        }
+        if ($process.ExitCode -ne 0) { throw "$Name --$mode failed: $($process.ExitCode)" }
+    }
+    $pages = @(Get-ChildItem -LiteralPath (Join-Path $Destination 'pages') -Filter 'page-*.png')
+    if ($pages.Count -eq 0) { throw "$Name produced no pages" }
+    foreach ($page in $pages) {
+        if ($page.Length -lt 1000) { throw "Suspiciously empty page: $($page.FullName)" }
+    }
+    $html = Get-Content -LiteralPath (Join-Path $Destination 'document.html') -Raw -Encoding UTF8
+    $mathCount = [regex]::Matches($html, 'class="math-(inline|display)"').Count
+    $expected = @{ 'math-compatibility' = 15; 'math-mixed-layout' = 25; 'math-inline-stress' = 9; 'markdown-regression-control' = 0 }
+    if ($mathCount -ne $expected[$Name]) { throw "$Name exported $mathCount math spans; expected $($expected[$Name])" }
+    if ($Name -eq 'math-mixed-layout' -and $html -notmatch '<a [^>]*><span class="math-inline"><svg[^>]*>[\s\S]*?currentColor') {
+        throw 'Math links lost their SVG or inherited color'
+    }
+    if ($Name -ne 'math-compatibility' -and $html -notmatch '<table>') { throw "$Name lost its table" }
+    Write-Output "$Name : $($pages.Count) native pages, $mathCount exported equations"
+}
+
+$runner = New-PortableRunner $binaryPath 'current'
+foreach ($fixture in @('math-compatibility', 'math-mixed-layout', 'math-inline-stress', 'markdown-regression-control')) {
+    Invoke-Fixture $runner $fixture (Join-Path $output $fixture)
+}
+if ($BaselineBinary) {
+    $baseline = New-PortableRunner (Resolve-Path -LiteralPath $BaselineBinary).Path 'baseline'
+    $control = 'markdown-regression-control'
+    $baselineOutput = Join-Path $output 'baseline-control'
+    Invoke-Fixture $baseline $control $baselineOutput
+    $currentOutput = Join-Path $output $control
+    $currentPages = @(Get-ChildItem -LiteralPath (Join-Path $currentOutput 'pages') -Filter 'page-*.png')
+    $baselinePages = @(Get-ChildItem -LiteralPath (Join-Path $baselineOutput 'pages') -Filter 'page-*.png')
+    if ($currentPages.Count -ne $baselinePages.Count) { throw 'Control pagination changed from baseline' }
+    foreach ($page in $currentPages) {
+        $reference = Join-Path $baselineOutput ('pages/' + $page.Name)
+        if ((Get-FileHash -LiteralPath $page.FullName).Hash -ne (Get-FileHash -LiteralPath $reference).Hash) {
+            throw "Control page differs from baseline: $($page.Name); inspect the images"
+        }
+    }
+    if ((Get-FileHash -LiteralPath (Join-Path $currentOutput 'document.html')).Hash -ne
+        (Get-FileHash -LiteralPath (Join-Path $baselineOutput 'document.html')).Hash) {
+        throw 'Control HTML differs from baseline; inspect the exports'
+    }
+    Write-Output 'Existing Markdown control: native PNGs and HTML are byte-identical to baseline.'
+}
+Write-Output "Review artifacts: $output"


### PR DESCRIPTION
The matrix example in #190 previously caused the entire equation to fall back to raw TeX. It now renders natively, including nested matrices, correctly sized delimiters and long arrows.

This also extends the existing renderer with cases, aligned/gathered equations, arrays and rules, indexed roots, binomial coefficients, limits, stacked annotations, labelled arrows, additional symbols and accents, mathematical alphabets, explicit spacing and equation-local macros. Text preserves spaces, fraction styles differ correctly, and tall inline equations reserve paragraph line space. Math also inherits highlighting, strikethrough and link colors; equations inside links are clickable.

Cambria Math is loaded from Windows when available, with the theme font as fallback. No fonts or rendering dependencies are bundled. Viewer drawing, native raster output and SVG share the layout. The supported subset and remaining limitations are documented in docs/math-support.md.

Validation:

- MSVC x64 Release build succeeds.
- All seven CTest suites pass.
- All 49 equations in three Markdown fixtures render, including the issue's exact example and mixed headings, aligned tables, nested lists, emphasis, links, quotes, callouts, literal code and Mermaid.
- Parser coverage includes nested/invalid environments, macro scoping and recursion, and 2,000 deterministic malformed-input mutations.
- Layout tests verify sizes, baselines, inline spacing, SVG primitives and native Direct2D offscreen drawing. Native PNG and browser-rendered SVG sample sheets were visually checked.
- Full-application fixture harness produces eight native math-document pages plus a two-page existing-Markdown control. Control PNGs and HTML are byte-identical to the pre-extension build.
- Mixed native pages and HTML exports were visually inspected. Computer-use checks covered the light viewer at 1050-pixel window width, the dark viewer at 650 pixels, scrolling, table borders and clicking a math glyph to open its linked local Markdown file. HTML was checked at 1100 and 650 pixels.
- tests/render_math_fixtures.ps1 reproduces native/HTML exports in an isolated portable configuration; AGENTS.md records the fixture and visual-validation workflow for future features.
- Same-toolchain executable comparison: 2,271,744 bytes before, 2,351,104 bytes after (+77.5 KiB, about 3.5%).

Scope: this remains a math subset. Document-wide macros, equation numbering/references, alternate Markdown math delimiters and arbitrary LaTeX packages are not implemented. Tall inline equations use uniform expanded line spacing within their paragraph.

Implementation commits (all reference #190):

- [a53aece — matrix/cases/aligned foundation](https://github.com/oipoistar/tinta/commit/a53aece)
- [25d7306 — notation, styles and alphabets](https://github.com/oipoistar/tinta/commit/25d7306)
- [6080cf8 — macros, arrays and spacing](https://github.com/oipoistar/tinta/commit/6080cf8)
- [88fe7bc — inline spacing, regression coverage and documentation](https://github.com/oipoistar/tinta/commit/88fe7bc)
- [88b42ee — avoid math allocations in plain paragraphs](https://github.com/oipoistar/tinta/commit/88b42ee)

- [c26980c — mixed Markdown styling, links and regression fixtures](https://github.com/oipoistar/tinta/commit/c26980c)
- [64a7f9d — repeatable fixture validation and workflow](https://github.com/oipoistar/tinta/commit/64a7f9d)

Refs #190. This PR is a draft; no issue reply has been posted.
