### PR TITLE
Fix E and F1 shortcut routing across keyboard layouts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SOURCES
     src/markdown.cpp
     src/themes.cpp
     src/settings.cpp
+    src/keymap.cpp
     src/config_dir.cpp
     src/signals.cpp
     src/tableedit.cpp
@@ -87,6 +88,7 @@ set(HEADERS
     include/types.h
     include/app.h
     include/settings.h
+    include/keymap.h
     include/d2d_init.h
     include/syntax.h
     include/utils.h
@@ -141,6 +143,21 @@ target_compile_definitions(tinta PRIVATE UNICODE _UNICODE
     TINTA_VERSION_PATCH=${PROJECT_VERSION_PATCH})
 
 if(BUILD_TESTING)
+    add_executable(keymap_tests tests/keymap_tests.cpp src/keymap.cpp)
+    target_include_directories(keymap_tests PRIVATE include)
+    add_test(NAME keymap COMMAND keymap_tests)
+
+    # Exercise the real input handlers and editor with a message-only test
+    # window, including layout-dependent character sequences (#195).
+    set(INPUT_TEST_SOURCES ${SOURCES})
+    list(REMOVE_ITEM INPUT_TEST_SOURCES src/main_d2d.cpp)
+    add_executable(input_tests tests/input_tests.cpp ${INPUT_TEST_SOURCES})
+    target_include_directories(input_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(input_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
+    target_compile_definitions(input_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
+        TINTA_SHORTCUT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/shortcuts-layouts.md")
+    add_test(NAME input_shortcuts COMMAND input_tests)
+
     add_executable(context_menu_tests tests/context_menu_tests.cpp src/context_menu.cpp
         src/markdown.cpp src/themes.cpp src/config_dir.cpp)
     target_include_directories(context_menu_tests PRIVATE include ${md4c_SOURCE_DIR}/src)

--- a/include/app.h
+++ b/include/app.h
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include "markdown.h"
+#include "keymap.h"
 
 using namespace qmd;
 
@@ -640,9 +641,8 @@ struct App {
     std::vector<std::pair<D2D1_RECT_F, int>> shortcutHits;  // rebuilt each paint
 
     // Resolved single-key bindings, indexed like KEY_ACTIONS (#77).
-    // Filled by applyKeymap from settings; slots beyond the action count
-    // stay zero.
-    unsigned keymap[16] = {};
+    // Filled by applyKeymap; each binding retains its input message kind.
+    KeyBinding keymap[KEY_ACTION_COUNT] = {};
 
     // Reading position restore (#77): applied once enough of the document is
     // laid out for the target to be reachable (chunked layout grows

--- a/include/input.h
+++ b/include/input.h
@@ -9,7 +9,8 @@ void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam);
 void handleMouseMove(App& app, HWND hwnd, LPARAM lParam);
 void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam);
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam);
-void handleKeyDown(App& app, HWND hwnd, WPARAM wParam);
+// True consumes this keystroke's character translation as well (#195).
+bool handleKeyDown(App& app, HWND hwnd, WPARAM wParam);
 void handleContextMenu(App& app, HWND hwnd, LPARAM lParam);
 void handleCharInput(App& app, HWND hwnd, WPARAM wParam);
 void handleDropFiles(App& app, HWND hwnd, WPARAM wParam);

--- a/include/keymap.h
+++ b/include/keymap.h
@@ -1,0 +1,60 @@
+#ifndef TINTA_KEYMAP_H
+#define TINTA_KEYMAP_H
+
+#include <windows.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+// A virtual key and a typed character are different namespaces. In
+// particular, VK_F1 is also the Unicode value of 'p', and VK_F12 of '{'.
+struct KeyBinding {
+    unsigned key = 0;
+    bool isChar = false;
+};
+
+struct KeyActionDef {
+    const char* name;
+    unsigned defaultKey;
+    bool isChar;
+};
+inline constexpr KeyActionDef KEY_ACTIONS[] = {
+    {"search", 'F', false}, {"browse", 'B', false},
+    {"toc", VK_TAB, false}, {"theme", 'T', false},
+    {"stats", 'S', false}, {"quit", 'Q', false},
+    {"newfile", 'N', false}, {"zen", VK_F11, false},
+    {"scrollup", 'K', false}, {"scrolldown", 'J', false},
+    {"edit", ':', true}, {"help", '?', true},
+    {"annotate", 'A', false},
+};
+inline constexpr int KEY_ACTION_COUNT = 13;
+enum KeyActionIndex {
+    KA_SEARCH = 0, KA_BROWSE, KA_TOC, KA_THEME, KA_STATS, KA_QUIT,
+    KA_NEWFILE, KA_ZEN, KA_SCROLLUP, KA_SCROLLDOWN, KA_EDIT, KA_HELP,
+    KA_ANNOTATE
+};
+
+struct KeyProfileDef {
+    const char* id;
+    KeyBinding keys[KEY_ACTION_COUNT];
+};
+inline constexpr KeyProfileDef KEY_PROFILES[] = {
+    {"windows", {{'F'}, {'B'}, {VK_TAB}, {'T'}, {'S'}, {'Q'}, {'N'},
+                 {VK_F11}, {'K'}, {'J'}, {'E'}, {VK_F1}, {'A'}}},
+    {"vim", {{'/', true}, {'B'}, {VK_TAB}, {'T'}, {'S'}, {'Q'}, {'N'},
+             {VK_F11}, {'K'}, {'J'}, {':', true}, {'?', true}, {'A'}}},
+};
+inline constexpr int KEY_PROFILE_COUNT = 2;
+
+int keyProfileIndexById(const std::string& id);
+KeyBinding parseKeyName(const std::string& value);
+std::string keyIniName(KeyBinding binding);
+std::wstring keyLabel(KeyBinding binding);
+void resolveKeymap(KeyBinding (&keys)[KEY_ACTION_COUNT], const std::string& profile,
+                   const std::vector<std::pair<std::string, std::string>>& overrides);
+bool keyBindingMatches(KeyBinding binding, unsigned key, bool isChar);
+// Convert to the legacy viewer command codes. Unbound characters produce
+// no command; navigation virtual keys pass through unless explicitly moved.
+unsigned translateActionKey(const KeyBinding* keys, unsigned key, bool isChar);
+
+#endif

--- a/include/settings.h
+++ b/include/settings.h
@@ -35,60 +35,8 @@ std::wstring tintaConfigDir();
 // does not share a Store/MSIX process's virtualized AppData view.
 std::wstring configFilePathForShell(const std::wstring& path);
 
-// User-remappable single-key actions (#77), written to settings.ini as a
-// [Keys] section. Char actions trigger via WM_CHAR (edit ':', help '?');
-// the rest are WM_KEYDOWN virtual-key codes. Ctrl combos stay fixed.
-struct KeyActionDef {
-    const char* name;     // ini key
-    unsigned defaultKey;  // VK code, or character for isChar actions
-    bool isChar;
-};
-inline constexpr KeyActionDef KEY_ACTIONS[] = {
-    {"search",     'F',    false},
-    {"browse",     'B',    false},
-    {"toc",        VK_TAB, false},
-    {"theme",      'T',    false},
-    {"stats",      'S',    false},
-    {"quit",       'Q',    false},
-    {"newfile",    'N',    false},
-    {"zen",        VK_F11, false},
-    {"scrollup",   'K',    false},
-    {"scrolldown", 'J',    false},
-    {"edit",       ':',    true},
-    {"help",       '?',    true},
-    {"annotate",   'A',    false},
-};
-inline constexpr int KEY_ACTION_COUNT = 13;
-enum KeyActionIndex {
-    KA_SEARCH = 0, KA_BROWSE, KA_TOC, KA_THEME, KA_STATS, KA_QUIT,
-    KA_NEWFILE, KA_ZEN, KA_SCROLLUP, KA_SCROLLDOWN, KA_EDIT, KA_HELP,
-    KA_ANNOTATE
-};
-
-// Shortcut profiles: Tinta grew from a keyboard-first viewer into a full
-// UI, leaving a mix of vim-style keys (j/k, ':') and Windows conventions.
-// Profiles let the user pick a coherent set; "custom" keeps the [Keys]
-// overrides-over-defaults semantics. Raw ':' and '?' stay hardwired to
-// edit/help in every profile, so documented habits never break.
-struct KeyProfileDef {
-    const char* id;                     // persisted in settings.ini
-    unsigned keys[KEY_ACTION_COUNT];    // same order as KEY_ACTIONS
-};
-inline constexpr KeyProfileDef KEY_PROFILES[] = {
-    // search browse toc     theme stats quit newfile zen     up   down edit help  annotate
-    {"windows", {'F', 'B', VK_TAB, 'T', 'S', 'Q', 'N', VK_F11, 'K', 'J', 'E', VK_F1, 'A'}},
-    {"vim",     {'/', 'B', VK_TAB, 'T', 'S', 'Q', 'N', VK_F11, 'K', 'J', ':', '?', 'A'}},
-};
-inline constexpr int KEY_PROFILE_COUNT = 2;
-// Index into KEY_PROFILES, or -1 for the custom [Keys] profile
-int keyProfileIndexById(const std::string& id);
-
-// Resolves settings.keyOverrides over the defaults into app.keymap
+// Resolve the selected profile and custom [Keys] bindings.
 void applyKeymap(App& app, const Settings& settings);
-// Key spelling used in settings.ini ("G", "Tab", "F5", ...)
-std::string keyIniName(unsigned key);
-// Same spelling as a wide string for overlay labels
-std::wstring keyLabel(unsigned key);
 bool registerFileAssociation();
 void openDefaultAppsSettings();
 void askAndRegisterFileAssociation(Settings& settings);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -594,7 +594,7 @@ static void settingsSliderApply(App& app, int which, float mx) {
 // Applies one settings-overlay action (id from app.settingsHits)
 // Shortcut editor: bind the armed action to `key` and land in the custom
 // profile so the change persists via [Keys]
-static void shortcutAssign(App& app, unsigned key) {
+static void shortcutAssign(App& app, KeyBinding key) {
     int row = app.shortcutEditorRow;
     if (row < 0 || row >= KEY_ACTION_COUNT) return;
     std::string value = keyIniName(key);
@@ -741,39 +741,6 @@ static void settingsAction(App& app, HWND hwnd, int action) {
             break;
     }
     InvalidateRect(hwnd, nullptr, FALSE);
-}
-
-// Maps a pressed key through the user keymap ([Keys] in settings.ini): a
-// remapped key becomes the built-in default the switches below expect, and
-// a default key the user moved elsewhere is swallowed. Non-action keys pass
-// through untouched. (#77)
-static WPARAM translateActionKey(App& app, WPARAM key, bool isChar) {
-    auto norm = [&](unsigned k) {
-        return isChar ? (unsigned)towupper((wint_t)k) : k;
-    };
-    unsigned pressed = norm((unsigned)key);
-    for (int i = 0; i < KEY_ACTION_COUNT; i++) {
-        if (KEY_ACTIONS[i].isChar != isChar) {
-            // Punctuation bound to a keydown action (vim '/'-search) only
-            // arrives as a character — its VK depends on the layout — so
-            // the char pass matches it too. Letters stay keydown-only.
-            bool punctInCharPass = isChar && !KEY_ACTIONS[i].isChar &&
-                app.keymap[i] > ' ' && app.keymap[i] < 128 &&
-                !iswalnum((wint_t)app.keymap[i]);
-            if (!punctInCharPass) continue;
-        }
-        if (norm(app.keymap[i]) == pressed) {
-            return (WPARAM)KEY_ACTIONS[i].defaultKey;
-        }
-    }
-    for (int i = 0; i < KEY_ACTION_COUNT; i++) {
-        if (KEY_ACTIONS[i].isChar != isChar) continue;
-        if (norm(KEY_ACTIONS[i].defaultKey) == pressed &&
-            norm(app.keymap[i]) != pressed) {
-            return 0;  // default key rebound elsewhere: swallow
-        }
-    }
-    return key;
 }
 
 void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
@@ -3299,7 +3266,7 @@ static void toggleZenMode(App& app, HWND hwnd) {
     InvalidateRect(hwnd, nullptr, FALSE);
 }
 
-void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
+bool handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     float pageSize = app.height * 0.8f;
     float maxScroll = std::max(0.0f, app.contentHeight - app.height);
     bool ctrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
@@ -3311,14 +3278,14 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             closeLightbox(app);
             InvalidateRect(hwnd, nullptr, FALSE);
         }
-        return;
+        return false;
     }
 
     // Annotation note editor owns the keyboard while open (#126)
     if (app.annotEditorOpen && !app.editMode) {
         annotationEditorKeyDown(app, hwnd, wParam, ctrl);
         InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        return false;
     }
 
     // Create-missing-reference dialog owns the keyboard while open
@@ -3332,7 +3299,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                                     std::chrono::milliseconds(150);
             createRefAction(app, hwnd, 2);
         }
-        return;
+        return false;
     }
 
     // Print preview captures the whole keyboard while open
