### PR TITLE
Add independent inline code theme color

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,16 @@ if(BUILD_TESTING)
         TINTA_CODE_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/code-block-spacing.md")
     add_test(NAME code_block_layout COMMAND code_block_layout_tests)
 
+    add_executable(theme_tests tests/theme_tests.cpp ${INPUT_TEST_SOURCES})
+    target_include_directories(theme_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(theme_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
+    target_compile_definitions(theme_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
+        TINTA_THEME_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/inline-code-color.md")
+    add_test(NAME inline_code_theme COMMAND ${CMAKE_COMMAND}
+        -DTEST_BINARY=$<TARGET_FILE:theme_tests>
+        -DTEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/theme-test-$<CONFIG>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_portable_test.cmake)
+
     add_executable(context_menu_tests tests/context_menu_tests.cpp src/context_menu.cpp
         src/markdown.cpp src/themes.cpp src/config_dir.cpp)
     target_include_directories(context_menu_tests PRIVATE include ${md4c_SOURCE_DIR}/src)

--- a/README.md
+++ b/README.md
@@ -260,6 +260,20 @@ Press `T` to open the theme chooser:
 - Ember - Warm charcoal
 - Abyss - Pure black (OLED-friendly)
 
+Custom themes live in `themes.ini` beside the portable executable, or in
+`%APPDATA%\Tinta`. Add `inlinecode` to a `[theme]` section to color inline code
+independently of fenced blocks:
+
+```ini
+code=334455
+inlinecode=B00020
+```
+
+Here inline code is red and plain fenced code stays neutral. Syntax highlighting
+keeps its own colors. Without `inlinecode`, inline code uses `code` as before.
+The override is preserved when saving a theme from the editor and applies to
+HTML and DOCX exports. Native printing keeps Tinta's existing light print palette.
+
 ## Dependencies
 
 - [MD4C](https://github.com/mity/md4c) - Fast markdown parser (fetched automatically by CMake)

--- a/include/app.h
+++ b/include/app.h
@@ -17,6 +17,7 @@
 #include <unordered_map>
 #include <chrono>
 #include <utility>
+#include <optional>
 
 #include "markdown.h"
 #include "keymap.h"
@@ -101,7 +102,13 @@ struct D2DTheme {
     D2D1_COLOR_F syntaxFunction;
     D2D1_COLOR_F syntaxType;
     D2D1_COLOR_F syntaxControlFlow;
+    // Optional themes.ini override. Missing means inherit code (#197).
+    std::optional<D2D1_COLOR_F> inlineCode = std::nullopt;
 };
+
+inline D2D1_COLOR_F themeInlineCodeColor(const D2DTheme& theme) {
+    return theme.inlineCode.value_or(theme.code);
+}
 
 // Helper to create color from hex
 inline D2D1_COLOR_F hexColor(uint32_t hex, float alpha = 1.0f) {

--- a/src/export_docx.cpp
+++ b/src/export_docx.cpp
@@ -578,6 +578,7 @@ struct RunProps {
     bool strike = false;
     bool highlight = false;
     bool code = false;
+    bool isLink = false;
     bool superScript = false;
     bool subScript = false;
     std::string color;  // hex override (links, wiki links)
@@ -597,6 +598,7 @@ struct DocxCtx {
     // Theme palette, guarded so dark themes stay readable on paper
     std::string textHex, headingHex, mutedHex, codeBgHex, borderHex;
     std::string accentHex, linkHex, quoteBorderHex;
+    std::string inlineCodeHex;  // explicit override; legacy paper colors otherwise
     std::string bodyFont, monoFont;
 };
 
@@ -638,7 +640,9 @@ std::string runPropsXml(const DocxCtx& ctx, const RunProps& props) {
     if (props.highlight) xml += "<w:highlight w:val=\"yellow\"/>";
     if (props.superScript) xml += "<w:vertAlign w:val=\"superscript\"/>";
     if (props.subScript) xml += "<w:vertAlign w:val=\"subscript\"/>";
-    if (!props.color.empty()) {
+    if (props.code && !props.isLink && !ctx.inlineCodeHex.empty()) {
+        xml += "<w:color w:val=\"" + ctx.inlineCodeHex + "\"/>";
+    } else if (!props.color.empty()) {
         xml += "<w:color w:val=\"" + props.color + "\"/>";
     }
     if (props.underline) xml += "<w:u w:val=\"single\"/>";
@@ -797,6 +801,7 @@ void walkInline(DocxCtx& ctx, const ElementPtr& elem, RunProps props,
                 }
             } else if (wiki) {
                 RunProps wikiProps = props;
+                wikiProps.isLink = true;
                 wikiProps.color = ctx.linkHex;
                 for (const auto& child : elem->children) {
                     walkInline(ctx, child, wikiProps, out);
@@ -804,6 +809,7 @@ void walkInline(DocxCtx& ctx, const ElementPtr& elem, RunProps props,
             } else {
                 int rel = addLinkRel(ctx, elem->url);
                 RunProps linkProps = props;
+                linkProps.isLink = true;
                 linkProps.color = ctx.linkHex;
                 linkProps.underline = true;
                 out += "<w:hyperlink r:id=\"rId" + std::to_string(rel) +
@@ -1322,6 +1328,7 @@ bool exportDocxFile(App& app, const std::wstring& path) {
     muted.a = 0.65f;
     ctx.mutedHex = dark ? "555555" : hexOver(muted, theme.background);
     ctx.codeBgHex = dark ? "F2F0EE" : hex6(theme.codeBackground);
+    if (theme.inlineCode) ctx.inlineCodeHex = hex6(*theme.inlineCode);
     D2D1_COLOR_F border = theme.text;
     border.a = 0.25f;
     ctx.borderHex = dark ? "C8C8C8" : hexOver(border, theme.background);

--- a/src/export_html.cpp
+++ b/src/export_html.cpp
@@ -1330,11 +1330,15 @@ std::string themeCss(const App& app, const std::string& bodyFont,
     css += ".wikilink{color:" + colorCss(t.link) +
            ";border-bottom:1px dashed " + colorCss(t.link) + ";}";
     css += "code{font-family:" + monoFont + ";background:" +
-           colorCss(t.codeBackground) + ";color:" + colorCss(t.code) +
+           colorCss(t.codeBackground) + ";color:" + colorCss(themeInlineCodeColor(t)) +
            ";padding:2px 6px;border-radius:4px;font-size:0.9em;}";
     css += "pre{background:" + colorCss(t.codeBackground) +
            ";padding:14px 16px;border-radius:8px;overflow-x:auto;}";
     css += "pre code{background:none;padding:0;}";
+    if (t.inlineCode) {
+        css += "pre code{color:" + colorCss(t.code) + ";}";
+        css += "a code{color:inherit;}";
+    }
     css += "blockquote{border-left:4px solid " +
            colorCss(t.blockquoteBorder) +
            ";margin:1em 0;padding:2px 18px;color:" + colorCss(mutedText) +

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1844,7 +1844,7 @@ void renderThemeChooser(App& app) {
                 app.brush);
             if (codeFormat) {
                 codeFormat->SetTextAlignment(DWRITE_TEXT_ALIGNMENT_CENTER);
-                D2D1_COLOR_F codeColor = t.code;
+                D2D1_COLOR_F codeColor = themeInlineCodeColor(t);
                 codeColor.a = anim;
                 app.brush->SetColor(codeColor);
                 app.renderTarget->DrawText(L"code()", 6, codeFormat,
@@ -3967,7 +3967,7 @@ void renderThemeEditor(App& app) {
             app.brush->SetColor(work.codeBackground);
             app.renderTarget->FillRoundedRectangle(
                 D2D1::RoundedRect(pill, dpi(app, 4.0f), dpi(app, 4.0f)), app.brush);
-            app.brush->SetColor(work.code);
+            app.brush->SetColor(themeInlineCodeColor(work));
             app.renderTarget->DrawText(L"inline_code()", 13, m,
                 D2D1::RectF(pill.left + dpi(app, 8.0f), pill.top + dpi(app, 2.0f),
                             pill.right, pill.bottom), app.brush);

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -491,7 +491,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
 
             case ElementType::Code: {
                 format = inlineCodeFormat(app, run.style.bold, run.style.italic);
-                if (!isLink) color = app.theme.code;
+                if (!isLink) color = themeInlineCodeColor(app.theme);
                 for (const auto& child : elem->children) {
                     if (child->type == ElementType::Text) {
                         text += toWide(child->text);
@@ -537,7 +537,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                 if (!box) {
                     // Unsupported TeX: show the raw source in code style
                     format = inlineCodeFormat(app, run.style.bold, run.style.italic);
-                    if (!isLink) color = app.theme.code;
+                    if (!isLink) color = themeInlineCodeColor(app.theme);
                     text = L"$" + latex + L"$";
                     break;
                 }

--- a/src/themes.cpp
+++ b/src/themes.cpp
@@ -319,6 +319,10 @@ void applyThemeKey(CustomTheme& ct, const std::string& key, const std::string& v
     else if (key == "heading") parseHexColor(value, t.heading);
     else if (key == "link") parseHexColor(value, t.link);
     else if (key == "code") parseHexColor(value, t.code);
+    else if (key == "inlinecode") {
+        D2D1_COLOR_F color;
+        if (parseHexColor(value, color)) t.inlineCode = color;
+    }
     else if (key == "codebackground") parseHexColor(value, t.codeBackground);
     else if (key == "blockquoteborder") parseHexColor(value, t.blockquoteBorder);
     else if (key == "accent") parseHexColor(value, t.accent);
@@ -338,6 +342,7 @@ void writeThemesIni() {
     if (!file) return;
     file << "; User themes. Colors are RRGGBB hex. Restart not required for\n";
     file << "; themes saved from the editor; hand edits load at next launch.\n";
+    file << "; Optional inlinecode overrides code for inline spans only.\n";
     for (const auto& ct : g_customThemes) {
         const D2DTheme& t = ct->theme;
         file << "\n[theme]\n";
@@ -354,6 +359,7 @@ void writeThemesIni() {
         file << "heading=" << colorToHex(t.heading) << "\n";
         file << "link=" << colorToHex(t.link) << "\n";
         file << "code=" << colorToHex(t.code) << "\n";
+        if (t.inlineCode) file << "inlinecode=" << colorToHex(*t.inlineCode) << "\n";
         file << "codebackground=" << colorToHex(t.codeBackground) << "\n";
         file << "blockquoteborder=" << colorToHex(t.blockquoteBorder) << "\n";
         file << "accent=" << colorToHex(t.accent) << "\n";

--- a/tests/fixtures/inline-code-color.md
+++ b/tests/fixtures/inline-code-color.md
@@ -1,0 +1,47 @@
+# Inline-code color: `inline_heading` and $E = mc^2$
+
+Theme regression for [#197](https://github.com/oipoistar/tinta/issues/197).
+Use the accompanying `inline-code-themes.ini` in an isolated portable test folder.
+
+Inline `inline_plain` should use the inline-code color. The fenced text below
+should keep the base code color. **Bold `inline_bold`** and *italic `inline_italic`*
+keep their formatting. A [`linked_code`](https://example.com) span keeps the link color.
+
+```text
+block_plain
+```
+
+```cpp
+int identifier = 42; // highlighted code retains its syntax colors
+```
+
+## Table with inline code and math
+
+| Style | Inline code | Math |
+| --- | --- | --- |
+| Neutral body text | `inline_table` | $\frac{1}{2}$ |
+| **Emphasis** | `inline_table_second` | $\sqrt{x^2+y^2}$ |
+
+> A quote with `inline_quote`, **bold text** and $a+b=c$.
+
+- A list item containing `inline_list`.
+- Another item with a [normal link](https://example.com).
+
+$$
+\begin{bmatrix}1 & 2 \\ 3 & 4\end{bmatrix}
+\begin{pmatrix}x \\ y\end{pmatrix}
+= \begin{pmatrix}x+2y \\ 3x+4y\end{pmatrix}
+$$
+
+## Literal code and inheritance
+
+```latex
+\frac{1}{2} + \sqrt{x} % Fenced TeX stays literal and uses the block palette.
+```
+
+With the legacy theme, inline spans and plain fenced text share `code` as before.
+With the separate-color themes, only inline spans change. Reopen the theme editor,
+save the theme, restart Tinta and verify that the separate color persists.
+
+The [existing mixed Markdown control](markdown-regression-control.md) should
+retain its layout and formatting with themes that omit the new key.

--- a/tests/fixtures/inline-code-themes.ini
+++ b/tests/fixtures/inline-code-themes.ini
@@ -1,0 +1,25 @@
+; Copy to themes.ini beside a portable test executable with settings.ini.
+; Select one of these appended custom themes in the theme chooser.
+
+[theme]
+name=Inline Code Legacy
+dark=0
+code=334455
+
+[theme]
+name=Inline Code Separate
+dark=0
+code=334455
+inlinecode=B00020
+
+[theme]
+name=Inline Code Dark
+dark=1
+background=15202B
+text=E6EDF3
+heading=F0F4F8
+link=72B7F2
+accent=72B7F2
+code=D1D9E0
+codebackground=223344
+inlinecode=FF8095

--- a/tests/inline-code-color-validation.md
+++ b/tests/inline-code-color-validation.md
@@ -1,0 +1,70 @@
+# Issue #197 validation
+
+Reported by @hochun836 in [Themes: separate inline-code text color from fenced code block text color](https://github.com/oipoistar/tinta/issues/197).
+
+## Behavior
+
+Reproduced on the pre-fix build at `fff531c`: inline spans and plain fenced code
+both use `code=334455`, even with `inlinecode=B00020` in the custom theme.
+The fixed build applies the optional override only to inline code. Missing or
+invalid overrides inherit `code`; fenced base text, plain/operator tokens and
+the existing syntax palette remain independent. Linked code retains link color.
+
+The theme chooser and editor specimens display the override. Saving a theme
+preserves it, while legacy themes keep an absent key. The advanced setting is
+edited in `themes.ini`, alongside the existing `code` setting.
+
+## Automated checks
+
+MSVC Release build and all 12 CTest suites passed. The new `inline_code_theme`
+suite runs a staged executable with isolated portable settings, so it does not
+touch the user's configuration. It exercises the actual theme loader/writer,
+Markdown parser, DirectWrite layout and HTML/DOCX exporters.
+
+- All built-in themes and legacy custom themes retain their fallback.
+- Explicit colors, optional `#`, lowercase hex, reversed key order and invalid
+  values are handled correctly. Inheritance follows subsequent `code` changes.
+- Save/reload preserves the override without adding it to legacy themes.
+- The mixed fixture renders eight inline contexts: headings, paragraphs, bold,
+  italic, table cells, quotes and lists. Linked code keeps its link color.
+- Plain fenced text and syntax plain/operator tokens keep the base code color.
+- Legacy, separate light and separate dark themes pass at widths 1050 and 650.
+- Changing only the inline color preserves every text position, run count and
+  total document height, including surrounding tables and LaTeX equations.
+- HTML separates inline, fenced and linked code colors; DOCX preserves explicit
+  inline colors in mixed content without recoloring fenced blocks or links.
+
+Run `cmake --build build --config Release`, then
+`ctest --test-dir build -C Release --output-on-failure`.
+
+## Computer-use and export checks
+
+Used isolated portable copies of `tests/fixtures/inline-code-color.md` and
+`inline-code-themes.ini`. Inspected the baseline and fixed app at 1050 x 900 in
+the separate light theme, and the fixed app at 650 x 760 in the separate dark
+theme. Inline spans use red/pink, plain blocks stay neutral, and mixed headings,
+tables, math, quotes and lists remain intact. Inspected the theme chooser and
+editor specimens, saved the active custom theme through the UI, and verified
+that `inlinecode=B00020` survived in the written file.
+
+`tests/render_inline_code_fixtures.ps1` exported the mixed fixture in built-in,
+legacy, separate light and separate dark themes, plus the existing
+`markdown-regression-control.md` in the built-in theme. Each document produced
+two native PNG print pages, HTML and DOCX, for both baseline and fixed builds.
+
+- All 10 native print PNGs are byte-identical to the baseline. Native printing
+  intentionally retains its existing light print palette.
+- All three built-in/legacy HTML files are byte-identical to the baseline.
+- Every ZIP entry in the three built-in/legacy DOCX files is unchanged (11, 7
+  and 11 entries).
+- Separate light/dark HTML differs only in inline color and the corresponding
+  fenced/link CSS rules. Each DOCX differs only in ten inline run colors inside
+  `word/document.xml`; all other entries and run content are unchanged.
+
+For comparison, run the script with `-Binary` and `-Output` for the pre-fix
+executable and again with the fixed executable and a different output directory.
+Generated artifacts and the comparison script from this check are ignored under
+`out/issue-197/`.
+
+DOCX was verified structurally, not opened in Word. No physical printer or
+separate Windows 10 machine was used. No release or issue reply was published.

--- a/tests/render_inline_code_fixtures.ps1
+++ b/tests/render_inline_code_fixtures.ps1
@@ -1,0 +1,56 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/inline-code-colors'
+)
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskOutput = Join-Path $repo $Output
+$taskBinary = if ([IO.Path]::IsPathRooted($Binary)) { $Binary } else { Join-Path $repo $Binary }
+foreach ($variant in @(@('builtin',0), @('legacy',10), @('separate',11), @('dark',12))) {
+    $variantDir = Join-Path $taskOutput $variant[0]
+    New-Item -ItemType Directory -Force "$variantDir/runner" | Out-Null
+    $exe = Join-Path $variantDir 'runner/tinta.exe'
+    Copy-Item -LiteralPath $taskBinary -Destination $exe -Force
+    Copy-Item -LiteralPath "$PSScriptRoot/fixtures/inline-code-themes.ini" -Destination "$variantDir/runner/themes.ini" -Force
+    @"
+[Settings]
+themeIndex=$($variant[1])
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+"@ | Set-Content -LiteralPath "$variantDir/runner/settings.ini"
+    $fixtures = @('inline-code-color')
+    if ($variant[0] -eq 'builtin') { $fixtures += 'markdown-regression-control' }
+    foreach ($name in $fixtures) {
+        $source = Join-Path $PSScriptRoot "fixtures/$name.md"
+        $destination = Join-Path $variantDir $name
+        New-Item -ItemType Directory -Force $destination | Out-Null
+        foreach ($mode in @('printpages','exporthtml','exportdocx')) {
+            $target = switch ($mode) {
+                'printpages' { "$destination/pages" }
+                'exporthtml' { "$destination/document.html" }
+                'exportdocx' { "$destination/document.docx" }
+            }
+            $process = Start-Process -FilePath $exe -ArgumentList @('"' + $source + '"', "--$mode", '"' + $target + '"') -WindowStyle Hidden -PassThru
+            if (!$process.WaitForExit(30000)) {
+                Stop-Process -Id $process.Id -Force
+                $process.WaitForExit()
+                throw "$name $mode timed out"
+            }
+            if ($process.ExitCode -ne 0 -or !(Test-Path -LiteralPath $target)) {
+                throw "$name $mode failed"
+            }
+        }
+        $html = Get-Content -LiteralPath "$destination/document.html" -Raw -Encoding UTF8
+        $equations = [regex]::Matches($html, 'class="math-(inline|display)"').Count
+        $expectedMath = if ($name -eq 'inline-code-color') { 5 } else { 0 }
+        $expectedBlocks = if ($name -eq 'inline-code-color') { 3 } else { 1 }
+        if ($equations -ne $expectedMath -or [regex]::Matches($html,'<pre><code').Count -ne $expectedBlocks -or
+            $html -notmatch '<table>' -or $html -notmatch '<h1') { throw "$name lost mixed content" }
+        $pages = @(Get-ChildItem -LiteralPath "$destination/pages" -Filter 'page-*.png')
+        if (!$pages.Count) { throw "$name produced no print pages" }
+        "$($variant[0]) / $name : $($pages.Count) native pages, HTML and DOCX exported"
+    }
+}

--- a/tests/run_portable_test.cmake
+++ b/tests/run_portable_test.cmake
@@ -1,0 +1,11 @@
+if(NOT DEFINED TEST_BINARY OR NOT DEFINED TEST_DIR)
+    message(FATAL_ERROR "TEST_BINARY and TEST_DIR are required")
+endif()
+file(MAKE_DIRECTORY "${TEST_DIR}")
+configure_file("${TEST_BINARY}" "${TEST_DIR}/theme_tests.exe" COPYONLY)
+file(WRITE "${TEST_DIR}/settings.ini" "; Isolated native theme test configuration\n")
+execute_process(COMMAND "${TEST_DIR}/theme_tests.exe" --portable-test
+    WORKING_DIRECTORY "${TEST_DIR}" RESULT_VARIABLE result)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Native theme test failed: ${result}")
+endif()

--- a/tests/theme_tests.cpp
+++ b/tests/theme_tests.cpp
@@ -1,0 +1,164 @@
+#include "d2d_init.h"
+#include "export.h"
+#include "render.h"
+#include "settings.h"
+#include "syntax.h"
+#include "utils.h"
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+std::string read(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary);
+    return {(std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>()};
+}
+bool sameColor(D2D1_COLOR_F a, D2D1_COLOR_F b) {
+    return std::abs(a.r-b.r) < 0.001f && std::abs(a.g-b.g) < 0.001f &&
+           std::abs(a.b-b.b) < 0.001f && std::abs(a.a-b.a) < 0.001f;
+}
+void checkRun(const App& app, const wchar_t* marker, D2D1_COLOR_F color) {
+    bool found = false;
+    for (const auto& run : app.layoutTextRuns) {
+        if (run.docLength && app.docText.substr(run.docStart, run.docLength) == marker) {
+            found = true;
+            check(sameColor(run.color, color), "native text run uses the right inline/block/link color");
+        }
+    }
+    if (!found) std::wcerr << L"Missing native marker: " << marker << L'\n';
+    check(found, "native fixture marker renders");
+}
+std::string docxRun(const std::string& zip, const std::string& marker) {
+    // Tinta writes stored ZIP entries, so the actual XML can be inspected
+    // here without introducing a ZIP dependency into the native tests.
+    size_t text = zip.find(">" + marker + "</w:t>");
+    if (text == std::string::npos) return {};
+    size_t start = zip.rfind("<w:r>", text);
+    return start == std::string::npos ? std::string() : zip.substr(start, text-start);
+}
+}
+
+int main(int argc, char** argv) {
+    namespace fs = std::filesystem;
+    // CTest stages this executable in an isolated portable folder. Refuse
+    // to touch any real configuration if the binary is launched directly.
+    wchar_t exe[MAX_PATH]{};
+    GetModuleFileNameW(nullptr, exe, MAX_PATH);
+    const auto dir = fs::path(exe).parent_path();
+    const auto settings = read(dir / "settings.ini");
+    if (argc != 2 || std::string(argv[1]) != "--portable-test" ||
+        !fs::equivalent(dir, fs::current_path()) ||
+        (settings != "; Isolated native theme test configuration\n" &&
+         settings != "; Isolated native theme test configuration\r\n")) {
+        std::cerr << "Run this test through CTest's isolated portable wrapper\n";
+        return 2;
+    }
+    const auto fixture = fs::path(TINTA_THEME_FIXTURE);
+    {
+        std::ofstream out(dir / "themes.ini", std::ios::binary);
+        out << read(fixture.parent_path() / "inline-code-themes.ini");
+        out << "\n[theme]\nname=Reverse order\ninlinecode=#b00020\ncode=334455\n"
+               "\n[theme]\nname=Invalid override\ninlinecode=broken\ncode=334455\n";
+    }
+    check(fs::equivalent(tintaConfigDir(), dir), "theme persistence uses only the portable test folder");
+    loadCustomThemes();
+    check(themeCount() == THEME_COUNT + 5, "all custom theme sections load");
+    for (int i = 0; i < THEME_COUNT; ++i) {
+        check(!themeAt(i).inlineCode, "built-in themes retain inheritance");
+        check(sameColor(themeInlineCodeColor(themeAt(i)), themeAt(i).code),
+              "built-in inline color remains exactly the existing code color");
+    }
+    check(!themeAt(THEME_COUNT).inlineCode, "legacy custom theme inherits code");
+    check(sameColor(themeInlineCodeColor(themeAt(THEME_COUNT)), hexColor(0x334455)),
+          "legacy custom code value is the fallback");
+    check(sameColor(themeInlineCodeColor(themeAt(THEME_COUNT+1)), hexColor(0xB00020)),
+          "explicit inlinecode loads");
+    check(sameColor(themeInlineCodeColor(themeAt(THEME_COUNT+3)), hexColor(0xB00020)),
+          "inlinecode before code and optional hash/lowercase load correctly");
+    check(!themeAt(THEME_COUNT+4).inlineCode, "invalid optional color retains inheritance");
+    D2DTheme inherited = themeAt(THEME_COUNT);
+    inherited.code = hexColor(0x123456);
+    check(sameColor(themeInlineCodeColor(inherited), inherited.code), "fallback follows changes to code");
+    D2DTheme explicitTheme = themeAt(THEME_COUNT+1);
+    explicitTheme.code = hexColor(0x123456);
+    check(sameColor(themeInlineCodeColor(explicitTheme), hexColor(0xB00020)),
+          "explicit inline color remains independent when code changes");
+
+    // The theme editor saves a full D2DTheme copy through this same writer.
+    auto original = themeAt(THEME_COUNT+1);
+    int saved = saveCustomTheme(original, L"Saved from editor", original.fontFamily, original.codeFontFamily);
+    check(saved >= THEME_COUNT, "custom theme saves");
+    std::string ini = read(dir / "themes.ini");
+    size_t legacy = ini.find("name=Inline Code Legacy");
+    size_t next = ini.find("[theme]", legacy);
+    check(ini.substr(legacy, next-legacy).find("inlinecode=") == std::string::npos,
+          "saving does not materialize an inherited color in legacy themes");
+    loadCustomThemes();
+    check(themeAt(saved).inlineCode &&
+          sameColor(themeInlineCodeColor(themeAt(saved)), hexColor(0xB00020)),
+          "saved explicit color survives restart/reload");
+
+    {
+        auto state = std::make_unique<App>();
+        App& app = *state;
+        if (!initD2D(app)) return 2;
+        app.height = 900;
+        app.readingWidthPct = 100;
+        auto doc = app.parser.parse(read(fixture));
+        check(doc.success, "mixed Markdown/theme fixture parses");
+        app.root = doc.root;
+        for (int index : {THEME_COUNT, THEME_COUNT+1, THEME_COUNT+2}) {
+            applyTheme(app, index);
+            for (int width : {1050, 650}) {
+                app.width = width;
+                layoutDocument(app);
+                for (const wchar_t* marker : {L"inline_heading", L"inline_plain", L"inline_bold",
+                        L"inline_italic", L"inline_table", L"inline_table_second", L"inline_quote", L"inline_list"})
+                    checkRun(app, marker, themeInlineCodeColor(app.theme));
+                checkRun(app, L"block_plain", app.theme.code);
+                checkRun(app, L"linked_code", app.theme.link);
+                check(sameColor(getTokenColor(app.theme, SyntaxTokenType::Plain), app.theme.code) &&
+                      sameColor(getTokenColor(app.theme, SyntaxTokenType::Operator), app.theme.code),
+                      "syntax plain/operator tokens retain the fenced-code base color");
+                check(app.codeBlocks.size() == 3, "all mixed fenced blocks remain intact");
+                auto before = app.layoutTextRuns;
+                float height = app.contentHeight;
+                app.theme.inlineCode = hexColor(0x00BB88);
+                layoutDocument(app);
+                check(app.layoutTextRuns.size() == before.size() && app.contentHeight == height,
+                      "changing only inline color leaves document geometry unchanged");
+                for (size_t i = 0; i < before.size() && i < app.layoutTextRuns.size(); ++i)
+                    check(before[i].pos.x == app.layoutTextRuns[i].pos.x && before[i].pos.y == app.layoutTextRuns[i].pos.y,
+                          "headings, tables, math and surrounding text keep their positions");
+                app.theme = themeAt(index);
+            }
+        }
+        applyTheme(app, THEME_COUNT+1);
+        check(exportHtmlFile(app, (dir / "separate.html").wstring()), "HTML export succeeds");
+        std::string html = read(dir / "separate.html");
+        check(html.find(";color:#b00020;") != std::string::npos &&
+              html.find("pre code{color:#334455;}") != std::string::npos &&
+              html.find("a code{color:inherit;}") != std::string::npos,
+              "HTML separates inline, fenced and linked code colors");
+        check(exportDocxFile(app, (dir / "separate.docx").wstring()), "DOCX export succeeds");
+        std::string zip = read(dir / "separate.docx");
+        for (const char* marker : {"inline_plain", "inline_heading", "inline_quote", "inline_table"})
+            check(docxRun(zip, marker).find("<w:color w:val=\"B00020\"/>") != std::string::npos,
+                  "DOCX inline spans preserve the explicit color in mixed content");
+        check(!docxRun(zip, "block_plain").empty() &&
+              docxRun(zip, "block_plain").find("B00020") == std::string::npos,
+              "DOCX fenced code does not acquire the inline color");
+        check(docxRun(zip, "linked_code").find("<w:color w:val=\"B85A3C\"/>") != std::string::npos,
+              "DOCX linked code preserves the link color");
+    }
+    CoUninitialize();
+    std::cout << "Inline code themes: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Custom themes currently use `code` for both inline spans and fenced base text. I added optional `inlinecode`, with `code` as the fallback, so a theme can use red inline spans while keeping fenced text neutral. Thanks @hochun836 for the report and compatibility suggestion.

The override survives theme saves and appears in the viewer, chooser/editor previews, HTML and DOCX. Fenced base and syntax colors stay unchanged; linked code keeps its link color. Existing themes retain their outputs, and native printing keeps its existing light palette. The README documents the INI setting.

Validation: MSVC Release build and all 12 CTest suites pass. A mixed Markdown fixture covers headings, tables, emphasis, links, quotes, lists and LaTeX. Native computer-use checks cover normal/light and narrow/dark views plus editor preview/save. All 10 print-page PNGs and all built-in/legacy HTML and DOCX contents match the baseline. Explicit-color exports differ only in the intended inline color properties. Details: `tests/inline-code-color-validation.md`.

Fixes #197.

Stacked on #200 (`issue-196-code-block-spacing`), which contains the earlier #194/#195 work. This PR's diff covers #197 only. No issue reply or release has been published.
