### PR TITLE
Fix extra trailing rows in fenced code blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,13 @@ if(BUILD_TESTING)
         TINTA_SHORTCUT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/shortcuts-layouts.md")
     add_test(NAME input_shortcuts COMMAND input_tests)
 
+    add_executable(code_block_layout_tests tests/code_block_layout_tests.cpp ${INPUT_TEST_SOURCES})
+    target_include_directories(code_block_layout_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(code_block_layout_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
+    target_compile_definitions(code_block_layout_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
+        TINTA_CODE_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/code-block-spacing.md")
+    add_test(NAME code_block_layout COMMAND code_block_layout_tests)
+
     add_executable(context_menu_tests tests/context_menu_tests.cpp src/context_menu.cpp
         src/markdown.cpp src/themes.cpp src/config_dir.cpp)
     target_include_directories(context_menu_tests PRIVATE include ${md4c_SOURCE_DIR}/src)

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2096,7 +2096,9 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
     float lineHeight = 20.0f * scale;
     float padding = 12.0f * scale;
 
-    int lineCount = 1;
+    // A terminal newline ends the last row; it does not start another.
+    // Count earlier blank rows normally and keep the empty-block minimum.
+    int lineCount = (code.empty() || code.back() != '\n') ? 1 : 0;
     for (char c : code) if (c == '\n') lineCount++;
 
     app.docText += L"\n";
@@ -2124,7 +2126,7 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
     size_t lineStart = 0;
     float maxLineWidth = 0.0f;
 
-    while (lineStart <= wcode.length()) {
+    while (lineStart < wcode.length()) {
         size_t lineEnd = wcode.find(L'\n', lineStart);
         if (lineEnd == std::wstring::npos) lineEnd = wcode.length();
 

--- a/tests/code-block-spacing-validation.md
+++ b/tests/code-block-spacing-validation.md
@@ -1,0 +1,60 @@
+# Issue #196 validation
+
+Reported by @hochun836 in [Rendering: fenced code blocks reserve an extra trailing line](https://github.com/oipoistar/tinta/issues/196).
+
+## Reproduction and fix
+
+Reproduced with the pre-fix build at `9932c9e`, using portable settings and
+`tests/fixtures/code-block-spacing.md`. A one-line fence had two rows' worth of
+background height. The native A4 PNG from `code-block-one-line.md` measured 64 px
+before the fix and 44 px after it: one 20 px line plus 12 px top/bottom padding.
+
+The reporter's diagnosis was correct: both the line count and the layout loop
+treated a terminal newline as another empty row. The renderer now stops after
+the actual rows. It leaves the source, copy-button text, searchable text,
+intentional blank lines, empty-block minimum height and padding unchanged.
+
+## Automated regression checks
+
+MSVC Release build and all 11 CTest suites passed. The new `code_block_layout`
+suite uses the real parser, DirectWrite formats and `layoutDocument` renderer.
+Its height assertions failed on the pre-fix renderer and pass with the fix.
+
+- Single/multiple lines with and without a terminal newline, LF and CRLF.
+- Internal blank lines, one/two intentional trailing blank lines and blank-only blocks.
+- Empty fences, closing fences at EOF, and unclosed fences at EOF.
+- Plain-text/JSON documents, highlighted C++ fences and invalid Mermaid fallback.
+- Original copy/search text retains its newlines; no text run occupies a phantom row.
+- Both themes 0 and 5, widths 1050 and 650, and content scaling 100% and 150%.
+- Nine blocks in the mixed fixture, including nested quote/list blocks, literal
+  TeX and a long line that still enables horizontal scrolling.
+- Mixed headings, tables, inline/display math, lists, emphasis and links survive.
+
+Run `cmake --build build --config Release`, then
+`ctest --test-dir build -C Release --output-on-failure`.
+
+## Visual and export checks
+
+Used computer use with isolated copies of the mixed Markdown fixture. Inspected
+the pre-fix and fixed application at 1050 x 900 with the light theme, and the fix
+at 650 x 760 in Midnight. Single-line and highlighted blocks have even padding;
+intentional blank lines, empty blocks and surrounding table/math remain visible.
+
+`tests/render_code_block_fixtures.ps1` exported the minimal fixture, mixed fixture
+and existing `markdown-regression-control.md` through native PNG print pages,
+HTML and DOCX. They produced one, three and two native pages respectively.
+
+- Inspected both minimal PNGs and all three fixed mixed-fixture pages.
+- The mixed fixture retains all nine code blocks and five equations.
+- All three HTML files match the pre-fix output byte for byte.
+- Every ZIP entry in all three DOCX files matches the pre-fix output (7, 11 and 7 entries).
+- The existing control's first native page is byte-identical. Its second page
+  changes because its code block becomes one row shorter.
+
+For an export comparison, run the script with `-Binary` and `-Output` for the
+pre-fix executable, then again with the fixed executable and `-BaselineOutput`
+pointing to the earlier output directory. Generated artifacts from this check
+are ignored under `out/issue-196/`.
+
+No physical printer or Windows 10 machine was used. Native print-page PNGs cover
+the shared print layout. No release was published and no issue reply was posted.

--- a/tests/code_block_layout_tests.cpp
+++ b/tests/code_block_layout_tests.cpp
@@ -1,0 +1,129 @@
+#include "d2d_init.h"
+#include "document.h"
+#include "render.h"
+#include "utils.h"
+
+#include <cmath>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+
+namespace {
+int failures = 0;
+void check(bool value, const std::string& message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+bool closeEnough(float a, float b) { return std::abs(a - b) < 0.05f; }
+
+void checkDocument(App& app, const qmd::ParseResult& doc, int rows,
+                   const std::wstring& source, const char* label) {
+    check(doc.success, std::string(label) + ": document parses");
+    app.root = doc.root;
+    layoutDocument(app);
+    check(app.codeBlocks.size() == 1, std::string(label) + ": one code block");
+    if (app.codeBlocks.size() != 1) return;
+    const auto& block = app.codeBlocks[0];
+    float scale = app.contentScale * app.zoomFactor;
+    float expectedHeight = (rows * 20.0f + 24.0f) * scale;
+    check(closeEnough(block.bounds.bottom - block.bounds.top, expectedHeight),
+          std::string(label) + ": actual rows plus top/bottom padding");
+    check(block.codeText == source, std::string(label) + ": copy source retains all newlines");
+    check(app.docText.find(source) != std::wstring::npos,
+          std::string(label) + ": selectable/searchable text retains all newlines");
+    for (const auto& run : app.layoutTextRuns) {
+        check(run.pos.y >= block.bounds.top + 12.0f * scale - 0.05f &&
+              run.pos.y + 20.0f * scale <= block.bounds.bottom - 12.0f * scale + 0.05f,
+              std::string(label) + ": no text layout exists in a phantom bottom row");
+    }
+}
+
+void testCases(App& app) {
+    struct Case { const char* code; int rows; };
+    for (const auto& item : {
+            Case{"single line", 1}, Case{"single line\n", 1},
+            Case{"single line\r\n", 1}, Case{"first\nsecond\n", 2},
+            Case{"first\n\nlast\n", 3}, Case{"line\n\n", 2},
+            Case{"line\n\n\n", 3}, Case{"line\r\n\r\n", 2},
+            Case{"\n", 1}, Case{"\n\n", 2}, Case{"", 1}}) {
+        for (const char* path : {"fixture.txt", "fixture.json"}) {
+            checkDocument(app, parseDocument(app.parser, item.code, std::string_view(path)),
+                          item.rows, toWide(item.code), "raw code");
+        }
+    }
+    checkDocument(app, app.parser.parse("```text\nsingle line\n```\n"),
+                  1, L"single line\n", "reporter LF fence");
+    checkDocument(app, app.parser.parse("```text\r\nsingle line\r\n```\r\n"),
+                  1, L"single line\n", "CRLF fence");
+    checkDocument(app, app.parser.parse("```cpp\nint x = 1;\n```"),
+                  1, L"int x = 1;\n", "closing fence at EOF");
+    checkDocument(app, app.parser.parse("```text\nsingle line"),
+                  1, L"single line\n", "unclosed fence at EOF");
+    checkDocument(app, app.parser.parse("```text\nline\n\n```\n"),
+                  2, L"line\n\n", "intentional trailing blank line");
+    checkDocument(app, app.parser.parse("```text\n```\n"),
+                  1, L"", "empty fence minimum height");
+    checkDocument(app, app.parser.parse("```mermaid\nnot a diagram\n```\n"),
+                  1, L"not a diagram\n", "invalid Mermaid falls back to code");
+}
+
+void testMixedFixture(App& app) {
+    std::ifstream file(TINTA_CODE_FIXTURE, std::ios::binary);
+    check(file.good(), "mixed fixture is available");
+    std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    auto doc = app.parser.parse(source);
+    check(doc.success, "mixed fixture parses");
+    std::map<qmd::ElementType, int> counts;
+    std::function<void(const qmd::ElementPtr&)> visit = [&](const qmd::ElementPtr& e) {
+        ++counts[e->type];
+        for (const auto& child : e->children) visit(child);
+    };
+    visit(doc.root);
+    for (auto type : {qmd::ElementType::Heading, qmd::ElementType::Table,
+                     qmd::ElementType::ListItem, qmd::ElementType::Strong,
+                     qmd::ElementType::Emphasis, qmd::ElementType::Link,
+                     qmd::ElementType::BlockQuote, qmd::ElementType::MathInline,
+                     qmd::ElementType::MathDisplay})
+        check(counts[type] > 0, "mixed content survives parsing");
+    app.root = doc.root;
+    layoutDocument(app);
+    const int rows[] = {1, 1, 2, 4, 1, 1, 1, 1, 1};
+    check(app.codeBlocks.size() == std::size(rows), "all nine mixed code blocks render");
+    float scale = app.contentScale * app.zoomFactor;
+    for (size_t i = 0; i < app.codeBlocks.size() && i < std::size(rows); ++i) {
+        const auto& bounds = app.codeBlocks[i].bounds;
+        check(closeEnough(bounds.bottom - bounds.top, (rows[i] * 20.0f + 24.0f) * scale),
+              "mixed code block height reflects intentional rows");
+        if (i) check(bounds.top > app.codeBlocks[i-1].bounds.bottom, "mixed code blocks never overlap");
+    }
+    check(app.docText.find(L"Final heading") != std::wstring::npos,
+          "content following the final code block renders");
+    check(app.contentWidth > app.width, "wide code still enables horizontal scrolling");
+}
+}
+
+int main() {
+    {
+        auto state = std::make_unique<App>();
+        App& app = *state;
+        if (!initD2D(app)) return 2;
+        app.height = 900;
+        app.readingWidthPct = 100;
+        for (int theme : {0, 5}) {
+            applyTheme(app, theme);
+            for (float scale : {1.0f, 1.5f}) {
+                app.contentScale = scale;
+                updateTextFormats(app);
+                for (int width : {1050, 650}) {
+                    app.width = width;
+                    testCases(app);
+                    testMixedFixture(app);
+                }
+            }
+        }
+    }
+    CoUninitialize();
+    std::cout << "Code block layout: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/tests/fixtures/code-block-one-line.md
+++ b/tests/fixtures/code-block-one-line.md
@@ -1,0 +1,3 @@
+```text
+single line
+```

--- a/tests/fixtures/code-block-spacing.md
+++ b/tests/fixtures/code-block-spacing.md
@@ -1,0 +1,86 @@
+# Code block spacing: $E = mc^2$
+
+Regression fixture for [#196](https://github.com/oipoistar/tinta/issues/196).
+A final newline should end the last code line. It should not add a blank row.
+
+## One line
+
+```text
+single line
+```
+
+This **paragraph** should follow the code block with normal spacing.
+
+## Highlighted code
+
+```cpp
+int answer = 42;
+```
+
+## Two lines
+
+```text
+first line
+second line
+```
+
+## Intentional blank lines
+
+The next block has an internal blank line and one blank line after `last line`.
+Both should remain visible.
+
+```text
+first line
+
+last line
+
+```
+
+## Empty fence
+
+```text
+```
+
+The empty block keeps its existing minimum height and copy-button area.
+
+## Mixed table and math
+
+| Item | Expression | Literal code |
+| --- | --- | --- |
+| Fraction | $\frac{1}{2}$ | `value = 0.5` |
+| Root | $\sqrt{x^2+y^2}$ | `sqrt(x*x+y*y)` |
+
+> A quote with *emphasis* and inline math $a+b=c$.
+>
+> ```text
+> quoted line
+> ```
+
+- A list item before a nested block:
+
+  ```python
+  print("one line")
+  ```
+
+- Another item follows the nested block.
+
+$$
+\begin{bmatrix}1 & 2 \\ 3 & 4\end{bmatrix}
+\begin{pmatrix}x \\ y\end{pmatrix}
+= \begin{pmatrix}x+2y \\ 3x+4y\end{pmatrix}
+$$
+
+## Literal TeX and a wide line
+
+```latex
+\frac{1}{2} + \sqrt{x} % This stays literal code.
+```
+
+```text
+wide line: 0123456789 abcdefghijklmnopqrstuvwxyz 0123456789 abcdefghijklmnopqrstuvwxyz 0123456789 abcdefghijklmnopqrstuvwxyz 0123456789 abcdefghijklmnopqrstuvwxyz 0123456789 abcdefghijklmnopqrstuvwxyz
+```
+
+## Final heading
+
+The [existing Markdown control](markdown-regression-control.md), table, math,
+copyable source text and content after each block should remain intact.

--- a/tests/render_code_block_fixtures.ps1
+++ b/tests/render_code_block_fixtures.ps1
@@ -1,0 +1,59 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/code-block-spacing',
+    [string]$BaselineOutput = ''
+)
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskOutput = [IO.Path]::GetFullPath((Join-Path $repo $Output))
+New-Item -ItemType Directory -Force "$taskOutput/runner" | Out-Null
+$taskExe = Join-Path $taskOutput 'runner/tinta.exe'
+Copy-Item -LiteralPath (Join-Path $repo $Binary) -Destination $taskExe -Force
+@'
+[Settings]
+themeIndex=0
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+'@ | Set-Content -LiteralPath "$taskOutput/runner/settings.ini"
+
+foreach ($name in @('code-block-one-line', 'code-block-spacing', 'markdown-regression-control')) {
+    $source = Join-Path $PSScriptRoot "fixtures/$name.md"
+    $destination = Join-Path $taskOutput $name
+    New-Item -ItemType Directory -Force $destination | Out-Null
+    foreach ($mode in @('printpages', 'exporthtml', 'exportdocx')) {
+        $target = switch ($mode) {
+            'printpages' { "$destination/pages" }
+            'exporthtml' { "$destination/document.html" }
+            'exportdocx' { "$destination/document.docx" }
+        }
+        $process = Start-Process -FilePath $taskExe -ArgumentList @('"' + $source + '"', "--$mode", '"' + $target + '"') -WindowStyle Hidden -PassThru
+        if (!$process.WaitForExit(30000)) {
+            Stop-Process -Id $process.Id -Force
+            $process.WaitForExit()
+            throw "$name $mode timed out"
+        }
+        if ($process.ExitCode -ne 0) { throw "$name $mode failed: $($process.ExitCode)" }
+    }
+    $html = Get-Content -LiteralPath "$destination/document.html" -Raw -Encoding UTF8
+    $codeCount = [regex]::Matches($html, '<pre><code').Count
+    $expectedCode = @{ 'code-block-one-line'=1; 'code-block-spacing'=9; 'markdown-regression-control'=1 }
+    if ($codeCount -ne $expectedCode[$name]) { throw "$name lost code blocks" }
+    if ($name -eq 'code-block-spacing') {
+        $equations = [regex]::Matches($html, 'class="math-(inline|display)"').Count
+        if ($equations -ne 5 -or $html -notmatch '<table>' -or $html -notmatch '<h1') {
+            throw "$name lost surrounding headings, table or math"
+        }
+    }
+    $pages = @(Get-ChildItem -LiteralPath "$destination/pages" -Filter 'page-*.png')
+    if (!$pages.Count) { throw "$name produced no native pages" }
+    if ($BaselineOutput) {
+        $baselineHtml = Join-Path $repo "$BaselineOutput/$name/document.html"
+        if ((Get-FileHash -LiteralPath $baselineHtml).Hash -ne (Get-FileHash -LiteralPath "$destination/document.html").Hash) {
+            throw "$name HTML changed; the fix should affect only native layout"
+        }
+    }
+    "$name : $($pages.Count) native pages, $codeCount code blocks, HTML and DOCX exported"
+}


### PR DESCRIPTION
A fenced block containing one line rendered with an extra blank row beneath it. I corrected the row count and layout-loop boundary so a terminal newline ends the last row without starting another. Intentional blank lines, empty-block sizing, padding and copy/search source text remain intact. Thanks @hochun836 for the clear reproduction and source-level diagnosis.

Validation: all 11 CTest suites pass. The new tests exercise the real parser and renderer with LF/CRLF, EOF fences, intentional blank lines, highlighted/plain code, mixed Markdown/math, two widths, two themes and 100%/150% scaling. Computer use confirmed the fix at normal and narrow widths. The minimal native PNG block shrank from 64 px to 44 px, while all HTML files and every DOCX ZIP entry remained unchanged. Details and a reusable export script are included under `tests/`.

This PR is stacked on #199, which is stacked on #198. Merge those first, then retarget this PR to master.

Fixes #196.
