### PR TITLE
Keep trailing block spacing outside quote bars

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,13 @@ if(BUILD_TESTING)
         TINTA_CODE_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/code-block-spacing.md")
     add_test(NAME code_block_layout COMMAND code_block_layout_tests)
 
+    add_executable(blockquote_layout_tests tests/blockquote_layout_tests.cpp ${INPUT_TEST_SOURCES})
+    target_include_directories(blockquote_layout_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(blockquote_layout_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
+    target_compile_definitions(blockquote_layout_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
+        TINTA_QUOTE_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/blockquote-spacing.md")
+    add_test(NAME blockquote_layout COMMAND blockquote_layout_tests)
+
     add_executable(theme_tests tests/theme_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(theme_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
     target_link_libraries(theme_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2225,6 +2225,7 @@ static void layoutBlockquote(App& app, const ElementPtr& elem, float& y, float i
     float scale = app.contentScale * app.zoomFactor;
     float quoteIndent = 20.0f * scale;
     float startY = y;
+    const LayoutSnapshot contentStart = takeSnapshot(app);
 
     // GitHub alert callouts: accent-colored bar plus a bold title line.
     // Colors are github.com's light/dark alert accents, picked by theme.
@@ -2262,7 +2263,28 @@ static void layoutBlockquote(App& app, const ElementPtr& elem, float& y, float i
         layoutElement(app, child, y, indent + quoteIndent, maxWidth - quoteIndent);
     }
 
-    app.layoutRects.push_back({D2D1::RectF(indent, startY, indent + 4, y), barColor});
+    // Child layout advances y past its trailing margin. Keep that spacing
+    // outside the bar, without moving the next block. Use retained content
+    // bounds so nested quotes, code padding, tables and math stay covered.
+    float contentBottom = startY;
+    for (size_t i = contentStart.textRuns; i < app.layoutTextRuns.size(); ++i)
+        contentBottom = std::max(contentBottom, app.layoutTextRuns[i].bounds.bottom);
+    for (size_t i = contentStart.textRects; i < app.textRects.size(); ++i)
+        contentBottom = std::max(contentBottom, app.textRects[i].rect.bottom);
+    for (size_t i = contentStart.rects; i < app.layoutRects.size(); ++i)
+        contentBottom = std::max(contentBottom, app.layoutRects[i].rect.bottom);
+    for (size_t i = contentStart.lines; i < app.layoutLines.size(); ++i) {
+        const auto& line = app.layoutLines[i];
+        contentBottom = std::max(contentBottom, std::max(line.p1.y, line.p2.y) + line.stroke / 2);
+    }
+    for (size_t i = contentStart.shapes; i < app.layoutShapes.size(); ++i)
+        contentBottom = std::max(contentBottom, app.layoutShapes[i].rect.bottom);
+    for (size_t i = contentStart.connectors; i < app.layoutConnectors.size(); ++i)
+        contentBottom = std::max(contentBottom, app.layoutConnectors[i].bounds.bottom);
+    for (size_t i = contentStart.bitmaps; i < app.layoutBitmaps.size(); ++i)
+        contentBottom = std::max(contentBottom, app.layoutBitmaps[i].destRect.bottom);
+
+    app.layoutRects.push_back({D2D1::RectF(indent, startY, indent + 4, std::min(y, contentBottom)), barColor});
 }
 
 static void layoutList(App& app, const ElementPtr& elem, float& y, float indent, float maxWidth) {

--- a/tests/blockquote-spacing-validation.md
+++ b/tests/blockquote-spacing-validation.md
@@ -1,0 +1,58 @@
+# Blockquote spacing validation
+
+The maintainer noticed that a quote looked as though it had an extra trailing
+line. Reproduced on `a1603a4` using `blockquote-one-line.md` and the mixed
+`blockquote-spacing.md` fixture. Paragraph layout adds a 14px bottom margin;
+the quote bar previously extended through that margin.
+
+The bar now ends at the retained content bounds. The layout cursor, text,
+internal paragraph gaps and spacing before the next block remain unchanged.
+Content bounds also preserve nested bars, code backgrounds and padding, table
+borders, heading rules, equations and callout titles/bodies.
+
+## Automated checks
+
+MSVC Release build and all 13 CTest suites passed. The new `blockquote_layout`
+suite uses the real Markdown parser and DirectWrite layout. Its bar-height
+assertions fail on the original renderer and pass with the fix.
+
+- Single-line paragraphs with LF, CRLF and EOF without a terminal newline.
+- Multiple paragraphs, explicit hard breaks and wrapping text.
+- Inline code, emphasis, links and math inside quotes.
+- Following paragraphs retain the 14px scaled gap; internal paragraphs retain
+  their spacing and hard breaks retain one line advance.
+- Nested quote bars end together at the final line.
+- Fenced code keeps padding, empty-block height and intentional blank rows.
+- Quotes ending in a table, display equation, list or heading rule.
+- Callouts with a body, title-only callouts and empty quotes.
+- Light and dark themes, widths 1050/650, and content scaling 100%/150%.
+- The mixed fixture keeps nine ordinary/nested bars, its callout, both tables,
+  both fences and the final content.
+
+Run `cmake --build build --config Release`, then
+`ctest --test-dir build -C Release --output-on-failure`.
+
+## Visual and export checks
+
+Inspected the fixed sample through computer use in Paper at 1050 x 900 and
+Midnight at 650 x 760. The one-line quote has a balanced bar, and nested quotes,
+tables, code, lists, callouts and math remain intact. Also inspected both pages
+of the mixed fixture's native print output.
+
+`tests/render_blockquote_fixtures.ps1` exports the minimal quote, mixed quote
+fixture, existing inline-code theme fixture and existing Markdown regression
+control. Run it with `-Binary` and `-Output` for separate baseline/fixed copies.
+
+- The four documents produce 1, 2, 2 and 2 native print pages respectively.
+- All four HTML files are byte-identical to the baseline.
+- Every DOCX ZIP entry is unchanged (7, 11, 11 and 7 entries).
+- Across all seven PNGs, changed pixels are confined to the ordinary/nested
+  quote-bar columns. All other pixels, including surrounding text and tables,
+  are unchanged. One page is entirely identical.
+- The minimal quote's solid bar measures 41px before and 27px after at 100%:
+  the 14px paragraph gap is now outside the bar.
+
+Generated artifacts and the comparison script are ignored under
+`out/blockquote-spacing/`. DOCX was checked structurally, not opened in Word.
+No physical printer or separate Windows 10 machine was used. No release or
+issue reply was published.

--- a/tests/blockquote_layout_tests.cpp
+++ b/tests/blockquote_layout_tests.cpp
@@ -1,0 +1,160 @@
+#include "d2d_init.h"
+#include "render.h"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+bool closeEnough(float a, float b) { return std::abs(a-b) < 0.05f; }
+bool sameColor(D2D1_COLOR_F a, D2D1_COLOR_F b) {
+    return closeEnough(a.r, b.r) && closeEnough(a.g, b.g) && closeEnough(a.b, b.b) && closeEnough(a.a, b.a);
+}
+std::vector<D2D1_RECT_F> bars(const App& app) {
+    std::vector<D2D1_RECT_F> result;
+    for (const auto& item : app.layoutRects)
+        if (closeEnough(item.rect.right-item.rect.left, 4) &&
+            sameColor(item.color, app.theme.blockquoteBorder)) result.push_back(item.rect);
+    return result;
+}
+void layout(App& app, const std::string& source) {
+    auto doc = app.parser.parse(source);
+    check(doc.success, "quote fixture parses");
+    app.root = doc.root;
+    layoutDocument(app);
+}
+float lastTextBottom(const App& app) {
+    float bottom = 0;
+    for (const auto& run : app.layoutTextRuns) bottom = std::max(bottom, run.bounds.bottom);
+    return bottom;
+}
+void paragraphCases(App& app) {
+    const float scale = app.contentScale * app.zoomFactor;
+    for (const char* source : {
+            "> One line.\n", "> One line.\r\n", "> One line.",
+            "> First paragraph.\n>\n> Last paragraph.\n",
+            "> First line.  \n> Last line.\n",
+            "> A quote with `inline code`, **bold**, *italic*, a [link](https://example.com) and $a+b=c$.\n",
+            "> A longer quote that wraps at narrow widths, retaining the full final line while keeping the paragraph gap outside the bar. More words make this wrap at both test widths when zoomed.\n"}) {
+        layout(app, source);
+        auto quoteBars = bars(app);
+        check(quoteBars.size() == 1, "one paragraph quote bar");
+        if (quoteBars.size() != 1) continue;
+        const float contentBottom = lastTextBottom(app);
+        check(closeEnough(quoteBars[0].bottom, contentBottom), "paragraph bar ends at the last line, before its margin");
+        const std::wstring quotedText = app.docText;
+        layout(app, std::string(source) + "\n\nFollowing paragraph.\n");
+        float followingY = -1;
+        for (const auto& run : app.layoutTextRuns)
+            if (run.docLength && app.docText.substr(run.docStart, run.docLength) == L"Following paragraph.")
+                followingY = run.bounds.top;
+        check(closeEnough(followingY, contentBottom + 14*scale), "following paragraph keeps the existing 14px gap");
+        check(app.docText.rfind(quotedText, 0) == 0, "quote searchable text is unchanged by a following block");
+    }
+
+    layout(app, "> First paragraph.\n>\n> Last paragraph.\n");
+    check(app.layoutTextRuns.size() == 2, "two quoted paragraphs retain both lines");
+    if (app.layoutTextRuns.size() == 2)
+        check(closeEnough(app.layoutTextRuns[1].bounds.top-app.layoutTextRuns[0].bounds.bottom, 14*scale),
+              "internal paragraph spacing is retained");
+
+    layout(app, "> First line.  \n> Last line.\n");
+    check(app.layoutTextRuns.size() == 2, "explicit hard break retains both lines");
+    if (app.layoutTextRuns.size() == 2)
+        check(closeEnough(app.layoutTextRuns[1].bounds.top, app.layoutTextRuns[0].bounds.bottom),
+              "hard break remains exactly one line advance");
+}
+void blockCases(App& app) {
+    layout(app, "> Outer paragraph.\n>\n> > Inner paragraph.\n");
+    auto quoteBars = bars(app);
+    check(quoteBars.size() == 2, "nested quote has two bars");
+    for (const auto& bar : quoteBars)
+        check(closeEnough(bar.bottom, lastTextBottom(app)), "nested bars both end at the final content line");
+
+    for (const char* source : {"> ```text\n> line\n> ```\n", "> ```text\n> line\n>\n> ```\n", "> ```text\n> ```\n"}) {
+        layout(app, source);
+        quoteBars = bars(app);
+        check(quoteBars.size() == 1 && app.codeBlocks.size() == 1, "quoted code block renders");
+        if (quoteBars.size() == 1 && app.codeBlocks.size() == 1)
+            check(closeEnough(quoteBars[0].bottom, app.codeBlocks[0].bounds.bottom),
+                  "bar retains code background padding and intentional empty rows");
+    }
+
+    layout(app, "> | Table | Value |\n> | --- | --- |\n> | Last row | $x$ |\n");
+    quoteBars = bars(app);
+    check(quoteBars.size() == 1 && app.tableRects.size() == 1, "quoted table renders");
+    if (quoteBars.size() == 1 && app.tableRects.size() == 1) {
+        float bottom = app.tableRects[0].bounds.bottom;
+        check(quoteBars[0].bottom >= bottom && quoteBars[0].bottom < bottom+2,
+              "bar covers the last table border without including the paragraph margin");
+    }
+
+    layout(app, "> $$\n> \\begin{bmatrix}1 & 2 \\\\ 3 & 4\\end{bmatrix}\n> $$\n");
+    quoteBars = bars(app);
+    check(quoteBars.size() == 1 && !app.textRects.empty(), "quoted display math renders");
+    if (quoteBars.size() == 1 && !app.textRects.empty())
+        check(closeEnough(quoteBars[0].bottom, app.textRects.back().rect.bottom), "bar covers the full display math box");
+
+    layout(app, "> - First item.\n> - Last item.\n");
+    quoteBars = bars(app);
+    check(quoteBars.size() == 1, "quoted list renders");
+    if (quoteBars.size() == 1)
+        check(closeEnough(quoteBars[0].bottom, lastTextBottom(app)), "bar ends at the final list line");
+
+    layout(app, "> ## Heading\n");
+    quoteBars = bars(app);
+    check(quoteBars.size() == 1 && !app.layoutLines.empty(), "quoted heading rule renders");
+    if (quoteBars.size() == 1 && !app.layoutLines.empty()) {
+        const auto& rule = app.layoutLines.back();
+        check(closeEnough(quoteBars[0].bottom, rule.p1.y+rule.stroke/2), "bar covers the heading underline");
+    }
+
+    for (const char* source : {"> [!NOTE]\n> Callout body.\n", "> [!TIP]\n"}) {
+        layout(app, source);
+        check(!app.layoutRects.empty(), "callout bar renders");
+        if (!app.layoutRects.empty())
+            check(closeEnough(app.layoutRects.back().rect.bottom, lastTextBottom(app)),
+                  "callout bar fits the body or standalone title");
+    }
+    layout(app, ">\n\nFollowing paragraph.\n");
+    quoteBars = bars(app);
+    check(quoteBars.size() == 1 && closeEnough(quoteBars[0].top, quoteBars[0].bottom), "empty quote does not acquire height");
+}
+}
+
+int main() {
+    {
+        auto state = std::make_unique<App>();
+        App& app = *state;
+        if (!initD2D(app)) return 2;
+        app.height = 900;
+        app.readingWidthPct = 100;
+        for (int theme : {0, 5}) {
+            applyTheme(app, theme);
+            for (float scale : {1.0f, 1.5f}) {
+                app.contentScale = scale;
+                updateTextFormats(app);
+                for (int width : {1050, 650}) {
+                    app.width = width;
+                    paragraphCases(app);
+                    blockCases(app);
+                    std::ifstream file(TINTA_QUOTE_FIXTURE, std::ios::binary);
+                    check(file.good(), "mixed quote fixture exists");
+                    layout(app, {(std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>()});
+                    check(bars(app).size() == 9, "all plain and nested quote bars survive the mixed fixture");
+                    check(app.tableRects.size() == 2 && app.codeBlocks.size() == 2, "mixed tables and fences survive");
+                    check(app.docText.find(L"All surrounding content") != std::wstring::npos, "final mixed content renders");
+                }
+            }
+        }
+    }
+    CoUninitialize();
+    std::cout << "Blockquote layout: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/tests/fixtures/blockquote-one-line.md
+++ b/tests/fixtures/blockquote-one-line.md
@@ -1,0 +1,3 @@
+> One quoted line.
+
+Following paragraph.

--- a/tests/fixtures/blockquote-spacing.md
+++ b/tests/fixtures/blockquote-spacing.md
@@ -1,0 +1,70 @@
+# Blockquote spacing
+
+Compare each quote's vertical bar with the last content line. The paragraph gap
+below a quote should separate it from the next block.
+
+> One line with `inline code`, **bold text** and $a+b=c$.
+
+Following paragraph.
+
+> First paragraph.
+>
+> Second paragraph with *emphasis* and a [link](https://example.com).
+
+| Existing feature | Check |
+| --- | --- |
+| Table | Stays below the quote |
+| Inline math | $\frac{1}{2}$ |
+
+> A quote with two explicit lines.\
+> This is the second line.
+
+- A list item after the quote.
+- Another item with `code`.
+
+```text
+A fenced block after the list.
+```
+
+## Nested quotes and callouts
+
+> Outer paragraph.
+>
+> > Inner paragraph with $\sqrt{x^2+y^2}$.
+
+The inner and outer bars should end together, with a gap before this paragraph.
+
+> [!NOTE]
+> A callout with `inline code` and **bold text**.
+
+Following the callout.
+
+## Quotes ending in other blocks
+
+> ```text
+> A code block with an intentional blank row below.
+>
+> ```
+
+The bar should cover the code background, including its padding and blank row.
+
+> | Quoted table | Math |
+> | --- | --- |
+> | Last row | $\frac{1}{2}$ |
+
+The bar should cover the table, with spacing outside the quote.
+
+> $$
+> \begin{bmatrix}1 & 2 \\ 3 & 4\end{bmatrix}
+> $$
+
+Following display math.
+
+> - A quoted list item.
+> - A second item.
+
+Following the quoted list.
+
+## Final heading
+
+All surrounding content should keep its position when only quote bars change.

--- a/tests/render_blockquote_fixtures.ps1
+++ b/tests/render_blockquote_fixtures.ps1
@@ -1,0 +1,50 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/blockquote-spacing/exports'
+)
+$ErrorActionPreference = 'Stop'
+$repo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskOutput = Join-Path $repo $Output
+$taskBinary = if ([IO.Path]::IsPathRooted($Binary)) { $Binary } else { Join-Path $repo $Binary }
+New-Item -ItemType Directory -Force "$taskOutput/runner" | Out-Null
+$taskExe = Join-Path $taskOutput 'runner/tinta.exe'
+Copy-Item -LiteralPath $taskBinary -Destination $taskExe -Force
+@'
+[Settings]
+themeIndex=0
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+'@ | Set-Content -LiteralPath "$taskOutput/runner/settings.ini"
+
+foreach ($name in @('blockquote-one-line', 'blockquote-spacing', 'inline-code-color', 'markdown-regression-control')) {
+    $source = Join-Path $PSScriptRoot "fixtures/$name.md"
+    $destination = Join-Path $taskOutput $name
+    New-Item -ItemType Directory -Force $destination | Out-Null
+    foreach ($mode in @('printpages', 'exporthtml', 'exportdocx')) {
+        $target = switch ($mode) {
+            'printpages' { "$destination/pages" }
+            'exporthtml' { "$destination/document.html" }
+            'exportdocx' { "$destination/document.docx" }
+        }
+        $process = Start-Process -FilePath $taskExe -ArgumentList @('"' + $source + '"', "--$mode", '"' + $target + '"') -WindowStyle Hidden -PassThru
+        if (!$process.WaitForExit(30000)) {
+            Stop-Process -Id $process.Id -Force
+            $process.WaitForExit()
+            throw "$name $mode timed out"
+        }
+        if ($process.ExitCode -ne 0 -or !(Test-Path -LiteralPath $target)) { throw "$name $mode failed" }
+    }
+    $html = Get-Content -LiteralPath "$destination/document.html" -Raw -Encoding UTF8
+    if ($html -notmatch '<blockquote') { throw "$name lost its quotes" }
+    if ($name -eq 'blockquote-spacing' -and ($html -notmatch '<table>' -or $html -notmatch '<h1' -or
+        [regex]::Matches($html, '<pre><code').Count -ne 2 -or
+        [regex]::Matches($html, 'class="math-(inline|display)"').Count -ne 5)) {
+        throw "$name lost mixed content"
+    }
+    $pages = @(Get-ChildItem -LiteralPath "$destination/pages" -Filter 'page-*.png')
+    if (!$pages.Count) { throw "$name produced no print pages" }
+    "$name : $($pages.Count) native pages, HTML and DOCX exported"
+}


### PR DESCRIPTION
A quote's vertical bar included its final paragraph's bottom margin, making a single-line quote look as though it contained an extra blank line. I now stop the bar at the content bounds while preserving text positions, internal spacing and the gap before the following block.

The same calculation covers nested quotes, callout titles/bodies, code backgrounds and padding, table borders, heading rules and equations. No export styles or Markdown parsing behavior change.

Validation: MSVC Release build and all 13 CTest suites pass. New native layout checks cover single/wrapped/multi-paragraph quotes, hard breaks, nested quotes, callouts and mixed blocks at two widths, themes and scales. I checked the sample in the app at normal/light and narrow/dark sizes. All seven exported PNGs differ only in quote-bar columns; all four HTML files and every DOCX entry match the baseline. Details: `tests/blockquote-spacing-validation.md`.

Stacked on #201 (`issue-197-inline-code-color`). This PR contains only the quote-bar fix and its fixtures/checks. No release or issue reply has been published.