@@ -3360,7 +3327,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 printPreviewSetPage(app, (int)app.printPreviewBounds.size() - 2);
                 break;
         }
-        return;
+        return false;
     }
 
     if (!app.confirmExitPending && app.showContextMenu) {
@@ -3381,7 +3348,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             if (contextMenuItemEnabled(app, item)) invokeContextMenuAction(app, hwnd, item);
         }
         InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        return false;
     }
     // Shortcut editor: an armed row captures the next key; Esc cancels
     // the capture, then closes back to settings
@@ -3402,15 +3369,15 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 (wParam >= '0' && wParam <= '9')) {
                 key = (unsigned)wParam;
             }
-            if (key) shortcutAssign(app, key);
+            if (key) shortcutAssign(app, {(unsigned)key, false});
         }
         InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        return false;
     }
     // Theme editor: Esc returns to settings; text arrives via WM_CHAR
     if (app.showThemeEditor) {
         if (wParam == VK_ESCAPE) closeThemeEditor(app, true);
-        return;
+        return false;
     }
     // Settings overlay captures the keyboard while open
     if (app.showSettings) {
@@ -3419,19 +3386,21 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             app.settingsAnimation = 0;
             InvalidateRect(hwnd, nullptr, FALSE);
         }
-        return;
+        return false;
     }
 
     if (app.showHelp || app.showThemeChooser) {
         if (wParam == VK_ESCAPE ||
-            (!ctrl && app.showHelp && wParam == app.keymap[KA_HELP]) ||
-            (!ctrl && app.showThemeChooser && wParam == app.keymap[KA_THEME])) {
+            (!ctrl && app.showHelp && keyBindingMatches(app.keymap[KA_HELP], (unsigned)wParam, false)) ||
+            (!ctrl && app.showThemeChooser && keyBindingMatches(app.keymap[KA_THEME], (unsigned)wParam, false))) {
             if (app.themeChooserPreviewBase >= 0) {
                 applyTheme(app, app.themeChooserPreviewBase);
                 app.themeChooserPreviewBase = -1;
             }
             app.showThemeChooser = false;
             app.showHelp = false;
+            InvalidateRect(hwnd, nullptr, FALSE);
+            return true;
         } else if (app.showHelp) {
             float step = dpi(app, 60.0f);
             if (wParam == VK_NEXT || wParam == VK_PRIOR) step = app.helpVisibleHeight;
@@ -3441,23 +3410,23 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 app.helpContentHeight - app.helpVisibleHeight));
         }
         InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        return false;  // punctuation Help bindings still need WM_CHAR
     }
     if (appMenuAvailable(app)) {
         if (wParam == VK_F10) {
             toggleApplicationMenu(app, hwnd, true);
-            return;
+            return false;
         }
         if (ctrl && wParam == 'O') {
             openFileDialog(app, hwnd);
-            return;
+            return false;
         }
         if (ctrl && wParam == VK_OEM_COMMA) {
             closeSearchIfOpen(app);
             app.showSettings = true;
             app.settingsAnimation = 0;
             InvalidateRect(hwnd, nullptr, FALSE);
-            return;
+            return false;
         }
     }
 
