### PR TITLE
Add Copy file path and fix the single-tab context menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,12 @@ if(BUILD_TESTING)
         TINTA_SHORTCUT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/shortcuts-layouts.md")
     add_test(NAME input_shortcuts COMMAND input_tests)
 
+    add_executable(file_path_tests tests/file_path_tests.cpp ${INPUT_TEST_SOURCES})
+    target_include_directories(file_path_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(file_path_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
+    target_compile_definitions(file_path_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>)
+    add_test(NAME copy_file_path COMMAND file_path_tests)
+
     add_executable(code_block_layout_tests tests/code_block_layout_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(code_block_layout_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
     target_link_libraries(code_block_layout_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)

--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ tinta.exe /register
 
 Or simply drag and drop a `.md` or `.mmd` file onto the window.
 
+To copy a document's full path, right-click the document or its tab (the filename
+in the title bar when only one file is open) and choose
+**Copy file path**, beside **Reveal in Explorer**. The tab menu copies the clicked
+tab's path, even if another tab is active. Untitled notes have no path until saved.
+
 ## File Association
 
 On first launch, Tinta will ask if you want to set it as the default viewer for Markdown and Mermaid files. If you choose "No", you won't be asked again.

--- a/include/app.h
+++ b/include/app.h
@@ -467,6 +467,8 @@ struct App {
         int index = -1;    // tab index; -2 = plus, -3 = chevron
         D2D1_RECT_F closeRect{};
         bool hasClose = false;
+        // The lone title accepts right-clicks while remaining draggable.
+        D2D1_RECT_F contextRect{};
     };
     std::vector<TabHit> tabHits;       // refreshed by renderTabStrip
     // Pin button in the title bar: keeps this window above every other

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -105,6 +105,7 @@ enum ContextMenuItem {
     CTX_SAVE,
     CTX_SAVE_AS,
     CTX_EXIT,
+    CTX_COPY_PATH,
     CTX_ITEM_COUNT
 };
 struct ContextMenuEntry {

--- a/include/tabs.h
+++ b/include/tabs.h
@@ -38,6 +38,7 @@ void renderTabSwitcher(App& app);
 bool tabStripVisible(const App& app);
 
 // Right-click tab context menu (NPP-style close operations)
+int tabContextMenuIndexAt(const App& app, float x, float y);
 void openTabMenu(App& app, int tabIndex, float x, float y);
 void closeTabMenu(App& app);
 int tabMenuItemAt(const App& app, float x, float y);

--- a/include/utils.h
+++ b/include/utils.h
@@ -28,7 +28,10 @@ void updateWindowTitle(App& app);
 // Ctrl+N: spawns a second Tinta window on an untitled quick note
 void launchQuickNoteWindow();
 void openUrl(const std::string& url);
-void copyToClipboard(HWND hwnd, const std::wstring& text);
+bool copyToClipboard(HWND hwnd, const std::wstring& text);
+// Resolve UTF-8 document paths without a MAX_PATH-sized buffer (#203).
+std::wstring absoluteFilePath(const std::string& path);
+void copyFilePath(App& app, HWND hwnd, const std::string& path);
 void extractText(const ElementPtr& elem, std::wstring& out);
 
 std::string slugifyHeading(const std::wstring& text);

--- a/src/context_menu.cpp
+++ b/src/context_menu.cpp
@@ -14,6 +14,7 @@ const std::vector<ContextMenuEntry>& contextMenuEntries(const App& app) {
         {CTX_SEARCH, "ctx.search", L"", false},
         {CTX_TOC, "ctx.toc", L"", true},
         {CTX_BROWSE, "ctx.browse", L"", false},
+        {CTX_COPY_PATH, "tab.menu.copy_path", L"", false},
         {CTX_REVEAL, "ctx.reveal", L"", true},
         {CTX_THEME, "ctx.theme", L"", false},
         {CTX_SETTINGS, "ctx.settings", L"Ctrl+,", false},
@@ -81,7 +82,7 @@ bool contextMenuItemEnabled(const App& app, int item) {
         case CTX_PRINT: case CTX_EXPORT: case CTX_EDIT:
         case CTX_SELECT_ALL: case CTX_SEARCH: case CTX_TOC:
             return document;
-        case CTX_REVEAL: return !app.currentFile.empty();
+        case CTX_COPY_PATH: case CTX_REVEAL: return !app.currentFile.empty();
         default: return item >= 0 && item < CTX_ITEM_COUNT;
     }
 }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1584,17 +1584,18 @@ static void invokeContextMenuAction(App& app, HWND hwnd, int item) {
             }
             populateFolderItems(app);
             break;
-        case CTX_REVEAL:
-            if (!app.currentFile.empty()) {
-                std::wstring widePath = toWide(app.currentFile);
-                wchar_t fullPath[MAX_PATH];
-                if (GetFullPathNameW(widePath.c_str(), MAX_PATH, fullPath, nullptr)) {
-                    std::wstring params = L"/select,\"" + std::wstring(fullPath) + L"\"";
-                    ShellExecuteW(nullptr, L"open", L"explorer.exe", params.c_str(),
-                                  nullptr, SW_SHOWNORMAL);
-                }
+        case CTX_COPY_PATH:
+            copyFilePath(app, hwnd, app.currentFile);
+            break;
+        case CTX_REVEAL: {
+            std::wstring fullPath = absoluteFilePath(app.currentFile);
+            if (!fullPath.empty()) {
+                std::wstring params = L"/select,\"" + fullPath + L"\"";
+                ShellExecuteW(nullptr, L"open", L"explorer.exe", params.c_str(),
+                              nullptr, SW_SHOWNORMAL);
             }
             break;
+        }
         case CTX_THEME:
             closeSearchIfOpen(app);
             app.showThemeChooser = true;
@@ -1633,14 +1634,10 @@ void handleContextMenu(App& app, HWND hwnd, LPARAM lParam) {
     // above panels too — the strip stays interactive there)
     if (!fromKeyboard && !app.showPrintPreview && !app.confirmExitPending &&
         (float)pt.y < chromeTopHeight(app)) {
-        for (const App::TabHit& hit : app.tabHits) {
-            if (hit.index >= 0 && (float)pt.x >= hit.rect.left &&
-                (float)pt.x <= hit.rect.right && (float)pt.y >= hit.rect.top &&
-                (float)pt.y <= hit.rect.bottom) {
-                openTabMenu(app, hit.index, (float)pt.x, (float)pt.y);
-                InvalidateRect(hwnd, nullptr, FALSE);
-                return;
-            }
+        int index = tabContextMenuIndexAt(app, (float)pt.x, (float)pt.y);
+        if (index >= 0) {
+            openTabMenu(app, index, (float)pt.x, (float)pt.y);
+            InvalidateRect(hwnd, nullptr, FALSE);
         }
         return;  // strip right-clicks never reach the document menu
     }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1312,6 +1312,12 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case WM_NCRBUTTONUP:
             if (app && !app->zenMode && wParam == HTCAPTION) {
+                POINT pt = {GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam)};
+                ScreenToClient(hwnd, &pt);
+                if (tabContextMenuIndexAt(*app, (float)pt.x, (float)pt.y) >= 0) {
+                    handleContextMenu(*app, hwnd, lParam);
+                    return 0;
+                }
                 HMENU menu = GetSystemMenu(hwnd, FALSE);
                 if (menu) {
                     int cmd = TrackPopupMenu(

--- a/src/tabs.cpp
+++ b/src/tabs.cpp
@@ -624,6 +624,7 @@ void renderTabStrip(App& app) {
             hit.index = 0;
             hit.closeRect = cb;
             hit.hasClose = true;
+            hit.contextRect = D2D1::RectF(textLeft, 0, cb.right, stripH);
             app.tabHits.push_back(hit);
             nextX = cb.right + dpi(app, 6.0f);
         }
@@ -1116,6 +1117,18 @@ bool tabStripVisible(const App& app) {
     return app.tabs.size() > 1 || (app.forceTabStrip && !app.tabs.empty());
 }
 
+int tabContextMenuIndexAt(const App& app, float x, float y) {
+    if (y < 0 || y >= chromeTopHeight(app)) return -1;
+    for (const App::TabHit& hit : app.tabHits) {
+        if (hit.index < 0 || hit.index >= (int)app.tabs.size()) continue;
+        const auto& rect = hit.contextRect.right > hit.contextRect.left
+                               ? hit.contextRect : hit.rect;
+        if (x >= rect.left && x <= rect.right &&
+            y >= rect.top && y <= rect.bottom) return hit.index;
+    }
+    return -1;
+}
+
 // --- tab context menu: right-click a tab for NPP-style close operations
 // (close, close others, close left/right) plus path utilities ---
 
@@ -1173,7 +1186,8 @@ bool tabMenuItemEnabled(const App& app, int item) {
         case TM_CLOSE_LEFT:   return index > 0;
         case TM_CLOSE_RIGHT:  return index + 1 < (int)app.tabs.size();
         case TM_COPY_PATH:
-        case TM_REVEAL:       return !app.tabs[index].path.empty();
+        case TM_REVEAL:
+            return !(index == app.activeTab ? app.currentFile : app.tabs[index].path).empty();
     }
     return false;
 }
@@ -1352,6 +1366,7 @@ bool tabMenuMouseDown(App& app, HWND hwnd, int x, int y) {
     // Re-validate against the surviving tab row (indices can shift while
     // the menu is up only via external means; the guard is cheap)
     App& a = app;
+    const std::string& path = index == a.activeTab ? a.currentFile : a.tabs[index].path;
     switch (item) {
         case TM_CLOSE:
             if (tabMenuItemEnabled(a, TM_CLOSE)) tabCloseIndex(a, hwnd, index);
@@ -1367,30 +1382,17 @@ bool tabMenuMouseDown(App& app, HWND hwnd, int x, int y) {
                 tabBulkCloseBegin(a, hwnd, 3, index);
             break;
         case TM_COPY_PATH:
-            if (!a.tabs[index].path.empty()) {
-                std::wstring wide = toWide(a.tabs[index].path);
-                wchar_t fullPath[MAX_PATH];
-                if (GetFullPathNameW(wide.c_str(), MAX_PATH, fullPath,
-                                     nullptr)) {
-                    wide = fullPath;
-                }
-                copyToClipboard(hwnd, wide);
-                signalPushKey(a, SIG_INFO, SIGI_COPY, "toast.copied");
+            copyFilePath(a, hwnd, path);
+            break;
+        case TM_REVEAL: {
+            std::wstring fullPath = absoluteFilePath(path);
+            if (!fullPath.empty()) {
+                std::wstring params = L"/select,\"" + fullPath + L"\"";
+                ShellExecuteW(nullptr, L"open", L"explorer.exe",
+                              params.c_str(), nullptr, SW_SHOWNORMAL);
             }
             break;
-        case TM_REVEAL:
-            if (!a.tabs[index].path.empty()) {
-                std::wstring wide = toWide(a.tabs[index].path);
-                wchar_t fullPath[MAX_PATH];
-                if (GetFullPathNameW(wide.c_str(), MAX_PATH, fullPath,
-                                     nullptr)) {
-                    std::wstring params =
-                        L"/select,\"" + std::wstring(fullPath) + L"\"";
-                    ShellExecuteW(nullptr, L"open", L"explorer.exe",
-                                  params.c_str(), nullptr, SW_SHOWNORMAL);
-                }
-            }
-            break;
+        }
     }
     return true;
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,6 +1,7 @@
 #include "utils.h"
 #include "render.h"
 #include "i18n.h"
+#include "signals.h"
 
 #include <windows.h>
 #include <shellapi.h>
@@ -197,24 +198,43 @@ void handleLinkClick(App& app) {
     }
 }
 
-void copyToClipboard(HWND hwnd, const std::wstring& text) {
-    if (text.empty()) return;
-
-    if (!OpenClipboard(hwnd)) return;
-    EmptyClipboard();
-
+bool copyToClipboard(HWND hwnd, const std::wstring& text) {
+    if (text.empty()) return false;
     size_t size = (text.length() + 1) * sizeof(wchar_t);
     HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, size);
-    if (hMem) {
-        wchar_t* dest = (wchar_t*)GlobalLock(hMem);
-        if (dest) {
-            memcpy(dest, text.c_str(), size);
-            GlobalUnlock(hMem);
-            SetClipboardData(CF_UNICODETEXT, hMem);
-        }
+    if (!hMem) return false;
+    wchar_t* dest = (wchar_t*)GlobalLock(hMem);
+    if (!dest) {
+        GlobalFree(hMem);
+        return false;
     }
-
+    memcpy(dest, text.c_str(), size);
+    GlobalUnlock(hMem);
+    if (!OpenClipboard(hwnd)) {
+        GlobalFree(hMem);
+        return false;
+    }
+    bool copied = EmptyClipboard() && SetClipboardData(CF_UNICODETEXT, hMem);
+    if (!copied) GlobalFree(hMem);  // ownership transfers only on success
     CloseClipboard();
+    return copied;
+}
+
+std::wstring absoluteFilePath(const std::string& path) {
+    if (path.empty()) return {};
+    std::wstring wide = toWide(path);
+    DWORD capacity = GetFullPathNameW(wide.c_str(), 0, nullptr, nullptr);
+    if (!capacity) return {};
+    std::wstring full(capacity, L'\0');
+    DWORD length = GetFullPathNameW(wide.c_str(), capacity, full.data(), nullptr);
+    if (!length || length >= capacity) return {};
+    full.resize(length);
+    return full;
+}
+
+void copyFilePath(App& app, HWND hwnd, const std::string& path) {
+    if (copyToClipboard(hwnd, absoluteFilePath(path)))
+        signalPushKey(app, SIG_INFO, SIGI_COPY, "toast.copied");
 }
 
 void extractText(const ElementPtr& elem, std::wstring& out) {

--- a/tests/context_menu_tests.cpp
+++ b/tests/context_menu_tests.cpp
@@ -22,6 +22,7 @@ int main() {
     check(!contextMenuItemEnabled(app, CTX_SAVE_AS), "launcher cannot save a copy");
     check(!contextMenuItemEnabled(app, CTX_PRINT), "launcher cannot print");
     check(!contextMenuItemEnabled(app, CTX_EXPORT), "launcher cannot export");
+    check(!contextMenuItemEnabled(app, CTX_COPY_PATH), "launcher has no file path to copy");
     check(nextContextMenuItem(app, CTX_OPEN, 1) == CTX_THEME,
           "keyboard skips all unavailable document commands");
     check(nextContextMenuItem(app, CTX_QUICK_NOTE, -1) == CTX_EXIT,
@@ -36,12 +37,14 @@ int main() {
           app.hoveredContextMenuItem == CTX_QUICK_NOTE && !app.contextMenuKeyboard,
           "a physical pointer move resumes mouse selection");
     app.currentFile = "fixture.md";
+    check(contextMenuItemEnabled(app, CTX_COPY_PATH), "saved document can copy its file path");
     check(contextMenuItemEnabled(app, CTX_SAVE_AS), "reading mode can save a copy");
     check(!contextMenuItemEnabled(app, CTX_SAVE), "reading mode cannot overwrite from a stale editor buffer");
     app.currentFile.clear();
     app.editMode = true;
     app.editorText = L"unsaved text";
     app.editorDirty = true;
+    check(!contextMenuItemEnabled(app, CTX_COPY_PATH), "untitled editor cannot copy a path");
     check(contextMenuItemEnabled(app, CTX_SAVE) && contextMenuItemEnabled(app, CTX_SAVE_AS),
           "untitled editor can save and save as");
     check(contextMenuItemEnabled(app, CTX_PRINT) && contextMenuItemEnabled(app, CTX_EXPORT),
@@ -70,6 +73,12 @@ int main() {
             check(app.contextMenuY + contextMenuHeight(app) <= app.height + 0.01f,
                   "all rows fit in a short scaled window");
             const auto& entries = contextMenuEntries(app);
+            if (!application) {
+                for (size_t i = 0; i < entries.size(); ++i)
+                    if (entries[i].action == CTX_COPY_PATH)
+                        check(i+1 < entries.size() && entries[i+1].action == CTX_REVEAL,
+                              "Copy file path is immediately beside Reveal in Explorer");
+            }
             std::set<int> actions;
             for (int row = 0; row < (int)entries.size(); row++) {
                 const auto& entry = entries[row];

--- a/tests/copy-file-path-validation.md
+++ b/tests/copy-file-path-validation.md
@@ -1,0 +1,67 @@
+# Copy file path validation (#203)
+
+Validated on Windows on 2026-09-09. Request by
+[@Orcomp](https://github.com/Orcomp) in [#203](https://github.com/oipoistar/tinta/issues/203).
+The maintainer also identified the single-tab title context-menu bug while testing.
+
+## Native regression checks
+
+```powershell
+cmake --build build --config Release --parallel 6
+ctest --test-dir build -C Release --output-on-failure
+# Explicit opt-in: this command overwrites the Windows clipboard with test values.
+& build/Release/file_path_tests.exe --clipboard-test
+```
+
+All 14 CTest suites and the explicit clipboard run pass. Ordinary CTest runs
+do not read or modify the clipboard.
+
+- `copy_file_path` renders Tinta's actual title strip into a hidden native
+  test window and exercises the right-click handler. It covers two tabs,
+  transition to one tab, and a forced single-tab row (detached windows),
+  in reading and split-editor modes. Cases include short Unicode and long
+  filenames, Paper and Midnight, widths 650 and 1050, and 100%, 150%, 200% scale.
+- The lone title has a context-menu target while its normal hit rectangles
+  still leave the text draggable. App icon, plus and pin targets stay separate;
+  the start page and zen mode do not acquire a document title target.
+- The native non-client right-click handler uses the same title hit test
+  before showing the Windows system menu. Empty caption space retains the
+  existing system-menu behavior. This message-routing branch was code-reviewed;
+  a full interactive drag/right-click retest was not completed.
+- The explicit clipboard run chooses Copy file path through the document
+  menu, active and inactive tab menus, and the rendered single-title menu.
+  It checks relative paths, slash normalization, spaces, Unicode, UNC paths,
+  paths longer than MAX_PATH, and extended-length paths without truncation
+  or added quotation marks.
+- Active tabs use the live file path even when their saved tab snapshot is
+  stale after Save As. Copying an inactive tab preserves the active editor's
+  text and dirty flag. Untitled notes and embedded help do not copy a path.
+- A clipboard held by another thread preserves its contents and does not
+  produce a false Copied confirmation. Clipboard allocation/ownership failures
+  return failure; only successful path copies show the confirmation.
+- `context_menu` checks that Copy file path sits immediately before Reveal
+  in Explorer, is disabled without a saved path, and that all menu rows still
+  fit a short window at 100%, 150%, and 200% scale.
+
+## Mixed Markdown fixtures and exports
+
+Open `fixtures/copy-file-path.md` and `fixtures/copy-file-path-companion.md`
+to exercise the feature with headings, tables, emphasis, links, lists,
+inline code, a fenced code block, blockquotes, and inline/display math.
+The companion includes instructions for reproducing the single-tab case.
+
+Both fixtures and `fixtures/markdown-regression-control.md` were exported by
+the built app through `--printpages`, `--exporthtml`, and `--exportdocx`.
+Outputs and the comparison harness are under the ignored `out/issue-203/`.
+
+- All four native PNG pages are byte-identical to exports of the same fixtures
+  from the pre-change master build (`df9225590f48faeb67afac0ef32bf4ed59dc4564`).
+- All three HTML files and all DOCX ZIP entries are unchanged.
+- The main and companion fixtures retain their four and one equations,
+  respectively, plus their headings, tables and quotes. Both fixture PNGs
+  were visually inspected; the code row and quote spacing remain correct.
+
+An earlier live Paper-window check confirmed the new document-menu row and
+its placement. Computer Use was stopped by the maintainer before copy/paste
+interaction completed; subsequent verification used the native tests above.
+No issue reply was posted and no release was tagged.

--- a/tests/file_path_tests.cpp
+++ b/tests/file_path_tests.cpp
@@ -1,0 +1,244 @@
+#include "d2d_init.h"
+#include "input.h"
+#include "overlays.h"
+#include "tabs.h"
+#include "utils.h"
+
+#include <filesystem>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+
+std::wstring clipboardText(HWND window) {
+    std::wstring result;
+    // Clipboard-history tools may briefly read a newly copied value.
+    bool opened = false;
+    for (int i = 0; i < 100 && !(opened = OpenClipboard(window)); ++i) Sleep(5);
+    if (!opened) { check(false, "test clipboard opens for inspection"); return {}; }
+    if (HANDLE data = GetClipboardData(CF_UNICODETEXT)) {
+        if (auto text = static_cast<const wchar_t*>(GlobalLock(data))) {
+            result = text;
+            GlobalUnlock(data);
+        }
+    }
+    CloseClipboard();
+    return result;
+}
+void documentCopy(App& app) {
+    openContextMenu(app, 20, 80);
+    app.hoveredContextMenuItem = CTX_COPY_PATH;
+    handleKeyDown(app, app.hwnd, VK_RETURN);
+    check(!app.showContextMenu, "document Copy file path closes the menu");
+}
+void clickTabCopy(App& app) {
+    // Copy file path follows the four close actions and their separator.
+    int x = static_cast<int>(app.tabMenuX + 20);
+    int y = static_cast<int>(app.tabMenuY + dpi(app, 6+4*30+9+15));
+    check(tabMenuItemAt(app, x, y) == 4, "tab Copy file path remains next to Reveal");
+    check(tabMenuMouseDown(app, app.hwnd, x, y), "tab path action consumes its click");
+    check(!app.showTabMenu, "tab Copy file path closes the menu");
+}
+void tabCopy(App& app, int index) {
+    openTabMenu(app, index, 20, 40);
+    clickTabCopy(app);
+}
+void renderStrip(App& app) {
+    app.renderTarget->BeginDraw();
+    renderTabStrip(app);
+    check(SUCCEEDED(app.renderTarget->EndDraw()), "native title strip renders");
+}
+void rightClick(App& app, int x, int y) {
+    closeTabMenu(app);
+    POINT point{x, y};
+    ClientToScreen(app.hwnd, &point);
+    handleContextMenu(app, app.hwnd, MAKELPARAM(point.x, point.y));
+}
+void titleMenuCases(bool testClipboard) {
+    // Render the actual caption into a hidden test window so these checks
+    // catch missing hit regions, rather than opening a tab menu directly.
+    auto state = std::make_unique<App>();
+    App& app = *state;
+    app.hwnd = CreateWindowExW(0, L"STATIC", L"Tinta title test", WS_POPUP,
+        100, 100, 1050, 900, nullptr, nullptr, nullptr, nullptr);
+    if (!app.hwnd || !initD2D(app) || !createRenderTarget(app)) {
+        check(false, "native caption test initializes");
+        if (app.hwnd) DestroyWindow(app.hwnd);
+        return;
+    }
+    app.height = 900;
+    app.editRailAnim = 1;
+    for (int theme : {0, 5}) {
+        applyTheme(app, theme);
+        for (float scale : {1.0f, 1.5f, 2.0f}) {
+            app.contentScale = scale;
+            updateTextFormats(app);
+            for (int width : {650, 1050}) {
+                app.width = width;
+                for (bool edit : {false, true}) {
+                    app.editMode = edit;
+                    app.editorShowPreview = edit;
+                    for (const std::string& path : {std::string(u8"C:\\Tinta tests\\\u017divot \u6f22\u5b57.md"),
+                            "C:\\Tinta tests\\" + std::string(120, 'a') + ".md"}) {
+                        app.currentFile = path;
+                        app.tabs.resize(2);
+                        app.tabs[1].path = "C:\\companion.md";
+                        app.tabs[1].title = L"companion.md";
+                        app.forceTabStrip = false;
+                        renderStrip(app);
+                        for (const auto& hit : app.tabHits) {
+                            if (hit.index < 0) continue;
+                            rightClick(app, (int)(hit.rect.left+5), (int)dpi(app, 20));
+                            check(app.showTabMenu && app.tabMenuIndex == hit.index,
+                                  "both tab headers open their own context menu");
+                        }
+                        app.tabs.resize(1);  // last companion closed
+                        renderStrip(app);
+                        int x = (int)dpi(app, edit ? 60 : 48);
+                        int y = (int)dpi(app, 20);
+                        check(!tabStripVisible(app) && tabContextMenuIndexAt(app, (float)x, (float)y) == 0,
+                              "the lone title has a tab context target after closing a companion");
+                        for (const auto& hit : app.tabHits)
+                            check(!(x >= hit.rect.left && x <= hit.rect.right &&
+                                    y >= hit.rect.top && y <= hit.rect.bottom),
+                                  "the lone title retains non-client window dragging");
+                        rightClick(app, x, y);
+                        check(app.showTabMenu && app.tabMenuIndex == 0,
+                              "right-click routing opens the lone document's tab menu");
+                        if (testClipboard && app.showTabMenu) {
+                            clickTabCopy(app);
+                            check(clipboardText(app.hwnd) == toWide(path),
+                                  "single-title menu copies the full path");
+                        }
+                        check(tabContextMenuIndexAt(app, dpi(app, 20), (float)y) == -1,
+                              "the app icon does not open the tab menu");
+                        for (const auto& hit : app.tabHits)
+                            if (hit.index < 0)
+                                check(tabContextMenuIndexAt(app, (hit.rect.left+hit.rect.right)/2,
+                                      (hit.rect.top+hit.rect.bottom)/2) == -1,
+                                      "plus, pin and caption controls remain separate");
+                        check(tabContextMenuIndexAt(app, (float)width/2, dpi(app, 50)) == -1,
+                              "document content has no tab context target");
+                        app.zenMode = true;
+                        check(tabContextMenuIndexAt(app, (float)x, (float)y) == -1,
+                              "zen mode cannot use stale caption hit regions");
+                        app.zenMode = false;
+                        app.forceTabStrip = true;
+                        renderStrip(app);
+                        rightClick(app, (int)dpi(app, 60), y);
+                        check(app.showTabMenu && app.tabMenuIndex == 0,
+                              "a detached single-tab window retains its tab menu");
+                    }
+                }
+            }
+        }
+    }
+    app.currentFile.clear();
+    app.editMode = false;
+    app.forceTabStrip = false;
+    renderStrip(app);
+    check(tabContextMenuIndexAt(app, dpi(app, 48), dpi(app, 20)) == -1,
+          "the start page has no document title menu");
+    DestroyWindow(app.hwnd);
+    app.hwnd = nullptr;
+    state.reset();
+    CoUninitialize();
+}
+}
+
+int main(int argc, char** argv) {
+    // Default CTest runs are read-only. The explicit clipboard mode also
+    // exercises the real menus/Win32 clipboard and overwrites its contents.
+    bool testClipboard = argc == 2 && std::string(argv[1]) == "--clipboard-test";
+    titleMenuCases(testClipboard);
+    auto state = std::make_unique<App>();
+    App& app = *state;
+    if (testClipboard) {
+        app.hwnd = CreateWindowExW(0, L"STATIC", L"Tinta clipboard test", 0,
+            0, 0, 0, 0, HWND_MESSAGE, nullptr, nullptr, nullptr);
+        if (!app.hwnd) return 2;
+    }
+    app.width = 1050;
+    app.height = 900;
+    app.tabs.resize(2);
+    app.activeTab = 0;
+    app.tabs[0].path = "C:\\old-name.md";  // live path is authoritative after Save As
+    app.tabs[1].path = "C:\\Tinta tests\\inactive document.md";
+
+    std::string longPath = "C:\\Tinta tests";
+    for (int i = 0; i < 20; ++i) longPath += "\\long folder name";
+    longPath += "\\document.md";
+    std::wstring relativeExpected =
+        (std::filesystem::current_path() / L"tests" / L"fixtures" / L"copy-file-path.md").wstring();
+    for (const auto& item : {
+            std::pair<std::string, std::wstring>{"tests\\..\\tests\\fixtures\\copy-file-path.md", relativeExpected},
+            {"C:/Tinta tests/new name.md", L"C:\\Tinta tests\\new name.md"},
+            {u8"C:\\Tinta tests\\\u017divot \u6f22\u5b57.md", L"C:\\Tinta tests\\\u017divot \u6f22\u5b57.md"},
+            {"\\\\server\\share\\folder name\\document.md", L"\\\\server\\share\\folder name\\document.md"},
+            {longPath, toWide(longPath)}, {"\\\\?\\"+longPath, L"\\\\?\\"+toWide(longPath)}}) {
+        app.currentFile = item.first;
+        check(absoluteFilePath(item.first) == item.second, "full paths resolve without quoting or truncation");
+        if (!testClipboard) continue;
+        documentCopy(app);
+        check(clipboardText(app.hwnd) == item.second, "document action copies the full Unicode path");
+        tabCopy(app, 0);
+        check(clipboardText(app.hwnd) == item.second, "active-tab action uses the live path, not its saved snapshot");
+    }
+    if (!testClipboard) {
+        std::cout << "Full file paths: " << failures << " failures (clipboard checks require --clipboard-test)\n";
+        return failures ? 1 : 0;
+    }
+    app.editMode = true;
+    app.editorText = L"# Unsaved edits\n\n$x^2$\n";
+    app.editorDirty = true;
+    tabCopy(app, 1);
+    check(clipboardText(app.hwnd) == L"C:\\Tinta tests\\inactive document.md", "inactive-tab action copies the clicked tab");
+    check(app.activeTab == 0 && app.editorDirty && app.editorText == L"# Unsaved edits\n\n$x^2$\n",
+          "copying an inactive path preserves the active editor and unsaved changes");
+
+    check(copyToClipboard(app.hwnd, L"sentinel"), "test clipboard writes Unicode text");
+    check(!copyToClipboard(app.hwnd, L""), "empty clipboard requests do nothing");
+    app.currentFile.clear();
+    app.signalChips.clear();
+    documentCopy(app);
+    tabCopy(app, 0);
+    check(clipboardText(app.hwnd) == L"sentinel" && app.signalChips.empty(),
+          "untitled documents keep the clipboard and show no copy confirmation");
+    app.tabs[1].path.clear();
+    tabCopy(app, 1);
+    check(clipboardText(app.hwnd) == L"sentinel", "untitled inactive tab cannot copy another document's path");
+    app.editMode = false;
+    app.startPageEmbeddedOpen = true;
+    documentCopy(app);
+    check(clipboardText(app.hwnd) == L"sentinel", "embedded help/start page has no file path");
+
+    std::promise<bool> opened;
+    std::promise<void> release;
+    auto released = release.get_future();
+    std::thread locker([&] {
+        bool locked = OpenClipboard(nullptr) != 0;
+        opened.set_value(locked);
+        released.wait();
+        if (locked) CloseClipboard();
+    });
+    bool locked = opened.get_future().get();
+    check(locked, "another thread can hold the test clipboard");
+    if (locked) {
+        app.signalChips.clear();
+        copyFilePath(app, app.hwnd, "C:\\document.md");
+        check(app.signalChips.empty(), "a busy clipboard does not produce a false Copied confirmation");
+    }
+    release.set_value();
+    locker.join();
+    check(clipboardText(app.hwnd) == L"sentinel", "clipboard contention preserves its previous content");
+    DestroyWindow(app.hwnd);
+    app.hwnd = nullptr;
+    std::cout << "Copy file path: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/tests/fixtures/copy-file-path-companion.md
+++ b/tests/fixtures/copy-file-path-companion.md
@@ -1,0 +1,16 @@
+# Copy path companion
+
+Keep the main fixture active while opening this file in another tab. Copy this
+tab's path from its tab menu and verify that it ends in `copy-file-path-companion.md`.
+
+| Marker | Value |
+| --- | --- |
+| Companion | $x^2$ |
+
+> An inactive tab must keep its own file identity.
+
+## Single-tab check
+
+Close the main fixture, leaving only this file. Right-click the filename at the
+top of the window and choose **Copy file path**. It should still copy this file's
+full path. Repeat in edit mode; left-dragging the title should still move the window.

--- a/tests/fixtures/copy-file-path.md
+++ b/tests/fixtures/copy-file-path.md
@@ -1,0 +1,31 @@
+# Copy file path: $E = mc^2$
+
+Regression fixture for [#203](https://github.com/oipoistar/tinta/issues/203).
+Right-click the document and choose **Copy file path**, beside **Reveal in Explorer**.
+Paste into an untitled note to verify that the clipboard contains this document's
+absolute path, including its extension, spaces and any Unicode characters.
+
+## Existing formatting
+
+| Feature | Example |
+| --- | --- |
+| Inline code | `clipboard_path` |
+| Math | $\frac{1}{2}$ |
+| Emphasis | **bold**, *italic* and a [link](https://example.com) |
+
+> A quote with `code` and $a+b=c$ should retain its corrected bar height.
+
+- Copy the active document's path.
+- Right-click an inactive tab and copy that tab's path without switching tabs.
+- After Save As, copy the new path.
+- An untitled note has no file path; its tab command should be disabled.
+
+```text
+A code block with one row.
+```
+
+$$
+\begin{bmatrix}1 & 2 \\ 3 & 4\end{bmatrix}
+$$
+
+Use the [companion document](copy-file-path-companion.md) for the inactive-tab check.


### PR DESCRIPTION
Copy file path was missing from the document context menu, and right-clicking a lone document's title opened the Windows menu instead of Tinta's tab menu. Add Copy file path beside Reveal in Explorer and make the single-document title open the tab menu while retaining left-drag window movement.

Both menus copy the full Unicode path without MAX_PATH truncation. Active tabs use the live path after Save As; inactive tabs keep their own path. Untitled notes cannot copy a path, and a failed clipboard write does not show a Copied confirmation.

Requested by @Orcomp. Closes #203.

Validation: Release build and all 14 CTest suites pass, plus the explicit Win32 clipboard test. Native title rendering/right-click tests cover single and multiple tabs, reading and split-editor modes, two themes, two widths and three scales. Three mixed Markdown fixtures retain byte-identical PNG/HTML exports and DOCX contents compared with pre-change master. Interactive testing confirmed the document-menu placement; the full live copy/paste and dragging retest remains incomplete. Details: `tests/copy-file-path-validation.md`.
