### PR TITLE
Add an application menu to the top-left icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCES
     src/render.cpp
     src/file_utils.cpp
     src/overlays.cpp
+    src/context_menu.cpp
     src/input.cpp
     src/editor.cpp
     src/mermaid.cpp
@@ -140,6 +141,13 @@ target_compile_definitions(tinta PRIVATE UNICODE _UNICODE
     TINTA_VERSION_PATCH=${PROJECT_VERSION_PATCH})
 
 if(BUILD_TESTING)
+    add_executable(context_menu_tests tests/context_menu_tests.cpp src/context_menu.cpp
+        src/markdown.cpp src/themes.cpp src/config_dir.cpp)
+    target_include_directories(context_menu_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(context_menu_tests PRIVATE md4c shell32)
+    target_compile_definitions(context_menu_tests PRIVATE UNICODE _UNICODE)
+    add_test(NAME context_menu COMMAND context_menu_tests)
+
     add_executable(math_parser_tests tests/math_parser_tests.cpp src/math_parser.cpp src/math_macros.cpp)
     target_include_directories(math_parser_tests PRIVATE src)
     add_test(NAME math_parser COMMAND math_parser_tests)

--- a/include/app.h
+++ b/include/app.h
@@ -566,8 +566,11 @@ struct App {
     bool folderInputJustOpened = false;      // Swallow the WM_CHAR of the key that opened it
     bool folderBrowserInputError = false;    // Last commit failed (bad path/name): red border
 
-    // Right-click context menu overlay
+    // Shared document context menu / icon application menu
     bool showContextMenu = false;
+    bool applicationMenu = false;
+    bool appMenuHover = false;
+    bool contextMenuKeyboard = false;
     // The mouse-up of a menu-item click must not reach the overlay handlers:
     // an action that opens the TOC or theme chooser would otherwise be
     // closed instantly by its own click's release landing "outside the panel"

--- a/include/editor.h
+++ b/include/editor.h
@@ -34,7 +34,8 @@ void restoreEditBuffer(App& app, const std::wstring& text, bool dirty,
 // shows a centered "Open a file" button in the preview pane until typing
 // starts; the button (or Ctrl+O) opens the classic file picker
 bool quickNoteEmptyStateActive(const App& app);
-void quickNoteOpenFile(App& app, HWND hwnd);
+// Open in a tab, preserving existing/unsaved documents in either mode.
+void openFileDialog(App& app, HWND hwnd);
 void renderQuickNoteEmptyState(App& app);
 
 // File save; Save As (Ctrl+Shift+S) re-prompts for the path and moves the
@@ -48,7 +49,8 @@ void saveFileAs(App& app, HWND hwnd);
 void confirmExitAction(App& app, HWND hwnd, int action);
 
 // Editor reparse (called from timer)
-void editorReparse(App& app);
+// Exports need the current buffer even when the preview pane is hidden.
+void editorReparse(App& app, bool force = false);
 // External edits: undo-capable range replace plus dirty + immediate
 // reparse, used by the preview table cell editor (#148)
 void editorReplaceRangeExternal(App& app, size_t start, size_t end,

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -100,8 +100,34 @@ enum ContextMenuItem {
     CTX_THEME,
     CTX_SETTINGS,
     CTX_HELP,
+    CTX_QUICK_NOTE,
+    CTX_OPEN,
+    CTX_SAVE,
+    CTX_SAVE_AS,
+    CTX_EXIT,
     CTX_ITEM_COUNT
 };
+struct ContextMenuEntry {
+    int action;
+    const char* key;
+    const wchar_t* shortcut;
+    bool separatorAfter;
+};
+const std::vector<ContextMenuEntry>& contextMenuEntries(const App& app);
+float contextMenuItemHeight(const App& app);
+float contextMenuSeparatorHeight(const App& app);
+float contextMenuPadding(const App& app);
+float contextMenuWidth(const App& app);
+float contextMenuHeight(const App& app);
+float contextMenuItemTop(const App& app, int row);
+int nextContextMenuItem(const App& app, int current, int direction);
+bool updateContextMenuHover(App& app, float x, float y, bool mouseMoved);
+void closeContextMenu(App& app);
+// The same icon cell is clickable in the caption and the editor tool rail.
+D2D1_RECT_F appMenuButtonRect(const App& app);
+bool appMenuButtonAt(const App& app, float x, float y);
+bool appMenuAvailable(const App& app);
+void renderAppMenuButtonBackground(App& app);
 void renderContextMenu(App& app);
 
 // Hovering a local .md link for a beat previews the target's first lines
@@ -119,7 +145,7 @@ D2D1_RECT_F lightboxImageRect(const App& app);
 void renderFolderSearchResults(App& app);
 bool folderSearchToggleAt(const App& app, float x, float y);
 // Opens at (x, y) client coordinates, clamped so the menu stays on screen
-void openContextMenu(App& app, float x, float y);
+void openContextMenu(App& app, float x, float y, bool application = false);
 // Item index under the point, or -1 (separators and gaps count as none)
 int contextMenuItemAt(const App& app, float x, float y);
 bool contextMenuItemEnabled(const App& app, int item);

--- a/src/context_menu.cpp
+++ b/src/context_menu.cpp
@@ -1,0 +1,154 @@
+#include "overlays.h"
+
+#include <algorithm>
+
+const std::vector<ContextMenuEntry>& contextMenuEntries(const App& app) {
+    static const std::vector<ContextMenuEntry> document = {
+        {CTX_COPY, "ctx.copy", L"Ctrl+C", false},
+        {CTX_SELECT_ALL, "ctx.select_all", L"Ctrl+A", false},
+        {CTX_ANNOTATE, "ctx.annotate", L"", true},
+        {CTX_NEW, "ctx.new", L"", false},
+        {CTX_PRINT, "ctx.print", L"Ctrl+P", false},
+        {CTX_EXPORT, "ctx.export", L"", false},
+        {CTX_EDIT, "ctx.edit", L"", false},
+        {CTX_SEARCH, "ctx.search", L"", false},
+        {CTX_TOC, "ctx.toc", L"", true},
+        {CTX_BROWSE, "ctx.browse", L"", false},
+        {CTX_REVEAL, "ctx.reveal", L"", true},
+        {CTX_THEME, "ctx.theme", L"", false},
+        {CTX_SETTINGS, "ctx.settings", L"Ctrl+,", false},
+        {CTX_HELP, "ctx.help", L"", false},
+    };
+    static const std::vector<ContextMenuEntry> application = {
+        {CTX_QUICK_NOTE, "ctx.new", L"Ctrl+N", false},
+        {CTX_OPEN, "ctx.open", L"Ctrl+O", false},
+        {CTX_SAVE, "ctx.save", L"Ctrl+S", false},
+        {CTX_SAVE_AS, "ctx.save_as", L"Ctrl+Shift+S", true},
+        {CTX_PRINT, "ctx.print", L"Ctrl+P", false},
+        {CTX_EXPORT, "ctx.export", L"", true},
+        {CTX_THEME, "ctx.theme", L"", false},
+        {CTX_SETTINGS, "ctx.settings", L"Ctrl+,", false},
+        {CTX_HELP, "ctx.help", L"", true},
+        {CTX_EXIT, "ctx.exit", L"Alt+F4", false},
+    };
+    return app.applicationMenu ? application : document;
+}
+
+float contextMenuPadding(const App& app) { return dpi(app, 6.0f); }
+float contextMenuSeparatorHeight(const App& app) { return dpi(app, 9.0f); }
+float contextMenuWidth(const App& app) {
+    return std::min(dpi(app, app.applicationMenu ? 260.0f : 210.0f), (float)app.width);
+}
+
+// Keep every action reachable on short windows and at high display scaling.
+float contextMenuItemHeight(const App& app) {
+    const auto& entries = contextMenuEntries(app);
+    float gaps = contextMenuPadding(app) * 2;
+    for (const auto& entry : entries)
+        if (entry.separatorAfter) gaps += contextMenuSeparatorHeight(app);
+    float available = app.height - chromeTopHeight(app) - gaps;
+    return std::max(1.0f, std::min(dpi(app, 30.0f), available / (float)entries.size()));
+}
+
+float contextMenuHeight(const App& app) {
+    float h = contextMenuPadding(app) * 2;
+    for (const auto& entry : contextMenuEntries(app)) {
+        h += contextMenuItemHeight(app);
+        if (entry.separatorAfter) h += contextMenuSeparatorHeight(app);
+    }
+    return h;
+}
+
+float contextMenuItemTop(const App& app, int row) {
+    float y = contextMenuPadding(app);
+    const auto& entries = contextMenuEntries(app);
+    for (int i = 0; i < row; i++) {
+        y += contextMenuItemHeight(app);
+        if (entries[i].separatorAfter) y += contextMenuSeparatorHeight(app);
+    }
+    return y;
+}
+
+bool contextMenuItemEnabled(const App& app, int item) {
+    bool document = app.editMode || !app.currentFile.empty() || app.startPageEmbeddedOpen;
+    switch (item) {
+        case CTX_COPY: return app.hasSelection && app.selAnchor != app.selFocus;
+        case CTX_ANNOTATE:
+            return !app.editMode && !app.currentFile.empty() &&
+                   app.hasSelection && app.selAnchor != app.selFocus;
+        case CTX_SAVE: return app.editMode;
+        case CTX_SAVE_AS: return app.editMode || !app.currentFile.empty();
+        case CTX_PRINT: case CTX_EXPORT: case CTX_EDIT:
+        case CTX_SELECT_ALL: case CTX_SEARCH: case CTX_TOC:
+            return document;
+        case CTX_REVEAL: return !app.currentFile.empty();
+        default: return item >= 0 && item < CTX_ITEM_COUNT;
+    }
+}
+
+int contextMenuItemAt(const App& app, float x, float y) {
+    if (x < app.contextMenuX || x >= app.contextMenuX + contextMenuWidth(app)) return -1;
+    const auto& entries = contextMenuEntries(app);
+    for (int row = 0; row < (int)entries.size(); row++) {
+        float top = app.contextMenuY + contextMenuItemTop(app, row);
+        if (y >= top && y < top + contextMenuItemHeight(app)) return entries[row].action;
+    }
+    return -1;
+}
+
+int nextContextMenuItem(const App& app, int current, int direction) {
+    const auto& entries = contextMenuEntries(app);
+    int count = (int)entries.size();
+    int row = direction > 0 ? -1 : 0;
+    for (int i = 0; i < count; i++) if (entries[i].action == current) row = i;
+    for (int i = 0; i < count; i++) {
+        row = (row + direction + count) % count;
+        if (contextMenuItemEnabled(app, entries[row].action)) return entries[row].action;
+    }
+    return -1;
+}
+
+void closeContextMenu(App& app) {
+    app.showContextMenu = false;
+    app.contextMenuAnimation = 0;
+    app.hoveredContextMenuItem = -1;
+    app.contextMenuKeyboard = false;
+}
+
+bool updateContextMenuHover(App& app, float x, float y, bool mouseMoved) {
+    // Repainting/activation can resend WM_MOUSEMOVE at the same position.
+    if (app.contextMenuKeyboard && !mouseMoved) return false;
+    int item = contextMenuItemAt(app, x, y);
+    bool changed = app.contextMenuKeyboard || item != app.hoveredContextMenuItem;
+    app.contextMenuKeyboard = false;
+    app.hoveredContextMenuItem = item;
+    return changed;
+}
+
+void openContextMenu(App& app, float x, float y, bool application) {
+    app.applicationMenu = application;
+    app.contextMenuX = std::max(0.0f, std::min(x, app.width - contextMenuWidth(app)));
+    app.contextMenuY = std::max(chromeTopHeight(app),
+                              std::min(y, app.height - contextMenuHeight(app)));
+    app.showContextMenu = true;
+    app.hoveredContextMenuItem = -1;
+    app.contextMenuKeyboard = false;
+    app.contextMenuAnimation = 0;
+    app.hoveredCodeBlock = -1;
+    app.hoveredLink.clear();
+}
+
+D2D1_RECT_F appMenuButtonRect(const App& app) {
+    return D2D1::RectF(0, 0, dpi(app, app.editMode ? 48.0f : 40.0f), chromeTopHeight(app));
+}
+
+bool appMenuButtonAt(const App& app, float x, float y) {
+    auto r = appMenuButtonRect(app);
+    return x >= r.left && x < r.right && y >= r.top && y < r.bottom;
+}
+
+bool appMenuAvailable(const App& app) {
+    return !app.zenMode && !app.confirmExitPending && !app.createRefPending &&
+           !app.showPrintPreview && !app.showLightbox && !app.annotEditorOpen &&
+           !app.showThemeEditor && !app.showShortcutEditor;
+}

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -781,9 +781,9 @@ void editorMarkDirtyAndReparse(App& app) {
     editorReparse(app);
 }
 
-void editorReparse(App& app) {
+void editorReparse(App& app, bool force) {
     KillTimer(app.hwnd, TIMER_EDITOR_REPARSE);
-    if (!app.editMode || !app.editorShowPreview) return;
+    if (!app.editMode || (!app.editorShowPreview && !force)) return;
     std::string utf8 = toUtf8(app.editorText);
 
     // Build line-to-byte-offset mapping for scroll sync
@@ -913,6 +913,9 @@ void restoreEditBuffer(App& app, const std::wstring& text, bool dirty,
     app.editorDirty = dirty;
     app.editorCursorPos = std::min(cursor, app.editorText.size());
     app.editorScrollY = std::max(0.0f, scrollY);
+    // Opening another file parks the unsaved source; restore its preview
+    // from that source too, rather than the last saved file or empty note.
+    editorReparse(app);
     updateWindowTitle(app);
 }
 
@@ -1062,12 +1065,15 @@ bool quickNoteEmptyStateActive(const App& app) {
     return app.editMode && app.currentFile.empty() && app.editorText.empty();
 }
 
-void quickNoteOpenFile(App& app, HWND hwnd) {
+void openFileDialog(App& app, HWND hwnd) {
     wchar_t path[MAX_PATH] = L"";
     OPENFILENAMEW ofn = {};
     ofn.lStructSize = sizeof(ofn);
     ofn.hwndOwner = hwnd;
-    ofn.lpstrFilter = L"Markdown / Mermaid (*.md;*.markdown;*.mmd)\0"
+    ofn.lpstrFilter = L"Documents (*.md;*.mmd;*.txt;*.json;*.yaml;...)\0"
+                      L"*.md;*.markdown;*.mmd;*.txt;*.json;*.yaml;*.yml;*.toml;"
+                      L"*.ini;*.csv;*.log\0"
+                      L"Markdown / Mermaid (*.md;*.markdown;*.mmd)\0"
                       L"*.md;*.markdown;*.mmd\0"
                       L"All files (*.*)\0*.*\0";
     ofn.lpstrFile = path;
@@ -1076,11 +1082,12 @@ void quickNoteOpenFile(App& app, HWND hwnd) {
                 OFN_HIDEREADONLY;
     if (!GetOpenFileNameW(&ofn)) return;
 
-    // The picked document takes over: open it as a tab (dedupe and
-    // activation included — this parks and leaves the empty editor),
-    // then drop the untitled shell tab
+    // Only an empty launcher/note is replaced. A document or unsaved
+    // buffer stays in its tab, including when the picked path is open.
+    bool replaceEmpty = app.currentFile.empty() && !app.startPageEmbeddedOpen &&
+                        (!app.editMode || (app.editorText.empty() && !app.editorDirty));
     tabsInit(app);
-    int untitledId = app.tabs[app.activeTab].id;
+    int untitledId = replaceEmpty ? app.tabs[app.activeTab].id : -1;
     tabOpenPath(app, hwnd, toUtf8(path));
     for (int i = 0; i < (int)app.tabs.size(); i++) {
         if (app.tabs[i].id == untitledId) {
@@ -1449,7 +1456,7 @@ void handleEditorKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     // Ctrl+O on an untitled, still-empty note opens the file picker
     // (the empty state's keycap hint; works with the preview hidden too)
     if (ctrl && wParam == 'O' && quickNoteEmptyStateActive(app)) {
-        quickNoteOpenFile(app, hwnd);
+        openFileDialog(app, hwnd);
         return;
     }
 
@@ -3132,5 +3139,4 @@ void renderEditor(App& app, float editorWidth) {
 
     app.renderTarget->PopAxisAlignedClip();
 }
-
 

--- a/src/editrail.cpp
+++ b/src/editrail.cpp
@@ -4,6 +4,7 @@
 // thread seam (also here) ties source blocks to their render.
 
 #include "editrail.h"
+#include "overlays.h"
 #include "editor.h"
 #include "i18n.h"
 #include "pandoc.h"
@@ -194,7 +195,8 @@ void renderEditRail(App& app) {
             app.brush);
     };
 
-    // Logo
+    // Logo also opens the application menu in edit mode (#194).
+    renderAppMenuButtonBackground(app);
     float y = dpi(app, 11.0f);
     startPageEnsureIcon(app);
     if (app.startPageIconBitmap) {

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -43,6 +43,10 @@ struct Entry {
 // Note: kept as a plain array (not unordered_map) on purpose. ~80 entries,
 // linear scan is cache-friendly and avoids a static-init ordering fiasco.
 const Entry kEntries[] = {
+    { "ctx.open", L"Open File...", L"\u6253\u5F00\u6587\u4EF6...", L"\u30D5\u30A1\u30A4\u30EB\u3092\u958B\u304F...", L"\uD30C\uC77C \uC5F4\uAE30..." },
+    { "ctx.save", L"Save", L"\u4FDD\u5B58", L"\u4FDD\u5B58", L"\uC800\uC7A5" },
+    { "ctx.save_as", L"Save As...", L"\u53E6\u5B58\u4E3A...", L"\u540D\u524D\u3092\u4ED8\u3051\u3066\u4FDD\u5B58...", L"\uB2E4\uB978 \uC774\uB984\uC73C\uB85C \uC800\uC7A5..." },
+    { "ctx.exit", L"Exit", L"\u9000\u51FA", L"\u7D42\u4E86", L"\uC885\uB8CC" },
     // ----- Help overlay -----
     { "help.title",            L"Keyboard Shortcuts",                       L"\u952E\u76D8\u5FEB\u6377\u952E",                       L"\u30AD\u30FC\u30DC\u30FC\u30C9\u30B7\u30E7\u30FC\u30C8\u30AB\u30C3\u30C8", L"\uD0A4\uBCF4\uB4DC \uB2E8\uCD95\uD0A4" },
     { "help.section.navigation", L"NAVIGATION",                             L"\u5BFC\u822A",                                          L"\u30CA\u30D3\u30B2\u30FC\u30B7\u30E7\u30F3", L"\uD0D0\uC0C9" },
@@ -956,6 +960,10 @@ const BuiltinTranslation kBuiltinTranslations[] = {
       L"Design",
       L"Th\u00E8me",
       L"Tema" },
+    { "ctx.open", L"Datei \u00F6ffnen...", L"Ouvrir un fichier...", L"Apri file..." },
+    { "ctx.save", L"Speichern", L"Enregistrer", L"Salva" },
+    { "ctx.save_as", L"Speichern unter...", L"Enregistrer sous...", L"Salva con nome..." },
+    { "ctx.exit", L"Beenden", L"Quitter", L"Esci" },
     { "ctx.settings",
       L"Einstellungen",
       L"Param\u00E8tres",

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -937,9 +937,20 @@ void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
 }
 
 void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
+    bool mouseMoved = app.mouseX != GET_X_LPARAM(lParam) || app.mouseY != GET_Y_LPARAM(lParam);
     app.mouseX = GET_X_LPARAM(lParam);
     app.mouseY = GET_Y_LPARAM(lParam);
 
+    bool iconHover = appMenuButtonAt(app, (float)app.mouseX, (float)app.mouseY);
+    if (iconHover != app.appMenuHover) {
+        app.appMenuHover = iconHover;
+        InvalidateRect(hwnd, nullptr, FALSE);
+    }
+    if (iconHover && appMenuAvailable(app) && app.tabDragIndex < 0 &&
+        !app.editorSelecting && !app.draggingSeparator && !app.selecting) {
+        SetCursor(cursorHand);
+        return;
+    }
     // An armed tab drag owns the mouse until release (capture held)
     if (app.tabDragIndex >= 0) {
         tabDragMove(app, hwnd, app.mouseX, app.mouseY);
@@ -1067,12 +1078,9 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     // Context menu open: hover tracks menu items only — document hover
     // (code-block copy button, link underline) stays suppressed underneath
     if (app.showContextMenu) {
-        bool repaint = false;
-        int item = contextMenuItemAt(app, (float)app.mouseX, (float)app.mouseY);
-        if (item != app.hoveredContextMenuItem) {
-            app.hoveredContextMenuItem = item;
-            repaint = true;
-        }
+        bool repaint = updateContextMenuHover(app, (float)app.mouseX,
+                                             (float)app.mouseY, mouseMoved);
+        int item = app.hoveredContextMenuItem;
         if (app.hoveredCodeBlock != -1) {
             app.hoveredCodeBlock = -1;
             repaint = true;
@@ -1497,12 +1505,6 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
 
 // --- Right-click context menu ---
 
-static void closeContextMenu(App& app) {
-    app.showContextMenu = false;
-    app.contextMenuAnimation = 0.0f;
-    app.hoveredContextMenuItem = -1;
-}
-
 static void closeSearchIfOpen(App& app) {
     if (!app.showSearch) {
         std::wstring().swap(app.docTextLower);
@@ -1545,16 +1547,35 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
         case CTX_ANNOTATE:
             annotationBeginCreate(app);
             break;
+        case CTX_QUICK_NOTE:
+            closeSearchIfOpen(app);
+            if (startPageActive(app)) startPageInvoke(app, hwnd, 2);
+            else tabOpenQuickNote(app, hwnd);
+            break;
+        case CTX_OPEN:
+            openFileDialog(app, hwnd);
+            break;
+        case CTX_SAVE:
+            if (app.editMode) saveEditorFile(app, hwnd);
+            break;
+        case CTX_SAVE_AS:
+            saveFileAs(app, hwnd);
+            break;
+        case CTX_EXIT:
+            PostMessageW(hwnd, WM_CLOSE, 0, 0);
+            break;
         case CTX_NEW:
             closeSearchIfOpen(app);
             startNewFileFlow(app, hwnd);
             break;
         case CTX_PRINT:
             closeSearchIfOpen(app);
+            if (app.editMode) editorReparse(app, true);
             openPrintPreview(app, hwnd);
             break;
         case CTX_EXPORT:
             closeSearchIfOpen(app);
+            if (app.editMode) editorReparse(app, true);
             exportDocumentAs(app, hwnd);
             break;
         case CTX_EDIT:
@@ -1626,6 +1647,11 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
 }
 
 void handleContextMenu(App& app, HWND hwnd, LPARAM lParam) {
+    // App panels own both mouse buttons in either reading or editing mode.
+    if (app.showSettings || app.showHelp || app.showThemeChooser ||
+        app.showThemeEditor || app.showShortcutEditor || app.showPrintPreview ||
+        app.confirmExitPending || app.createRefPending || app.showLightbox) return;
+    closeContextMenu(app);
     POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
     bool fromKeyboard = pt.x == -1 && pt.y == -1;
     if (fromKeyboard) {
@@ -1693,7 +1719,54 @@ void handleContextMenu(App& app, HWND hwnd, LPARAM lParam) {
     InvalidateRect(hwnd, nullptr, FALSE);
 }
 
+static void toggleApplicationMenu(App& app, HWND hwnd, bool keyboard = false) {
+    if (!appMenuAvailable(app)) return;
+    if (app.showContextMenu && app.applicationMenu) {
+        closeContextMenu(app);
+    } else {
+        closeSearchIfOpen(app);
+        closeTabMenu(app);
+        app.showTabSwitcher = false;
+        app.editCtxOpen = false;
+        app.showHelp = false;
+        app.showSettings = false;
+        if (app.themeChooserPreviewBase >= 0) {
+            applyTheme(app, app.themeChooserPreviewBase);
+            app.themeChooserPreviewBase = -1;
+        }
+        app.showThemeChooser = false;
+        tableEditCommit(app);
+        openContextMenu(app, dpi(app, 4.0f), chromeTopHeight(app), true);
+        if (keyboard) {
+            app.contextMenuKeyboard = true;
+            app.hoveredContextMenuItem = nextContextMenuItem(app, -1, 1);
+        }
+    }
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
 void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    if (appMenuButtonAt(app, (float)GET_X_LPARAM(lParam), (float)GET_Y_LPARAM(lParam))) {
+        toggleApplicationMenu(app, hwnd);
+        app.swallowNextMouseUp = true;
+        return;
+    }
+    // Context menu: a click lands on an item or dismisses the menu; either
+    // way the click is consumed
+    if (app.showContextMenu) {
+        int clickX = GET_X_LPARAM(lParam);
+        int clickY = GET_Y_LPARAM(lParam);
+        int item = contextMenuItemAt(app, (float)clickX, (float)clickY);
+        closeContextMenu(app);
+        app.swallowNextMouseUp = true;
+        if (item >= 0 && contextMenuItemEnabled(app, item)) {
+            invokeContextMenuAction(app, hwnd, item);
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
+
     // Title-bar tab strip and its switcher sit above every overlay
     {
         int mx = GET_X_LPARAM(lParam);
@@ -1778,21 +1851,6 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     // Print preview: controls act on the release
     if (app.showPrintPreview) return;
 
-    // Context menu: a click lands on an item or dismisses the menu; either
-    // way the click is consumed
-    if (app.showContextMenu) {
-        int clickX = GET_X_LPARAM(lParam);
-        int clickY = GET_Y_LPARAM(lParam);
-        int item = contextMenuItemAt(app, (float)clickX, (float)clickY);
-        closeContextMenu(app);
-        app.swallowNextMouseUp = true;
-        if (item >= 0 && contextMenuItemEnabled(app, item)) {
-            invokeContextMenuAction(app, hwnd, item);
-        }
-        InvalidateRect(hwnd, nullptr, FALSE);
-        return;
-    }
-
     // Annotation editor is modal: buttons act, outside dismisses (#126)
     if (app.annotEditorOpen && !app.editMode) {
         float mx = (float)GET_X_LPARAM(lParam);
@@ -1811,6 +1869,44 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         InvalidateRect(hwnd, nullptr, FALSE);
         return;
     }
+
+    // Help overlay: check scrollbar click
+    if (app.showHelp) {
+        float maxScroll = std::max(0.0f, app.helpContentHeight - app.helpVisibleHeight);
+        if (maxScroll > 0) {
+            int clickX = GET_X_LPARAM(lParam);
+            int clickY = GET_Y_LPARAM(lParam);
+            // Scrollbar hit area: right edge of panel
+            float panelWidth = std::min(dpi(app, 520.0f), app.width - dpi(app, 40.0f));
+            float panelRight = (app.width + panelWidth) / 2;
+            float sbHitWidth = dpi(app, 16.0f);
+            if (clickX >= panelRight - sbHitWidth && clickX <= panelRight &&
+                clickY >= app.helpScrollbarTop && clickY <= app.helpScrollbarTop + app.helpVisibleHeight) {
+                app.helpScrollbarDragging = true;
+                app.helpScrollbarDragStartY = (float)clickY;
+                app.helpScrollbarDragStartScroll = app.helpScroll;
+                SetCapture(hwnd);
+
+                // Jump if clicked outside thumb
+                float sbHeight = app.helpVisibleHeight / app.helpContentHeight * app.helpVisibleHeight;
+                sbHeight = std::max(sbHeight, dpi(app, 20.0f));
+                float sbY = app.helpScrollbarTop + (app.helpScroll / maxScroll * (app.helpVisibleHeight - sbHeight));
+                if (clickY < sbY || clickY > sbY + sbHeight) {
+                    float trackHeight = app.helpVisibleHeight - sbHeight;
+                    float clickPos = (float)clickY - app.helpScrollbarTop - sbHeight / 2;
+                    clickPos = std::max(0.0f, std::min(clickPos, trackHeight));
+                    app.helpScroll = (trackHeight > 0) ? (clickPos / trackHeight) * maxScroll : 0;
+                    app.helpScrollbarDragStartScroll = app.helpScroll;
+                    app.helpScrollbarDragStartY = (float)clickY;
+                }
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+        }
+        return;
+    }
+
+    // The chooser acts on release; do not place an editor caret under it.
+    if (app.showThemeChooser) return;
 
     // Edit mode: route to editor or preview
     if (app.editMode) {
@@ -1846,7 +1942,7 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             (float)y >= app.quickNoteButtonRect.top &&
             (float)y <= app.quickNoteButtonRect.bottom) {
             app.swallowNextMouseUp = true;
-            quickNoteOpenFile(app, hwnd);
+            openFileDialog(app, hwnd);
             return;
         }
         // In-place table editing (#148): cells and the + affordances
@@ -1939,46 +2035,7 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
             }
         }
     }
-
-    // Help overlay: check scrollbar click
-    if (app.showHelp) {
-        float maxScroll = std::max(0.0f, app.helpContentHeight - app.helpVisibleHeight);
-        if (maxScroll > 0) {
-            int clickX = GET_X_LPARAM(lParam);
-            int clickY = GET_Y_LPARAM(lParam);
-            // Scrollbar hit area: right edge of panel
-            float panelWidth = std::min(dpi(app, 520.0f), app.width - dpi(app, 40.0f));
-            float panelRight = (app.width + panelWidth) / 2;
-            float sbHitWidth = dpi(app, 16.0f);
-            if (clickX >= panelRight - sbHitWidth && clickX <= panelRight &&
-                clickY >= app.helpScrollbarTop && clickY <= app.helpScrollbarTop + app.helpVisibleHeight) {
-                app.helpScrollbarDragging = true;
-                app.helpScrollbarDragStartY = (float)clickY;
-                app.helpScrollbarDragStartScroll = app.helpScroll;
-                SetCapture(hwnd);
-
-                // Jump if clicked outside thumb
-                float sbHeight = app.helpVisibleHeight / app.helpContentHeight * app.helpVisibleHeight;
-                sbHeight = std::max(sbHeight, dpi(app, 20.0f));
-                float sbY = app.helpScrollbarTop + (app.helpScroll / maxScroll * (app.helpVisibleHeight - sbHeight));
-                if (clickY < sbY || clickY > sbY + sbHeight) {
-                    float trackHeight = app.helpVisibleHeight - sbHeight;
-                    float clickPos = (float)clickY - app.helpScrollbarTop - sbHeight / 2;
-                    clickPos = std::max(0.0f, std::min(clickPos, trackHeight));
-                    app.helpScroll = (trackHeight > 0) ? (clickPos / trackHeight) * maxScroll : 0;
-                    app.helpScrollbarDragStartScroll = app.helpScroll;
-                    app.helpScrollbarDragStartY = (float)clickY;
-                }
-                InvalidateRect(hwnd, nullptr, FALSE);
-            }
-        }
-        return;
-    }
-
-    // If theme chooser, folder browser, or TOC is open, don't start
-    // selection - just record for click handling. A PINNED panel only
-    // claims presses inside its own envelope (#156): the document beside
-    // it keeps selection and every other press behavior.
+    // Pinned side panels only claim presses inside their own envelope.
     {
         bool browserClaims = false;
         if (app.showFolderBrowser) {
@@ -2245,34 +2302,7 @@ static bool openFileRefTarget(App& app, HWND hwnd, const std::string& path) {
 // 2 new document, 3 browse, 4 clear, 5 shortcuts, 10+i recent, 20+i learn.
 static void startPageInvoke(App& app, HWND hwnd, int id) {
     if (id == 1) {
-        // Open a file: picker, then the picked document takes over the
-        // launcher shell (same handover as the quick-note empty state)
-        wchar_t path[MAX_PATH] = L"";
-        OPENFILENAMEW ofn = {};
-        ofn.lStructSize = sizeof(ofn);
-        ofn.hwndOwner = hwnd;
-        ofn.lpstrFilter =
-            L"Documents (*.md;*.mmd;*.txt;*.json;*.yaml;...)\0"
-            L"*.md;*.markdown;*.mmd;*.txt;*.json;*.yaml;*.yml;*.toml;"
-            L"*.ini;*.csv;*.log\0"
-            L"Markdown / Mermaid (*.md;*.markdown;*.mmd)\0"
-            L"*.md;*.markdown;*.mmd\0"
-            L"All files (*.*)\0*.*\0";
-        ofn.lpstrFile = path;
-        ofn.nMaxFile = MAX_PATH;
-        ofn.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST |
-                    OFN_NOCHANGEDIR | OFN_HIDEREADONLY;
-        if (GetOpenFileNameW(&ofn)) {
-            tabsInit(app);
-            int shellId = app.tabs[app.activeTab].id;
-            tabOpenPath(app, hwnd, toUtf8(path));
-            for (int i = 0; i < (int)app.tabs.size(); i++) {
-                if (app.tabs[i].id == shellId) {
-                    tabCloseIndex(app, hwnd, i);
-                    break;
-                }
-            }
-        }
+        openFileDialog(app, hwnd);
     } else if (id == 2) {
         // New document: the note takes over this window (#121 semantics);
         // the keystroke's WM_CHAR must not type into the fresh editor
@@ -2799,6 +2829,70 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         return;
     }
 
+    if (app.showHelp) return;
+
+    // Theme chooser click handling
+    if (app.showThemeChooser) {
+        float clickX = (float)GET_X_LPARAM(lParam);
+        float clickY = (float)GET_Y_LPARAM(lParam);
+        int hit = themeChooserHitAt(app, clickX, clickY);
+
+        auto restorePreview = [&]() {
+            if (app.themeChooserPreviewBase >= 0) {
+                applyTheme(app, app.themeChooserPreviewBase);
+                app.themeChooserPreviewBase = -1;
+            }
+        };
+
+        if (hit == -1) {
+            // "Follow Windows" toggle
+            restorePreview();
+            app.followSystemTheme = !app.followSystemTheme;
+            if (app.followSystemTheme) {
+                // Adopt the current theme as this mode's preference, then
+                // snap to whatever the system mode wants
+                if (app.theme.isDark) app.darkThemeIndex = app.currentThemeIndex;
+                else app.lightThemeIndex = app.currentThemeIndex;
+                PostMessageW(hwnd, WM_SETTINGCHANGE, 0,
+                             (LPARAM)L"ImmersiveColorSet");
+            }
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
+        }
+        if (hit == -3) {
+            // Footer: open the theme editor on the committed theme
+            restorePreview();
+            app.showThemeChooser = false;
+            app.themeChooserAnimation = 0;
+            openThemeEditor(app, true);
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
+        }
+        if (hit >= 0) {
+            // Commit the pick (the hover preview already applied it)
+            applyTheme(app, hit);
+            app.themeChooserPreviewBase = -1;
+            // While auto mode is on, picking a card records it as the
+            // preference for that card's light/dark class
+            if (app.followSystemTheme) {
+                if (themeAt(hit).isDark) app.darkThemeIndex = hit;
+                else app.lightThemeIndex = hit;
+            }
+            // New windows spawned from here on come up in this theme
+            persistThemeChoice(app);
+            app.showThemeChooser = false;
+            app.themeChooserAnimation = 0;
+        } else {
+            // Close (x) or a click on empty panel / outside: put the
+            // committed theme back and dismiss
+            restorePreview();
+            app.showThemeChooser = false;
+            app.themeChooserAnimation = 0;
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
     // Edit mode: route to editor
     if (app.editMode && (app.draggingSeparator || app.editorSelecting ||
                          app.editorScrollbarDragging)) {
@@ -3032,67 +3126,6 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         // Pinned (#156): the click belongs to the document - fall through
     }
 
-    // Theme chooser click handling
-    if (app.showThemeChooser) {
-        float clickX = (float)GET_X_LPARAM(lParam);
-        float clickY = (float)GET_Y_LPARAM(lParam);
-        int hit = themeChooserHitAt(app, clickX, clickY);
-
-        auto restorePreview = [&]() {
-            if (app.themeChooserPreviewBase >= 0) {
-                applyTheme(app, app.themeChooserPreviewBase);
-                app.themeChooserPreviewBase = -1;
-            }
-        };
-
-        if (hit == -1) {
-            // "Follow Windows" toggle
-            restorePreview();
-            app.followSystemTheme = !app.followSystemTheme;
-            if (app.followSystemTheme) {
-                // Adopt the current theme as this mode's preference, then
-                // snap to whatever the system mode wants
-                if (app.theme.isDark) app.darkThemeIndex = app.currentThemeIndex;
-                else app.lightThemeIndex = app.currentThemeIndex;
-                PostMessageW(hwnd, WM_SETTINGCHANGE, 0,
-                             (LPARAM)L"ImmersiveColorSet");
-            }
-            InvalidateRect(hwnd, nullptr, FALSE);
-            return;
-        }
-        if (hit == -3) {
-            // Footer: open the theme editor on the committed theme
-            restorePreview();
-            app.showThemeChooser = false;
-            app.themeChooserAnimation = 0;
-            openThemeEditor(app, true);
-            InvalidateRect(hwnd, nullptr, FALSE);
-            return;
-        }
-        if (hit >= 0) {
-            // Commit the pick (the hover preview already applied it)
-            applyTheme(app, hit);
-            app.themeChooserPreviewBase = -1;
-            // While auto mode is on, picking a card records it as the
-            // preference for that card's light/dark class
-            if (app.followSystemTheme) {
-                if (themeAt(hit).isDark) app.darkThemeIndex = hit;
-                else app.lightThemeIndex = hit;
-            }
-            // New windows spawned from here on come up in this theme
-            persistThemeChoice(app);
-            app.showThemeChooser = false;
-            app.themeChooserAnimation = 0;
-        } else {
-            // Close (x) or a click on empty panel / outside: put the
-            // committed theme back and dismiss
-            restorePreview();
-            app.showThemeChooser = false;
-            app.themeChooserAnimation = 0;
-        }
-        InvalidateRect(hwnd, nullptr, FALSE);
-        return;
-    }
 
     if (app.scrollbarDragging) {
         app.scrollbarDragging = false;
@@ -3330,6 +3363,104 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
         return;
     }
 
+    if (!app.confirmExitPending && app.showContextMenu) {
+        if (wParam == VK_ESCAPE || wParam == VK_F10) {
+            closeContextMenu(app);
+        } else if (wParam == VK_DOWN || wParam == VK_UP ||
+                   wParam == VK_HOME || wParam == VK_END) {
+            int current = (wParam == VK_HOME || wParam == VK_END)
+                              ? -1 : app.hoveredContextMenuItem;
+            app.contextMenuKeyboard = true;
+            app.hoveredContextMenuItem = nextContextMenuItem(
+                app, current, (wParam == VK_UP || wParam == VK_END) ? -1 : 1);
+        } else if (wParam == VK_RETURN || wParam == VK_SPACE) {
+            int item = app.hoveredContextMenuItem;
+            closeContextMenu(app);
+            app.swallowCharsUntil = std::chrono::steady_clock::now() +
+                                    std::chrono::milliseconds(150);
+            if (contextMenuItemEnabled(app, item)) invokeContextMenuAction(app, hwnd, item);
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+    // Shortcut editor: an armed row captures the next key; Esc cancels
+    // the capture, then closes back to settings
+    if (app.showShortcutEditor) {
+        if (wParam == VK_ESCAPE) {
+            if (app.shortcutEditorRow >= 0) {
+                app.shortcutEditorRow = -1;
+            } else {
+                app.showShortcutEditor = false;
+                app.showSettings = true;
+                app.settingsAnimation = 0;
+            }
+        } else if (app.shortcutEditorRow >= 0) {
+            unsigned key = 0;
+            if (wParam == VK_TAB || wParam == VK_SPACE ||
+                (wParam >= VK_F1 && wParam <= VK_F12) ||
+                (wParam >= 'A' && wParam <= 'Z') ||
+                (wParam >= '0' && wParam <= '9')) {
+                key = (unsigned)wParam;
+            }
+            if (key) shortcutAssign(app, key);
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+    // Theme editor: Esc returns to settings; text arrives via WM_CHAR
+    if (app.showThemeEditor) {
+        if (wParam == VK_ESCAPE) closeThemeEditor(app, true);
+        return;
+    }
+    // Settings overlay captures the keyboard while open
+    if (app.showSettings) {
+        if (wParam == VK_ESCAPE || (ctrl && wParam == VK_OEM_COMMA)) {
+            app.showSettings = false;
+            app.settingsAnimation = 0;
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
+        return;
+    }
+
+    if (app.showHelp || app.showThemeChooser) {
+        if (wParam == VK_ESCAPE ||
+            (!ctrl && app.showHelp && wParam == app.keymap[KA_HELP]) ||
+            (!ctrl && app.showThemeChooser && wParam == app.keymap[KA_THEME])) {
+            if (app.themeChooserPreviewBase >= 0) {
+                applyTheme(app, app.themeChooserPreviewBase);
+                app.themeChooserPreviewBase = -1;
+            }
+            app.showThemeChooser = false;
+            app.showHelp = false;
+        } else if (app.showHelp) {
+            float step = dpi(app, 60.0f);
+            if (wParam == VK_NEXT || wParam == VK_PRIOR) step = app.helpVisibleHeight;
+            if (wParam == VK_DOWN || wParam == VK_NEXT) app.helpScroll += step;
+            if (wParam == VK_UP || wParam == VK_PRIOR) app.helpScroll -= step;
+            app.helpScroll = std::max(0.0f, std::min(app.helpScroll,
+                app.helpContentHeight - app.helpVisibleHeight));
+        }
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+    if (appMenuAvailable(app)) {
+        if (wParam == VK_F10) {
+            toggleApplicationMenu(app, hwnd, true);
+            return;
+        }
+        if (ctrl && wParam == 'O') {
+            openFileDialog(app, hwnd);
+            return;
+        }
+        if (ctrl && wParam == VK_OEM_COMMA) {
+            closeSearchIfOpen(app);
+            app.showSettings = true;
+            app.settingsAnimation = 0;
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return;
+        }
+    }
+
     // Tab shortcuts work everywhere except modal capture states: Ctrl+Tab
     // cycles, Ctrl+W closes, Ctrl+T opens the browser into a new tab,
     // Ctrl+1..9 jumps (a dirty editor parks its buffer in the tab)
@@ -3441,15 +3572,6 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                     break;
             }
         }
-        InvalidateRect(hwnd, nullptr, FALSE);
-        return;
-    }
-
-    // An open context menu takes Esc before any overlay
-    if (app.showContextMenu && wParam == VK_ESCAPE) {
-        app.showContextMenu = false;
-        app.contextMenuAnimation = 0;
-        app.hoveredContextMenuItem = -1;
         InvalidateRect(hwnd, nullptr, FALSE);
         return;
     }
@@ -3614,44 +3736,6 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 break;
         }
     } else {
-        // Shortcut editor: an armed row captures the next key; Esc cancels
-        // the capture, then closes back to settings
-        if (app.showShortcutEditor) {
-            if (wParam == VK_ESCAPE) {
-                if (app.shortcutEditorRow >= 0) {
-                    app.shortcutEditorRow = -1;
-                } else {
-                    app.showShortcutEditor = false;
-                    app.showSettings = true;
-                    app.settingsAnimation = 0;
-                }
-            } else if (app.shortcutEditorRow >= 0) {
-                unsigned key = 0;
-                if (wParam == VK_TAB || wParam == VK_SPACE ||
-                    (wParam >= VK_F1 && wParam <= VK_F12) ||
-                    (wParam >= 'A' && wParam <= 'Z') ||
-                    (wParam >= '0' && wParam <= '9')) {
-                    key = (unsigned)wParam;
-                }
-                if (key) shortcutAssign(app, key);
-            }
-            InvalidateRect(hwnd, nullptr, FALSE);
-            return;
-        }
-        // Theme editor: Esc returns to settings; text arrives via WM_CHAR
-        if (app.showThemeEditor) {
-            if (wParam == VK_ESCAPE) closeThemeEditor(app, true);
-            return;
-        }
-        // Settings overlay captures the keyboard while open
-        if (app.showSettings) {
-            if (wParam == VK_ESCAPE) {
-                app.showSettings = false;
-                app.settingsAnimation = 0;
-                InvalidateRect(hwnd, nullptr, FALSE);
-            }
-            return;
-        }
         // TOC filter: printable keys narrow the heading list via WM_CHAR,
         // Backspace edits, Enter jumps to the first match. A pinned panel
         // hands the keyboard back to the document (#156).
@@ -3970,6 +4054,16 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
             }
         }
         InvalidateRect(hwnd, nullptr, FALSE);
+        return;
+    }
+
+    if (app.showContextMenu || app.showSettings || app.showThemeChooser) return;
+    if (app.showHelp) {
+        if ((unsigned)wParam == app.keymap[KA_HELP]) {
+            app.showHelp = false;
+            app.helpAnimation = 0;
+            InvalidateRect(hwnd, nullptr, FALSE);
+        }
         return;
     }
 

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1047,13 +1047,6 @@ render_document:
     if (app.showFolderBrowser) renderFolderBrowser(app);
     if (app.showToc) renderToc(app);
     if (app.annotEditorOpen) renderAnnotationEditor(app);
-    if (app.showContextMenu) renderContextMenu(app);
-    if (app.showThemeChooser) renderThemeChooser(app);
-    if (app.showHelp) renderHelpOverlay(app);
-    if (app.showSettings) renderSettingsOverlay(app);
-    if (app.showLightbox) renderLightbox(app);
-    if (app.showThemeEditor) renderThemeEditor(app);
-    if (app.showShortcutEditor) renderShortcutEditor(app);
 
     // Close edit mode split view clipping
     if (app.editMode) {
@@ -1085,8 +1078,16 @@ render_document:
         renderEditRail(app);
         renderEditCtxMenu(app);
     }
+    if (app.showThemeChooser) renderThemeChooser(app);
+    if (app.showHelp) renderHelpOverlay(app);
+    if (app.showSettings) renderSettingsOverlay(app);
+    if (app.showLightbox) renderLightbox(app);
+    if (app.showThemeEditor) renderThemeEditor(app);
+    if (app.showShortcutEditor) renderShortcutEditor(app);
+
     renderTabSwitcher(app);
     renderTabMenu(app);
+    if (app.showContextMenu) renderContextMenu(app);
 
     // Unsaved-changes dialog above it all (also entered from tab closes)
     if (app.confirmExitPending) renderConfirmExitDialog(app);
@@ -1221,6 +1222,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                 y < (float)GetSystemMetrics(SM_CYSIZEFRAME)) {
                 return HTTOP;
             }
+            if (appMenuButtonAt(*app, x, y)) return HTCLIENT;
             int button = captionHitTest(*app, x, y);
             if (button == 1) return HTMINBUTTON;
             if (button == 2) return HTMAXBUTTON;  // Win11 snap flyout
@@ -1263,7 +1265,18 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             }
             break;
 
+        case WM_KILLFOCUS:
+            if (app && app->showContextMenu) {
+                closeContextMenu(*app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            break;
+
         case WM_NCLBUTTONDOWN:
+            if (app && app->showContextMenu) {
+                closeContextMenu(*app);
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
             if (app && !app->zenMode &&
                 (wParam == HTMINBUTTON || wParam == HTMAXBUTTON ||
                  wParam == HTCLOSE)) {
@@ -1367,6 +1380,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case WM_SIZE:
             if (app && app->d2dFactory) {
+                closeContextMenu(*app);  // its anchor belongs to the old viewport
                 // The preview's geometry is stale after a resize: restore
                 // the document at the new size and close the overlay
                 if (app->showPrintPreview) {
@@ -1505,6 +1519,10 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             return TRUE;
 
         case WM_SYSKEYDOWN:
+            if (app && wParam == VK_F10) {
+                handleKeyDown(*app, hwnd, wParam);
+                return 0;
+            }
             // Alt+Left / Alt+Right mirror the mouse side buttons
             if (app && (lParam & (1 << 29)) &&
                 (wParam == VK_LEFT || wParam == VK_RIGHT)) {

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -2178,95 +2178,21 @@ void renderHelpOverlay(App& app) {
     }
 }
 
-// --- Right-click context menu ---
-//
-// Drawn in the current theme like the folder browser and theme chooser.
-// Every entry shows its keyboard shortcut, so the menu doubles as
-// discoverable documentation for the single-key commands.
-
-namespace {
-
-struct ContextMenuEntry {
-    const wchar_t* label;
-    const wchar_t* shortcut;
-    bool separatorAfter;
-};
-
-const ContextMenuEntry CTX_ENTRIES[CTX_ITEM_COUNT] = {
-    { L"Copy",               L"Ctrl+C", false },
-    { L"Select All",         L"Ctrl+A", false },
-    { L"Annotate",           L"",       true  },
-    { L"New File",           L"N",      false },
-    { L"Print / PDF",        L"Ctrl+P", false },
-    { L"Export as...",       L"",       false },
-    { L"Edit",               L":",      false },
-    { L"Search",             L"F",      false },
-    { L"Table of Contents",  L"Tab",    true  },
-    { L"Browse Files",       L"B",      false },
-    { L"Reveal in Explorer", L"",       true  },
-    { L"Theme",              L"T",      false },
-    { L"Settings",           L"Ctrl+,", false },
-    { L"Help",               L"?",      false },
-};
-
-float ctxItemHeight(const App& app) { return dpi(app, 30.0f); }
-float ctxSeparatorHeight(const App& app) { return dpi(app, 9.0f); }
-float ctxWidth(const App& app) { return dpi(app, 210.0f); }
-float ctxPadding(const App& app) { return dpi(app, 6.0f); }
-
-float ctxTotalHeight(const App& app) {
-    float h = ctxPadding(app) * 2;
-    for (const auto& entry : CTX_ENTRIES) {
-        h += ctxItemHeight(app);
-        if (entry.separatorAfter) h += ctxSeparatorHeight(app);
-    }
-    return h;
-}
-
-// Top y of the item at `index` relative to the menu top
-float ctxItemTop(const App& app, int index) {
-    float y = ctxPadding(app);
-    for (int i = 0; i < index; i++) {
-        y += ctxItemHeight(app);
-        if (CTX_ENTRIES[i].separatorAfter) y += ctxSeparatorHeight(app);
-    }
-    return y;
-}
-
-} // namespace
-
-bool contextMenuItemEnabled(const App& app, int item) {
-    switch (item) {
-        case CTX_COPY:   return app.hasSelection && app.selAnchor != app.selFocus;
-        case CTX_ANNOTATE:
-            // Viewer-only: annotating writes a comment into the file (#126)
-            return !app.editMode && !app.currentFile.empty() &&
-                   app.hasSelection && app.selAnchor != app.selFocus;
-        case CTX_REVEAL: return !app.currentFile.empty();
-        default:         return item >= 0 && item < CTX_ITEM_COUNT;
-    }
-}
-
-int contextMenuItemAt(const App& app, float x, float y) {
-    if (x < app.contextMenuX || x > app.contextMenuX + ctxWidth(app)) return -1;
-    float rel = y - app.contextMenuY;
-    for (int i = 0; i < CTX_ITEM_COUNT; i++) {
-        float top = ctxItemTop(app, i);
-        if (rel >= top && rel < top + ctxItemHeight(app)) return i;
-    }
-    return -1;
-}
-
-void openContextMenu(App& app, float x, float y) {
-    float w = ctxWidth(app);
-    float h = ctxTotalHeight(app);
-    app.contextMenuX = std::max(0.0f, std::min(x, (float)app.width - w));
-    app.contextMenuY = std::max(0.0f, std::min(y, (float)app.height - h));
-    app.showContextMenu = true;
-    app.hoveredContextMenuItem = -1;
-    app.contextMenuAnimation = 0.0f;
-    app.hoveredCodeBlock = -1;
-    app.hoveredLink.clear();
+// The caption icon and document right-click share the same themed popup.
+void renderAppMenuButtonBackground(App& app) {
+    if (!appMenuAvailable(app) ||
+        !(app.appMenuHover || (app.showContextMenu && app.applicationMenu))) return;
+    auto r = appMenuButtonRect(app);
+    float inset = dpi(app, 4.0f);
+    r.left += inset;
+    r.right -= inset;
+    r.top += inset;
+    r.bottom -= inset;
+    D2D1_COLOR_F c = app.theme.accent;
+    c.a = app.showContextMenu && app.applicationMenu ? 0.2f : 0.1f;
+    app.brush->SetColor(c);
+    app.renderTarget->FillRoundedRectangle(
+        D2D1::RoundedRect(r, dpi(app, 6.0f), dpi(app, 6.0f)), app.brush);
 }
 
 void renderContextMenu(App& app) {
@@ -2283,8 +2209,8 @@ void renderContextMenu(App& app) {
 
     float x = app.contextMenuX;
     float y = app.contextMenuY;
-    float w = ctxWidth(app);
-    float h = ctxTotalHeight(app);
+    float w = contextMenuWidth(app);
+    float h = contextMenuHeight(app);
 
     D2D1_COLOR_F panelBg = app.theme.isDark ? hexColor(0x1E1E1E, 0.97f)
                                             : hexColor(0xF8F8F8, 0.97f);
@@ -2297,17 +2223,14 @@ void renderContextMenu(App& app) {
     app.renderTarget->DrawRoundedRectangle(
         D2D1::RoundedRect(D2D1::RectF(x, y, x + w, y + h), 6, 6), app.brush, 1.0f);
 
-    app.hoveredContextMenuItem = contextMenuItemAt(app, app.mouseX, app.mouseY);
-
-    // Labels come from the translation table (order matches ContextMenuItem)
-    static const char* kCtxKeys[CTX_ITEM_COUNT] = {
-        "ctx.copy", "ctx.select_all", "ctx.annotate", "ctx.new", "ctx.print",
-        "ctx.export", "ctx.edit", "ctx.search", "ctx.toc", "ctx.browse",
-        "ctx.reveal", "ctx.theme", "ctx.settings", "ctx.help",
-    };
+    const auto& entries = contextMenuEntries(app);
 
     // Shortcut hints reflect the user keymap ([Keys] in settings.ini)
-    auto shortcutLabel = [&](int item) -> std::wstring {
+    auto shortcutLabel = [&](const ContextMenuEntry& entry) -> std::wstring {
+        int item = entry.action;
+        // Single-key reading commands type text in the editor.
+        if (app.applicationMenu && app.editMode &&
+            (item == CTX_THEME || item == CTX_HELP)) return L"";
         switch (item) {
             case CTX_ANNOTATE: return keyLabel(app.keymap[KA_ANNOTATE]);
             case CTX_NEW:    return keyLabel(app.keymap[KA_NEWFILE]);
@@ -2317,15 +2240,17 @@ void renderContextMenu(App& app) {
             case CTX_BROWSE: return keyLabel(app.keymap[KA_BROWSE]);
             case CTX_THEME:  return keyLabel(app.keymap[KA_THEME]);
             case CTX_HELP:   return keyLabel(app.keymap[KA_HELP]);
-            default:         return CTX_ENTRIES[item].shortcut;
+            default:         return entry.shortcut;
         }
     };
 
-    float pad = ctxPadding(app);
-    float itemH = ctxItemHeight(app);
+    float pad = contextMenuPadding(app);
+    float itemH = contextMenuItemHeight(app);
     float inset = dpi(app, 12.0f);
-    for (int i = 0; i < CTX_ITEM_COUNT; i++) {
-        float top = y + ctxItemTop(app, i);
+    for (int row = 0; row < (int)entries.size(); row++) {
+        const auto& entry = entries[row];
+        int i = entry.action;
+        float top = y + contextMenuItemTop(app, row);
         bool enabled = contextMenuItemEnabled(app, i);
 
         if (i == app.hoveredContextMenuItem && enabled) {
@@ -2342,12 +2267,12 @@ void renderContextMenu(App& app) {
         textColor.a = (enabled ? 1.0f : 0.35f) * anim;
         app.brush->SetColor(textColor);
         float textY = top + (itemH - dpi(app, 18.0f)) / 2;
-        const wchar_t* itemLabel = tr(app, kCtxKeys[i]);
+        const wchar_t* itemLabel = tr(app, entry.key);
         app.renderTarget->DrawText(
             itemLabel, (UINT32)wcslen(itemLabel), format,
             D2D1::RectF(x + inset, textY, x + w - inset, top + itemH), app.brush);
 
-        std::wstring hintText = shortcutLabel(i);
+        std::wstring hintText = shortcutLabel(entry);
         if (!hintText.empty()) {
             IDWriteTextLayout* hint = nullptr;
             app.dwriteFactory->CreateTextLayout(
@@ -2366,8 +2291,8 @@ void renderContextMenu(App& app) {
             }
         }
 
-        if (CTX_ENTRIES[i].separatorAfter) {
-            float sepY = top + itemH + ctxSeparatorHeight(app) * 0.5f;
+        if (entry.separatorAfter) {
+            float sepY = top + itemH + contextMenuSeparatorHeight(app) * 0.5f;
             app.brush->SetColor(borderColor);
             app.renderTarget->DrawLine(
                 D2D1::Point2F(x + pad, sepY), D2D1::Point2F(x + w - pad, sepY),

--- a/src/tabs.cpp
+++ b/src/tabs.cpp
@@ -4,6 +4,7 @@
 // a chevron opens the open-files switcher when the strip is crowded.
 
 #include "tabs.h"
+#include "overlays.h"
 
 #include "document.h"
 #include "drafts.h"
@@ -545,6 +546,7 @@ void renderTabStrip(App& app) {
             DestroyIcon(icon);
         }
     }
+    if (!app.editMode) renderAppMenuButtonBackground(app);
     if (app.titleIconBitmap) {
         float iconSize = dpi(app, 16.0f);
         float ix = (iconCell - iconSize) * 0.5f;

--- a/tests/application-menu-validation.md
+++ b/tests/application-menu-validation.md
@@ -1,0 +1,62 @@
+# Application menu validation (#194)
+
+Validated on Windows on 2026-09-08 using a portable test build and copies of
+`fixtures/application-menu.md` and `fixtures/application-menu-companion.md`.
+Test settings, saved files, drafts, exports and native page images live under
+the ignored `out/app-menu/` directory.
+
+## Checked in the built app
+
+- The caption icon opens the menu in reading mode and on the start page; the
+  editor rail icon opens it with the preview shown or hidden.
+- New, Open, Save, Save As, Theme, Settings, Help, Print / PDF, Export and Exit
+  are reachable. Save is disabled in reading mode; document commands are
+  disabled on the start page.
+- F10 opens the menu, arrows and End change selection, and Enter invokes an
+  action. Escape and an outside click dismiss it. Keyboard selection survives
+  repeated Windows mouse messages without physical pointer movement.
+- Open from the start page replaces the empty launcher. Opening the companion
+  while an untitled note is dirty preserves the note and its source in a tab.
+- Returning to a dirty file restores its unsaved heading in both source and
+  preview. The fixture on disk stays unchanged.
+- Save on an untitled note opens the native Save As dialog and writes the
+  expected Markdown. Save As creates a second copy with the same file hash;
+  cancelling the dialog keeps the original tab.
+- Settings and Help cover both editor panes. Typing while Settings is open
+  does not modify a clean editor. Settings also works with the preview hidden.
+- Choosing Paper from Midnight applies the theme without leaving editing mode.
+- Exit with a dirty editor opens the existing unsaved-changes prompt; cancelling
+  keeps the draft and window open.
+- Print preview includes unsaved headings and the table's math. Export through
+  the menu includes changes made with the preview hidden, while leaving the
+  source file untouched.
+- The document right-click menu and editor insert menu remain available.
+- The menu stays anchored below the icon with Contents pinned. Clicking outside
+  the menu preserves the pinned panel. Dragging empty title-bar space still
+  moves the window (observed movement: 50 pixels right and 40 pixels down).
+- Reviewed light and dark themes at window sizes 1050 x 900 and 650 x 760.
+
+## Automated and native export checks
+
+Build all Release targets and run:
+
+```powershell
+cmake --build build --config Release --parallel 6
+ctest --test-dir build -C Release --output-on-failure
+```
+
+All eight suites pass. `context_menu` checks command availability, action hit
+testing, separator gaps, keyboard wrapping/skipping, physical versus synthetic
+mouse movement, icon boundaries, modal guards and menu bounds at 100%, 150%
+and 200% scaling. `math_layout` parses both fixtures, checks table column counts,
+keeps code literal and lays out each equation.
+
+The app's `--printpages` and `--exporthtml` commands rendered both fixtures and
+`markdown-regression-control.md`. The new fixtures retain six equations in
+total, their headings and tables. All five native PNG pages and three HTML
+files are byte-identical to the same exports from the published v3.5.6 binary.
+Both pages of the main fixture were visually inspected.
+
+Physical printing, screen-reader navigation, and a live multi-monitor DPI
+transition were not exercised. High-DPI menu geometry is covered by automated
+checks; live interaction used the test desktop's current display scaling.

--- a/tests/context_menu_tests.cpp
+++ b/tests/context_menu_tests.cpp
@@ -1,0 +1,92 @@
+#include "overlays.h"
+
+#include <iostream>
+#include <memory>
+#include <set>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+}
+
+int main() {
+    auto state = std::make_unique<App>();
+    App& app = *state;
+    app.width = 650;
+    app.height = 600;
+    app.contentScale = 1.0f;
+    openContextMenu(app, 4, 40, true);
+    check(!contextMenuItemEnabled(app, CTX_SAVE), "launcher cannot save a nonexistent document");
+    check(!contextMenuItemEnabled(app, CTX_SAVE_AS), "launcher cannot save a copy");
+    check(!contextMenuItemEnabled(app, CTX_PRINT), "launcher cannot print");
+    check(!contextMenuItemEnabled(app, CTX_EXPORT), "launcher cannot export");
+    check(nextContextMenuItem(app, CTX_OPEN, 1) == CTX_THEME,
+          "keyboard skips all unavailable document commands");
+    check(nextContextMenuItem(app, CTX_QUICK_NOTE, -1) == CTX_EXIT,
+          "keyboard wraps to the last action");
+    app.contextMenuKeyboard = true;
+    app.hoveredContextMenuItem = CTX_EXIT;
+    float firstRowY = app.contextMenuY + contextMenuPadding(app) + 5;
+    check(!updateContextMenuHover(app, 20, firstRowY, false) &&
+          app.hoveredContextMenuItem == CTX_EXIT,
+          "synthetic mouse moves cannot overwrite keyboard selection");
+    check(updateContextMenuHover(app, 20, firstRowY, true) &&
+          app.hoveredContextMenuItem == CTX_QUICK_NOTE && !app.contextMenuKeyboard,
+          "a physical pointer move resumes mouse selection");
+    app.currentFile = "fixture.md";
+    check(contextMenuItemEnabled(app, CTX_SAVE_AS), "reading mode can save a copy");
+    check(!contextMenuItemEnabled(app, CTX_SAVE), "reading mode cannot overwrite from a stale editor buffer");
+    app.currentFile.clear();
+    app.editMode = true;
+    app.editorText = L"unsaved text";
+    app.editorDirty = true;
+    check(contextMenuItemEnabled(app, CTX_SAVE) && contextMenuItemEnabled(app, CTX_SAVE_AS),
+          "untitled editor can save and save as");
+    check(contextMenuItemEnabled(app, CTX_PRINT) && contextMenuItemEnabled(app, CTX_EXPORT),
+          "unsaved editor content can print and export");
+    check(appMenuButtonAt(app, 46, 20), "editor logo uses the full rail width");
+    check(!appMenuButtonAt(app, 55, 20), "tabs are outside the logo button");
+    app.editMode = false;
+    check(!appMenuButtonAt(app, 46, 20), "reading logo does not steal title dragging");
+    app.confirmExitPending = true;
+    check(!appMenuAvailable(app), "menu cannot bypass the unsaved-changes dialog");
+    app.confirmExitPending = false;
+    app.showThemeEditor = true;
+    check(!appMenuAvailable(app), "menu cannot discard a custom theme in progress");
+    app.showThemeEditor = false;
+    app.zenMode = true;
+    check(!appMenuButtonAt(app, 20, 20), "zen mode has no invisible logo hit target");
+    app.zenMode = false;
+
+    for (float scale : {1.0f, 1.5f, 2.0f}) {
+        app.contentScale = scale;
+        for (bool application : {false, true}) {
+            openContextMenu(app, 900, 800, application);
+            check(app.contextMenuX + contextMenuWidth(app) <= app.width + 0.01f,
+                  "menu clamps to the right edge");
+            check(app.contextMenuY >= chromeTopHeight(app), "menu clears title-bar controls");
+            check(app.contextMenuY + contextMenuHeight(app) <= app.height + 0.01f,
+                  "all rows fit in a short scaled window");
+            const auto& entries = contextMenuEntries(app);
+            std::set<int> actions;
+            for (int row = 0; row < (int)entries.size(); row++) {
+                const auto& entry = entries[row];
+                check(actions.insert(entry.action).second, "actions occur once per menu");
+                float x = app.contextMenuX + 10;
+                float y = app.contextMenuY + contextMenuItemTop(app, row);
+                check(contextMenuItemAt(app, x, y + contextMenuItemHeight(app) / 2) == entry.action,
+                      "hit testing resolves actions, not row indices");
+                if (entry.separatorAfter)
+                    check(contextMenuItemAt(app, x, y + contextMenuItemHeight(app) + 1) == -1,
+                          "separators never activate a neighboring command");
+            }
+            check(application ? actions.count(CTX_COPY) == 0 : actions.count(CTX_COPY) == 1,
+                  "document-only commands stay in the document menu");
+        }
+    }
+    closeContextMenu(app);
+    check(!app.showContextMenu && app.hoveredContextMenuItem == -1, "dismissal clears menu selection");
+    return failures ? 1 : 0;
+}

--- a/tests/fixtures/application-menu-companion.md
+++ b/tests/fixtures/application-menu-companion.md
@@ -1,0 +1,13 @@
+# Companion document
+
+Opening this file from the icon menu must preserve other tabs and unsaved notes.
+
+| Check | Value |
+| --- | --- |
+| Inline math | $\sum_{k=1}^{n} k = \frac{n(n+1)}{2}$ |
+| Formatting | **bold** and *italic* |
+
+> Return to the original tab and confirm its content and editing state.
+
+- [Main fixture](application-menu.md)
+- `Open File` should activate an already open file without duplicating its tab.

--- a/tests/fixtures/application-menu.md
+++ b/tests/fixtures/application-menu.md
@@ -1,0 +1,47 @@
+# Application menu: mixed document
+
+Open a **copy** of this fixture for issue [#194](https://github.com/oipoistar/tinta/issues/194).
+Click the top-left Tinta icon in reading and editing modes. The menu must sit
+above this document and the editor rail, and dismiss with Escape, another icon
+click, or a click outside. F10, arrow keys and Enter also operate the menu.
+
+## Table and inline math $E = mc^2$
+
+| Action | Expected result | Formula |
+| --- | --- | --- |
+| Open File | Another file opens without losing an unsaved tab | $x^2 + y^2$ |
+| Save | Edits are written; an untitled note asks for a name | $\frac{1}{2}$ |
+| Save As | A new copy becomes the active file | $\sqrt{a+b}$ |
+
+## Existing formatting
+
+- **Bold**, *emphasis*, and `inline code` remain intact.
+- [Local companion](application-menu-companion.md) opens normally.
+- A nested list still works:
+  1. Open Settings while editing, type a few keys, then close with Escape.
+  2. Confirm the keys did not change the source or mark a clean file dirty.
+
+> Theme and Help must cover both panes, including with the preview hidden.
+> Try normal and narrow windows, light and dark themes, and pinned Contents.
+
+$$
+\begin{bmatrix} a & b \\ c & d \end{bmatrix}
+\begin{pmatrix} x \\ y \end{pmatrix}
+= \begin{pmatrix} ax+by \\ cx+dy \end{pmatrix}
+$$
+
+```latex
+\begin{bmatrix} this & stays \\ literal & code \end{bmatrix}
+```
+
+## File safety checks
+
+1. Create a new note from the menu, type text, and open the companion file.
+2. Switch back: the unsaved note and its text must still exist.
+3. Save it, edit again, choose Save As, and verify both files on disk.
+4. Cancel an Open or Save As picker: the current document stays active.
+5. Choose Exit with an unsaved tab: the existing save/discard dialog appears.
+
+Print preview and HTML export must keep the headings, table, code and equations.
+The document right-click menu and editor insert menu must keep working, and the
+empty title-bar space must still drag the window.

--- a/tests/math_layout_tests.cpp
+++ b/tests/math_layout_tests.cpp
@@ -154,6 +154,8 @@ int main(int argc, char** argv) {
         checkMarkdownFixture(app, "math-mixed-layout.md", 25, true, 3);
         checkMarkdownFixture(app, "math-inline-stress.md", 9, true, 2);
         checkMarkdownFixture(app, "markdown-regression-control.md", 0, false, 3);
+        checkMarkdownFixture(app, "application-menu.md", 5, false, 3);
+        checkMarkdownFixture(app, "application-menu-companion.md", 1, false, 2);
         auto markdown = app.parser.parse("$$\n\\begin{bmatrix}1&2\\\\5&6\\end{bmatrix}\\longrightarrow 6\n$$");
         check(markdown.success && !markdown.root->children.empty(), "display math Markdown parses");
         if (markdown.success && !markdown.root->children.empty()) {


### PR DESCRIPTION
Clicking the top-left Tinta icon now opens an application menu in reading mode, editing mode and on the start page. It reuses the document context menu's renderer and action dispatch for New, Open, Save, Save As, Print / PDF, Export, Theme, Settings, Help and Exit. The rest of the title bar still drags the window.

Settings, Help and Theme now render over both editor panes and capture input before it reaches the source. Open preserves existing and unsaved tabs, restoring their current preview on return. Print and Export include unsaved changes even with the preview hidden. F10, arrow keys, Enter and Escape operate the menu, and unavailable document actions are disabled.

Validation: all eight CTest suites pass. Added two runnable mixed Markdown fixtures, menu regression checks and fixture math/table checks. Exercised the app in light/dark themes at normal/narrow widths, including native file dialogs, save cancellation, unsaved-tab preservation, Settings/Help, theme switching, keyboard navigation, pinned Contents, title-bar dragging, hidden-preview HTML export and print preview. Five native page images and three HTML exports are byte-identical to v3.5.6 for the two fixtures and the existing Markdown control. Details and remaining coverage limits are in `tests/application-menu-validation.md`.

Refs #194, reported by ILCNa. No release or issue reply is included in this PR.