@@ -3470,68 +3439,79 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
         bool shift = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
         if (wParam == VK_TAB) {
             tabCycle(app, hwnd, shift ? -1 : 1);
-            return;
+            return false;
         }
         if (wParam == 'W' && !app.editMode) {
             // In edit mode Ctrl+W keeps its documented word-wrap toggle
             tabCloseIndex(app, hwnd, app.activeTab);
-            return;
+            return false;
         }
         if (wParam == VK_F4) {
             // Ctrl+F4 closes the tab in BOTH modes - the reachable close
             // while editing, where Ctrl+W means word wrap (#181)
             tabCloseIndex(app, hwnd, app.activeTab);
-            return;
+            return false;
         }
         if (wParam == 'T') {
             // New tab = the start page (browser-style new-tab page); its
             // Open/Browse/recents land in this tab. The old open-into-a-
             // new-tab browser flow lives on as Ctrl+click in the browser.
             tabOpenStartPage(app, hwnd);
-            return;
+            return false;
         }
         if (wParam >= '1' && wParam <= '9' && app.tabs.size() > 1) {
             int index = (int)(wParam - '1');
             if (index < (int)app.tabs.size()) tabActivate(app, hwnd, index);
-            return;
+            return false;
         }
     }
     if (app.showTabSwitcher && wParam == VK_ESCAPE) {
         app.showTabSwitcher = false;
         InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        return false;
     }
     // Esc aborts a tab drag in flight (ghost vanishes, tab snaps home)
     if (app.tabDragIndex >= 0 && wParam == VK_ESCAPE) {
         tabDragCancel(app, hwnd);
-        return;
+        return false;
     }
     // An open tab menu takes Esc before anything else (edit mode too —
     // the strip stays interactive while editing)
     if (app.showTabMenu && wParam == VK_ESCAPE) {
         closeTabMenu(app);
         InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        return false;
+    }
+
+    // Function-key Help remains available while editing. Printable custom
+    // bindings stay with the text editor, as do Tab and Space.
+    if (app.editMode && !app.confirmExitPending && !ctrl &&
+        wParam >= VK_F1 && wParam <= VK_F12 &&
+        keyBindingMatches(app.keymap[KA_HELP], (unsigned)wParam, false)) {
+        app.showHelp = true;
+        app.helpAnimation = 0;
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return true;
     }
 
     // Edit mode: Ctrl+C with preview pane selection should copy from preview
     if (app.editMode) {
         // An open table cell editor owns the keyboard (#148)
-        if (tableEditKeyDown(app, hwnd, wParam)) return;
+        if (tableEditKeyDown(app, hwnd, wParam)) return false;
         if (ctrl && wParam == 'C' && app.hasSelection &&
             app.selAnchor != app.selFocus) {
             std::wstring selected = selectionTextForRange(
                 app, std::min(app.selAnchor, app.selFocus),
                 std::max(app.selAnchor, app.selFocus));
-            if (selected.empty()) return;
+            if (selected.empty()) return false;
             copyToClipboard(hwnd, selected);
             signalPushKey(app, SIG_INFO, SIGI_COPY, "toast.copied");
             app.hasSelection = false;
             InvalidateRect(hwnd, nullptr, FALSE);
-            return;
+            return false;
         }
         handleEditorKeyDown(app, hwnd, wParam);
-        return;
+        return false;
     }
 
     // Folder browser path/name input captures the keyboard while active
@@ -3573,7 +3553,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             }
         }
         InvalidateRect(hwnd, nullptr, FALSE);
-        return;
+        return false;
     }
 
     // Handle search-specific keys when search is active
@@ -3590,7 +3570,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                 clearFolderSearch(app);
                 updateBlinkTimer(app);
                 InvalidateRect(hwnd, nullptr, FALSE);
-                return;
+                return false;
             case VK_RETURN:
                 // Cycle to next match
                 if (!app.searchMatches.empty()) {
@@ -3598,7 +3578,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                     scrollToCurrentMatch(app);
                     InvalidateRect(hwnd, nullptr, FALSE);
                 }
-                return;
+                return false;
             case VK_BACK:
                 // Delete last character
                 if (!app.searchQuery.empty()) {
@@ -3610,7 +3590,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                     }
                     InvalidateRect(hwnd, nullptr, FALSE);
                 }
-                return;
+                return false;
         }
     }
 
@@ -3743,7 +3723,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             if (wParam == VK_BACK) {
                 if (!app.tocFilter.empty()) app.tocFilter.pop_back();
                 InvalidateRect(hwnd, nullptr, FALSE);
-                return;
+                return false;
             }
             if (wParam == VK_RETURN) {
                 std::wstring needle = toLower(app.tocFilter);
@@ -3763,11 +3743,11 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
                     }
                 }
                 InvalidateRect(hwnd, nullptr, FALSE);
-                return;
+                return false;
             }
             if ((wParam >= 'A' && wParam <= 'Z') ||
                 (wParam >= '0' && wParam <= '9') || wParam == VK_SPACE) {
-                return;  // swallowed here; WM_CHAR feeds the filter
+                return false;  // swallowed here; WM_CHAR feeds the filter
             }
         }
 
@@ -3778,21 +3758,37 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
         if (startPageActive(app)) {
             if (ctrl && wParam == 'O') {
                 startPageInvoke(app, hwnd, 1);
-                return;
+                return false;
             }
-            if (!ctrl && wParam == app.keymap[KA_NEWFILE]) {
+            if (!ctrl && keyBindingMatches(app.keymap[KA_NEWFILE], (unsigned)wParam, false)) {
                 startPageInvoke(app, hwnd, 2);
-                return;
+                return false;
             }
             if (!ctrl && wParam >= '1' && wParam <= '5' &&
                 (int)(wParam - '1') < (int)app.startPageRecents.size()) {
                 startPageInvoke(app, hwnd, 10 + (int)(wParam - '1'));
-                return;
+                return false;
             }
         }
 
-        wParam = translateActionKey(app, wParam, false);
+        wParam = translateActionKey(app.keymap, (unsigned)wParam, false);
         switch (wParam) {
+            case ':':
+            case '?':
+                if (!app.showSearch &&
+                    (!app.showFolderBrowser || app.browserPinned) &&
+                    (!app.showToc || app.tocPinned)) {
+                    if (wParam == ':') enterEditMode(app);
+                    else {
+                        app.showHelp = true;
+                        app.helpAnimation = 0;
+                        InvalidateRect(hwnd, nullptr, FALSE);
+                    }
+                    // The message loop skips TranslateMessage for this
+                    // keystroke, so E cannot become the first edit (#195).
+                    return true;
+                }
+                break;
             case VK_ESCAPE:
                 // Priority: ContextMenu > Help > Search > FolderBrowser > TOC > Theme chooser > Quit
                 if (app.showContextMenu) {
@@ -4002,6 +3998,7 @@ void handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     app.targetScrollY = std::max(0.0f, std::min(app.targetScrollY, maxScroll));
     app.scrollY = app.targetScrollY;
     InvalidateRect(hwnd, nullptr, FALSE);
+    return false;
 }
 
 void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
@@ -4025,7 +4022,7 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
         wchar_t ch = (wchar_t)wParam;
         if (app.shortcutEditorRow >= 0 && ch > 32 && ch < 127 &&
             !iswalnum(ch)) {
-            shortcutAssign(app, (unsigned)ch);
+            shortcutAssign(app, {(unsigned)ch, true});
             InvalidateRect(hwnd, nullptr, FALSE);
         }
         return;  // the editor swallows all other typing
@@ -4059,7 +4056,7 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
 
     if (app.showContextMenu || app.showSettings || app.showThemeChooser) return;
     if (app.showHelp) {
-        if ((unsigned)wParam == app.keymap[KA_HELP]) {
+        if (translateActionKey(app.keymap, (unsigned)wParam, true) == '?') {
             app.showHelp = false;
             app.helpAnimation = 0;
             InvalidateRect(hwnd, nullptr, FALSE);
@@ -4098,12 +4095,7 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
         WPARAM key = wParam;
         if (key == 0xFF1A) key = L':';  // ：
         if (key == 0xFF1F) key = L'?';  // ？
-        wchar_t ch = (wchar_t)translateActionKey(app, key, true);
-        // Universal fallbacks: raw ':' and '?' keep working in every
-        // profile — the docs and years of habit point at them
-        if (ch == 0 && (key == L':' || key == L'?')) {
-            ch = (wchar_t)key;
-        }
+        wchar_t ch = (wchar_t)translateActionKey(app.keymap, (unsigned)key, true);
         if (ch == L':' && !app.showHelp) {
             enterEditMode(app);
             return;
@@ -4124,7 +4116,7 @@ void handleCharInput(App& app, HWND hwnd, WPARAM wParam) {
             app.searchQuery.clear();
             app.searchMatches.clear();
             app.searchCurrentIndex = 0;
-            app.searchJustOpened = true;
+            app.searchJustOpened = false;
             updateBlinkTimer(app);
             InvalidateRect(app.hwnd, nullptr, FALSE);
             return;

--- a/src/keymap.cpp
+++ b/src/keymap.cpp
@@ -1,0 +1,80 @@
+#include "keymap.h"
+
+#include <cctype>
+
+KeyBinding parseKeyName(const std::string& value) {
+    if (value.empty()) return {};
+    if (value.size() == 1) {
+        unsigned char ch = (unsigned char)value[0];
+        if (ch < 32 || ch >= 127) return {};
+        return {(unsigned)std::toupper(ch), ch != ' ' && !std::isalnum(ch)};
+    }
+    std::string lower;
+    for (unsigned char ch : value) lower += (char)std::tolower(ch);
+    if (lower == "tab") return {VK_TAB};
+    if (lower == "space") return {VK_SPACE};
+    for (unsigned n = 1; n <= 12; ++n) {
+        if (lower == "f" + std::to_string(n)) return {VK_F1 + n - 1};
+    }
+    return {};
+}
+
+std::string keyIniName(KeyBinding binding) {
+    if (!binding.isChar) {
+        if (binding.key == VK_TAB) return "Tab";
+        if (binding.key == VK_SPACE) return "Space";
+        if (binding.key >= VK_F1 && binding.key <= VK_F12)
+            return "F" + std::to_string(binding.key - VK_F1 + 1);
+    }
+    return std::string(1, (char)binding.key);
+}
+
+std::wstring keyLabel(KeyBinding binding) {
+    std::string value = keyIniName(binding);
+    return std::wstring(value.begin(), value.end());
+}
+
+int keyProfileIndexById(const std::string& id) {
+    for (int i = 0; i < KEY_PROFILE_COUNT; ++i)
+        if (id == KEY_PROFILES[i].id) return i;
+    return -1;
+}
+
+void resolveKeymap(KeyBinding (&keys)[KEY_ACTION_COUNT], const std::string& profile,
+                   const std::vector<std::pair<std::string, std::string>>& overrides) {
+    int index = keyProfileIndexById(profile);
+    for (int i = 0; i < KEY_ACTION_COUNT; ++i) {
+        keys[i] = index >= 0 ? KEY_PROFILES[index].keys[i]
+                            : KeyBinding{KEY_ACTIONS[i].defaultKey, KEY_ACTIONS[i].isChar};
+        if (index >= 0) continue;
+        for (const auto& override : overrides) {
+            if (override.first != KEY_ACTIONS[i].name) continue;
+            KeyBinding binding = parseKeyName(override.second);
+            if (binding.key) keys[i] = binding;
+        }
+    }
+}
+
+bool keyBindingMatches(KeyBinding binding, unsigned key, bool isChar) {
+    // Only punctuation bindings use WM_CHAR. Never case-fold a virtual
+    // key as Unicode, or compare it to a layout-dependent character.
+    if (isChar && key == 0xFF1A) key = ':';
+    if (isChar && key == 0xFF1F) key = '?';
+    return binding.isChar == isChar && binding.key == key;
+}
+
+unsigned translateActionKey(const KeyBinding* keys, unsigned key, bool isChar) {
+    for (int i = 0; i < KEY_ACTION_COUNT; ++i) {
+        if (keyBindingMatches(keys[i], key, isChar)) return KEY_ACTIONS[i].defaultKey;
+    }
+    if (isChar) {
+        // Preserve the documented ':'/'?' fallbacks in every profile.
+        if (key == ':' || key == 0xFF1A) return ':';
+        if (key == '?' || key == 0xFF1F) return '?';
+        return 0;
+    }
+    for (const auto& action : KEY_ACTIONS) {
+        if (!action.isChar && action.defaultKey == key) return 0;
+    }
+    return key;
+}

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1504,7 +1504,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             break;
 
         case WM_KEYDOWN:
-            if (app) handleKeyDown(*app, hwnd, wParam);
+            if (app) return handleKeyDown(*app, hwnd, wParam) ? 1 : 0;
             return 0;
 
         case WM_XBUTTONUP:
@@ -2257,8 +2257,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     // Message loop
     MSG msg;
     while (GetMessage(&msg, nullptr, 0, 0)) {
-        TranslateMessage(&msg);
-        DispatchMessage(&msg);
+        if (msg.hwnd == app.hwnd && msg.message == WM_KEYDOWN) {
+            // Give command shortcuts the first chance to consume a key.
+            // Only unconsumed keystrokes generate WM_CHAR; no timed input
+            // suppression is needed when E opens the editor (#195).
+            if (!DispatchMessage(&msg)) TranslateMessage(&msg);
+        } else {
+            TranslateMessage(&msg);
+            DispatchMessage(&msg);
+        }
     }
 
     g_app = nullptr;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -75,7 +75,7 @@ void saveSettings(const Settings& settings) {
     file << "[Keys]\n";
     file << "; single letters/digits, Tab, Space, F1-F12, or one character\n";
     for (int i = 0; i < KEY_ACTION_COUNT; i++) {
-        std::string value = keyIniName(KEY_ACTIONS[i].defaultKey);
+        std::string value = keyIniName({KEY_ACTIONS[i].defaultKey, KEY_ACTIONS[i].isChar});
         for (const auto& kv : settings.keyOverrides) {
             if (kv.first == KEY_ACTIONS[i].name) { value = kv.second; break; }
         }
@@ -110,58 +110,8 @@ void saveSettings(const Settings& settings) {
     }
 }
 
-// "G" -> 'G', "Tab"/"Space"/"F1".."F12" -> VK code, ":" -> ':'; 0 = invalid
-static unsigned parseKeyName(const std::string& value) {
-    if (value.empty()) return 0;
-    if (value.size() == 1) return (unsigned)toupper((unsigned char)value[0]);
-    std::string lower;
-    for (char c : value) lower += (char)tolower((unsigned char)c);
-    if (lower == "tab") return VK_TAB;
-    if (lower == "space") return VK_SPACE;
-    if (lower.size() >= 2 && lower[0] == 'f') {
-        int n = atoi(lower.c_str() + 1);
-        if (n >= 1 && n <= 12) return VK_F1 + n - 1;
-    }
-    return 0;
-}
-
-std::string keyIniName(unsigned key) {
-    if (key == VK_TAB) return "Tab";
-    if (key == VK_SPACE) return "Space";
-    if (key >= VK_F1 && key <= VK_F12) return "F" + std::to_string(key - VK_F1 + 1);
-    return std::string(1, (char)key);
-}
-
-std::wstring keyLabel(unsigned key) {
-    std::string narrow = keyIniName(key);
-    return std::wstring(narrow.begin(), narrow.end());
-}
-
-int keyProfileIndexById(const std::string& id) {
-    for (int i = 0; i < KEY_PROFILE_COUNT; i++) {
-        if (id == KEY_PROFILES[i].id) return i;
-    }
-    return -1;
-}
-
 void applyKeymap(App& app, const Settings& settings) {
-    int prof = keyProfileIndexById(settings.keyProfile);
-    for (int i = 0; i < KEY_ACTION_COUNT; i++) {
-        app.keymap[i] = prof >= 0 ? KEY_PROFILES[prof].keys[i]
-                                  : KEY_ACTIONS[i].defaultKey;
-    }
-    if (prof < 0) {
-        // Custom: [Keys] overrides over the defaults, the #77 semantics
-        for (const auto& kv : settings.keyOverrides) {
-            for (int i = 0; i < KEY_ACTION_COUNT; i++) {
-                if (kv.first == KEY_ACTIONS[i].name) {
-                    unsigned key = parseKeyName(kv.second);
-                    if (key) app.keymap[i] = key;
-                    break;
-                }
-            }
-        }
-    }
+    resolveKeymap(app.keymap, settings.keyProfile, settings.keyOverrides);
     app.keyProfile = settings.keyProfile;
 }
 
@@ -413,7 +363,7 @@ Settings loadSettings() {
         for (const auto& kv : settings.keyOverrides) {
             for (int i = 0; i < KEY_ACTION_COUNT; i++) {
                 if (kv.first == KEY_ACTIONS[i].name &&
-                    kv.second != keyIniName(KEY_ACTIONS[i].defaultKey)) {
+                    kv.second != keyIniName({KEY_ACTIONS[i].defaultKey, KEY_ACTIONS[i].isChar})) {
                     customized = true;
                     break;
                 }

--- a/tests/fixtures/shortcuts-layouts.md
+++ b/tests/fixtures/shortcuts-layouts.md
@@ -1,0 +1,47 @@
+# Shortcut regression: $E = mc^2$
+
+Open a **copy** of this document to check issue [#195](https://github.com/oipoistar/tinta/issues/195).
+Select the Windows shortcut profile in Settings. Start in reading mode.
+
+| Key | Expected behavior | Math stays intact |
+| --- | --- | --- |
+| F1 | Help opens; F1 closes it | $x^2 + y^2$ |
+| P | Help stays closed | $\frac{1}{2}$ |
+| E | Editor opens with no extra character | $\sqrt{a+b}$ |
+
+## Reading and editing
+
+1. Press F1 twice. Check that the table, heading and equations still render.
+2. Press P. It must not open Help.
+3. Press E, then immediately type a letter. Only the typed letter should be inserted.
+4. Undo, then open and close Help with F1 in the editor. The buffer stays clean.
+5. Enter `e p : ?` and non-Latin text in the editor and search field. These remain text.
+6. With a non-Latin layout active, press the key that Windows reports as E. Edit opens.
+7. Repeat with pinned Contents, then unpin Contents and verify typing filters headings.
+
+> Text samples: **English**, *Hrvatski*, русский: у, Ελληνικά: ε.
+> These characters are document content; shortcut matching must not consume normal typing.
+
+$$
+\begin{bmatrix}a & b \\ c & d\end{bmatrix}
+\begin{pmatrix}x \\ y\end{pmatrix}
+= \begin{pmatrix}ax+by \\ cx+dy\end{pmatrix}
+$$
+
+## Vim and custom bindings
+
+- In the Vim profile, `:` enters Edit, `?` toggles Help and `/` opens Search.
+- The first character typed after `/` must remain in the query.
+- Raw `:` and `?` also work in the Windows profile; full-width `：` and `？` remain supported.
+- In a portable custom profile, bind Edit to F2 and Help to F3, then to G and H.
+- Check the same commands in the top-left menu and the document right-click menu.
+
+```latex
+% Literal code must stay literal after opening and closing overlays.
+\frac{1}{2} + \sqrt{x} % E, F1, :, ?
+```
+
+## Final heading
+
+The [existing mixed-content control](markdown-regression-control.md), lists, emphasis,
+links, quote and fenced code should remain unchanged when switching modes.

--- a/tests/input_tests.cpp
+++ b/tests/input_tests.cpp
@@ -1,0 +1,122 @@
+#include "input.h"
+#include "settings.h"
+
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+
+// Same contract as the main message loop: a consumed key must not have
+// its layout-dependent WM_CHAR translated into the new editor/overlay.
+void stroke(App& app, unsigned vk, unsigned character = 0) {
+    bool consumed = handleKeyDown(app, app.hwnd, vk);
+    if (!consumed && character) handleCharInput(app, app.hwnd, character);
+}
+}
+
+int main() {
+    auto state = std::make_unique<App>();
+    App& app = *state;
+    app.hwnd = CreateWindowExW(0, L"STATIC", L"Tinta input tests", 0,
+                              0, 0, 0, 0, HWND_MESSAGE, nullptr, nullptr, nullptr);
+    check(app.hwnd != nullptr, "message-only test window created");
+    if (!app.hwnd) return 1;
+    app.currentFile = TINTA_SHORTCUT_FIXTURE;
+    app.width = 1050;
+    app.height = 900;
+    Settings settings;
+    settings.keyProfile = "windows";
+    applyKeymap(app, settings);
+
+    stroke(app, VK_F1);
+    check(app.showHelp, "F1 opens Help with no character message");
+    stroke(app, VK_F1);
+    check(!app.showHelp, "F1 closes Help");
+    stroke(app, 'P', 'p');
+    check(!app.showHelp, "P cannot open Help");
+
+    std::wstring original;
+    for (unsigned ch : {0x65, 0x0443, 0x03B5}) {
+        app.editMode = false;
+        stroke(app, 'E', ch);
+        check(app.editMode && !app.editorDirty, "E enters a clean editor for Latin/Cyrillic/Greek input");
+        check(app.editorText.rfind(L"# Shortcut regression:", 0) == 0,
+              "the mode-switch key cannot prefix the Markdown heading");
+        original = app.editorText;
+        stroke(app, 'X', 'x');
+        check(app.editorText == L"x" + original, "immediate next character is preserved without a timer");
+    }
+    app.editMode = false;
+    stroke(app, 'E', 0x0443);
+    original = app.editorText;
+    stroke(app, VK_F1);
+    check(app.showHelp && app.editMode, "F1 opens Help while editing");
+    stroke(app, 'E', 'e');
+    check(app.editorText == original, "Help captures printable input over the editor");
+    stroke(app, VK_F1);
+    check(!app.showHelp && app.editMode && !app.editorDirty, "Help closes over a clean editor");
+    stroke(app, 'P', 'p');
+    check(app.editorText == L"p" + original, "normal P typing survives in editor");
+
+    app.editMode = false;
+    app.showSearch = true;
+    app.searchActive = true;
+    app.searchJustOpened = false;
+    stroke(app, 'E', 0x0443);
+    check(!app.editMode && app.searchQuery == L"\x0443", "search receives non-Latin E text");
+    stroke(app, VK_ESCAPE);
+    app.showToc = true;
+    app.tocPinned = false;
+    stroke(app, 'E', 0x0443);
+    check(!app.editMode && app.tocFilter == L"\x0443", "unpinned Contents receives non-Latin filter text");
+    app.tocPinned = true;
+    stroke(app, 'E', 0x0443);
+    check(app.editMode, "pinned Contents lets E reach the document");
+
+    app.editMode = false;
+    app.showToc = false;
+    app.showSettings = true;
+    stroke(app, 'E', 'e');
+    stroke(app, VK_F1);
+    check(!app.editMode && !app.showHelp, "Settings retains modal keyboard capture");
+    app.showSettings = false;
+    settings.keyProfile = "vim";
+    applyKeymap(app, settings);
+    stroke(app, VK_OEM_2, '?');
+    check(app.showHelp, "vim punctuation opens Help");
+    stroke(app, VK_OEM_2, '?');
+    check(!app.showHelp, "vim punctuation closes Help");
+    stroke(app, VK_OEM_2, '/');
+    stroke(app, 'E', 'e');
+    check(app.showSearch && app.searchQuery == L"e", "vim search keeps its first query character");
+    stroke(app, VK_ESCAPE);
+    stroke(app, VK_OEM_1, 0xFF1A);
+    check(app.editMode && !app.editorDirty, "full-width colon still enters a clean editor");
+
+    app.editMode = false;
+    settings.keyProfile = "custom";
+    settings.keyOverrides = {{"edit", "F2"}, {"help", "H"}};
+    applyKeymap(app, settings);
+    stroke(app, 'H', 'h');
+    check(app.showHelp, "custom letter Help opens only once");
+    stroke(app, 'H', 'h');
+    check(!app.showHelp, "custom letter Help closes without reopening");
+    stroke(app, VK_F2);
+    check(app.editMode && !app.editorDirty, "custom function key enters Edit");
+    app.confirmExitPending = true;
+    settings.keyOverrides = {{"help", "F3"}};
+    applyKeymap(app, settings);
+    stroke(app, VK_F3);
+    check(app.confirmExitPending && !app.showHelp, "Help cannot bypass unsaved-changes confirmation");
+
+    DestroyWindow(app.hwnd);
+    app.hwnd = nullptr;
+    std::cout << "Input shortcuts: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/tests/keymap_tests.cpp
+++ b/tests/keymap_tests.cpp
@@ -1,0 +1,66 @@
+#include "keymap.h"
+
+#include <iostream>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+}
+
+int main() {
+    KeyBinding keys[KEY_ACTION_COUNT];
+    resolveKeymap(keys, "windows", {});
+    check(translateActionKey(keys, 'E', false) == ':', "VK_E enters edit before any character arrives");
+    for (unsigned character : {0x65, 0x45, 0x0443, 0x0423, 0x03B5, 0xFF45}) {
+        check(translateActionKey(keys, character, true) == 0,
+              "Latin, Cyrillic, Greek and full-width text cannot trigger or duplicate E");
+    }
+    check(translateActionKey(keys, VK_F1, false) == '?', "F1 opens help without a WM_CHAR");
+    check(translateActionKey(keys, 'p', true) == 0 &&
+          translateActionKey(keys, 'P', true) == 0, "P does not alias F1");
+    check(translateActionKey(keys, VK_F11, false) == VK_F11, "Windows zen key survives");
+    check(translateActionKey(keys, VK_DOWN, false) == VK_DOWN, "unbound arrow navigation survives");
+    for (unsigned character : {0x3A, 0xFF1A})
+        check(translateActionKey(keys, character, true) == ':', "ASCII/full-width edit fallback");
+    for (unsigned character : {0x3F, 0xFF1F})
+        check(translateActionKey(keys, character, true) == '?', "ASCII/full-width help fallback");
+
+    resolveKeymap(keys, "vim", {});
+    check(translateActionKey(keys, '/', true) == 'F', "vim slash opens search via WM_CHAR");
+    check(translateActionKey(keys, VK_OEM_2, false) != 'F', "layout-dependent slash VK is not a character");
+    check(translateActionKey(keys, 'F', false) == 0 &&
+          translateActionKey(keys, 'F', true) == 0, "rebound default cannot reopen search via WM_CHAR");
+    check(translateActionKey(keys, 'E', false) != ':' &&
+          translateActionKey(keys, 'e', true) == 0, "Windows E stays inactive in vim");
+
+    for (unsigned n = 1; n <= 12; ++n) {
+        std::string name = "F" + std::to_string(n);
+        resolveKeymap(keys, "custom", {{"help", name}, {"zen", "Z"}});
+        check(translateActionKey(keys, VK_F1 + n - 1, false) == '?', "function-key help remap works");
+        check(translateActionKey(keys, VK_F1 + n - 1, true) != '?', "function key is not a Unicode alias");
+        check(keyIniName(keys[KA_HELP]) == name, "function binding round trips");
+    }
+    resolveKeymap(keys, "custom", {{"edit", "G"}, {"help", "H"}});
+    check(translateActionKey(keys, 'G', false) == ':' &&
+          translateActionKey(keys, 'H', false) == '?', "letter remaps work on keydown");
+    check(translateActionKey(keys, 'g', true) == 0 &&
+          translateActionKey(keys, 'h', true) == 0, "letter remaps cannot fire twice");
+    resolveKeymap(keys, "custom", {{"edit", "F2"}, {"help", "{"}});
+    check(translateActionKey(keys, VK_F2, false) == ':', "function-key edit remap works");
+    check(translateActionKey(keys, 'q', true) == 0, "function-key edit cannot alias Q");
+    check(translateActionKey(keys, '{', true) == '?' &&
+          translateActionKey(keys, VK_F12, false) != '?', "brace and F12 stay distinct");
+    check(keyIniName(keys[KA_HELP]) == "{", "brace remains punctuation in settings and hints");
+    resolveKeymap(keys, "custom", {{"edit", "Tab"}, {"toc", "I"},
+                                  {"help", "Space"}});
+    check(translateActionKey(keys, VK_TAB, false) == ':' &&
+          translateActionKey(keys, VK_SPACE, false) == '?', "named nonprinting bindings use keydown");
+    resolveKeymap(keys, "custom", {{"help", "F1garbage"}});
+    check(translateActionKey(keys, '?', true) == '?', "invalid binding retains default");
+    check(!parseKeyName("F13").key && !parseKeyName("F1garbage").key,
+          "malformed function-key settings are rejected");
+    std::cout << "Keymap: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/tests/shortcuts-validation.md
+++ b/tests/shortcuts-validation.md
@@ -1,0 +1,71 @@
+# Issue #195 validation
+
+Issue: [Shortcuts not working](https://github.com/oipoistar/tinta/issues/195), reported by @Fromville.
+
+## Reproduction and cause
+
+Reproduced in the published v3.5.6 executable, using isolated portable settings
+with `keyProfile=windows` and an open Markdown document:
+
+1. F1 does nothing.
+2. P opens the Keyboard Shortcuts overlay, whose own hint says F1.
+3. Latin E enters Edit normally.
+
+Edit and Help were still classified by their original `:`/`?` defaults as
+character actions. Windows-profile E therefore depended on a Latin WM_CHAR.
+F1 only produced a key event, while its numeric VK value (`0x70`) was incorrectly
+case-folded as the character `p`. The same namespace collision affected custom
+function-key bindings. This is consistent with Microsoft's distinction between
+[WM_KEYDOWN virtual keys](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-keydown)
+and [WM_CHAR text](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-char).
+
+The fix stores the input kind with each binding, dispatches Edit/Help on keydown
+for letter/function-key bindings, and skips character translation when the action
+consumes the key. It does not use a time delay that could swallow subsequent typing.
+Punctuation and full-width `：`/`？` still use the character path. Vim `/` search now
+keeps the first query character instead of waiting to swallow a second opening key.
+
+## Automated checks
+
+Built with MSVC Release; all 10 CTest suites passed.
+
+- `keymap`: Windows/Vim/custom profiles, E versus Latin/Cyrillic/Greek/full-width
+  text, P/F1 aliasing, F1-F12 binding resolution, punctuation versus virtual keys,
+  F12 versus `{`, Tab/Space remaps, invalid settings and default suppression.
+- `input_shortcuts`: real application input handlers and editor with a
+  message-only window and `tests/fixtures/shortcuts-layouts.md`. Checks F1 open/close,
+  E followed by Latin/Cyrillic/Greek character sequences, a clean initial buffer,
+  immediate next input, Help over the editor, normal editor/search/filter text,
+  pinned Contents, modal capture, Vim punctuation, full-width colon, custom Help
+  on H and Edit on F2, and unsaved-changes confirmation.
+- Existing context-menu, math-parser, math-layout, Mermaid, document-type,
+  inline-style, translation and configuration suites passed.
+
+Run with `cmake --build build --config Release`, then
+`ctest --test-dir build -C Release --output-on-failure`.
+
+## Native application and rendering checks
+
+Used copies of `shortcuts-layouts.md` with portable settings, preserving the source
+fixture and the user's settings. In the fixed Windows-profile app at 1050 x 900:
+F1 opens and closes Help in both reading and editing modes; P leaves Help closed;
+E enters the editor without inserting a character or marking the file dirty.
+The heading math and table equations remain intact through these transitions.
+
+At 650 x 760 in Midnight with the Vim profile, the mixed fixture renders normally;
+`/` opens Search and the next E appears as `e` in the query.
+
+Exported `shortcuts-layouts.md` and `markdown-regression-control.md` through the
+native `--printpages` and `--exporthtml` paths. Both documents produced two PNG
+pages and one HTML file. All six artifacts match the published v3.5.6 outputs
+byte for byte. The shortcut fixture retains five equations, headings, table,
+lists, emphasis, links, quote and fenced code. Both of its native pages were
+visually inspected. Generated files are ignored under `out/issue-195/`.
+
+## Coverage limits
+
+Only English and Croatian input layouts are installed on this machine. The
+non-Latin cases exercise explicit key/character sequences through the real input
+handlers; the reporter's exact layout and IME were not tested interactively.
+F10 remains reserved for the application menu. No release was published and no
+reply was posted to the reporter.


### PR DESCRIPTION
With the Windows shortcut profile, F1 did nothing and P opened Help instead. E also depended on receiving a Latin character, so it failed when the layout produced non-Latin text. Thanks @Fromville for reporting both symptoms.

I separated virtual-key bindings from typed-character bindings and routed Edit/Help accordingly. Consumed shortcuts no longer generate text in the editor, without delaying subsequent input. This also preserves Vim punctuation, fixes the first character being dropped after `/` search, and keeps custom function keys distinct from character codes.

Validation: all 10 CTest suites pass, including the real input handlers with Latin/Cyrillic/Greek character sequences. I reproduced the F1/P bug in published v3.5.6 and verified the fix through computer use in reading/editing modes. The new mixed Markdown/math fixture and the existing control produced six PNG/HTML artifacts identical to v3.5.6. The exact reporter layout/IME remains untested interactively; only English and Croatian are installed locally. Details are in `tests/shortcuts-validation.md`.

This PR is stacked on #198 so the application menu remains in the test build. Merge #198 first, then retarget this PR to master.

Fixes #195.
