### PR TITLE
Dismiss Settings on outside clicks and add a close button

### DIFF
--- a/include/overlays.h
+++ b/include/overlays.h
@@ -34,6 +34,7 @@ enum SettingsAction {
     SET_TOC_LEFT, SET_TOC_RIGHT,
     SET_LANG_DROPDOWN, SET_OPEN_LANGS_INI,
     SET_KEYS_DROPDOWN, SET_EDIT_KEYS,
+    SET_CLOSE,
     // Language picks encode as SET_LANG_PICK_BASE + i: 0 = Auto, then the
     // registry languages in order (the list is dynamic via languages.ini)
     SET_LANG_PICK_BASE = 1000,
@@ -66,6 +67,8 @@ FolderBrowserMetrics folderBrowserMetrics(const App& app);
 // relative to the content origin (add listStartY + namingOffset - scroll)
 float folderItemContentY(const FolderBrowserMetrics& g, int index);
 void renderSettingsOverlay(App& app);
+D2D1_RECT_F settingsPanelRect(const App& app);
+D2D1_RECT_F settingsCloseButtonRect(const App& app);
 
 // Theme editor ("+ New" in settings). Font-list entries encode their
 // absolute family index as TE_FONT_BASE + i; everything else stays < 100.

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -614,6 +614,17 @@ static void shortcutAssign(App& app, KeyBinding key) {
     app.shortcutEditorRow = -1;
 }
 
+static void closeSettings(App& app, HWND hwnd) {
+    app.showSettings = false;
+    app.settingsAnimation = 0;
+    app.settingsLangOpen = false;
+    app.settingsKeysOpen = false;
+    app.settingsDragSlider = 0;
+    app.settingsHits.clear();
+    if (GetCapture() == hwnd) ReleaseCapture();
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
 static void settingsAction(App& app, HWND hwnd, int action) {
     // Shortcut profile picks (checked first: their base is above the
     // language pick base)
@@ -647,6 +658,7 @@ static void settingsAction(App& app, HWND hwnd, int action) {
     if (action != SET_LANG_DROPDOWN) app.settingsLangOpen = false;
     if (action != SET_KEYS_DROPDOWN) app.settingsKeysOpen = false;
     switch (action) {
+        case SET_CLOSE: closeSettings(app, hwnd); return;
         case SET_SECTION_GENERAL: app.settingsSection = 0; break;
         case SET_SECTION_APPEARANCE: app.settingsSection = 1; break;
         case SET_SECTION_EDITOR: app.settingsSection = 2; break;
@@ -1039,6 +1051,7 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         }
         setCursorFromHits(app.settingsHits, (float)app.mouseX,
                           (float)app.mouseY, false, true);
+        if (mouseMoved) InvalidateRect(hwnd, nullptr, FALSE);
         return;
     }
 
@@ -1710,6 +1723,22 @@ static void toggleApplicationMenu(App& app, HWND hwnd, bool keyboard = false) {
 }
 
 void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    // Settings owns the entire click, including the title strip behind it.
+    // Sliders drag from the press; dismissal and other actions use release.
+    if (app.showSettings) {
+        float mx = (float)GET_X_LPARAM(lParam);
+        float my = (float)GET_Y_LPARAM(lParam);
+        for (const auto& hit : app.settingsHits) {
+            if ((hit.second == SET_SLIDER_READING || hit.second == SET_SLIDER_ZEN) &&
+                cursorPointInRect(mx, my, hit.first)) {
+                app.settingsDragSlider = hit.second;
+                SetCapture(hwnd);
+                settingsSliderApply(app, hit.second, mx);
+                return;
+            }
+        }
+        return;
+    }
     if (appMenuButtonAt(app, (float)GET_X_LPARAM(lParam), (float)GET_Y_LPARAM(lParam))) {
         toggleApplicationMenu(app, hwnd);
         app.swallowNextMouseUp = true;
@@ -1796,22 +1825,6 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     // press must not start a document selection underneath it
     if (app.createRefPending) return;
 
-    // Settings: sliders drag from the press; everything else acts on release
-    if (app.showSettings) {
-        float mx = (float)GET_X_LPARAM(lParam);
-        float my = (float)GET_Y_LPARAM(lParam);
-        for (const auto& hit : app.settingsHits) {
-            if ((hit.second == SET_SLIDER_READING || hit.second == SET_SLIDER_ZEN) &&
-                mx >= hit.first.left && mx <= hit.first.right &&
-                my >= hit.first.top && my <= hit.first.bottom) {
-                app.settingsDragSlider = hit.second;
-                SetCapture(hwnd);
-                settingsSliderApply(app, hit.second, mx);
-                return;
-            }
-        }
-        return;
-    }
     // Print preview: controls act on the release
     if (app.showPrintPreview) return;
 
@@ -2749,6 +2762,10 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
                 return;
             }
         }
+        if (!cursorPointInRect(mx, my, settingsPanelRect(app))) {
+            closeSettings(app, hwnd);
+            return;
+        }
         if (app.settingsLangOpen || app.settingsKeysOpen) {
             app.settingsLangOpen = false;  // click elsewhere collapses them
             app.settingsKeysOpen = false;
@@ -3379,9 +3396,7 @@ bool handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
     // Settings overlay captures the keyboard while open
     if (app.showSettings) {
         if (wParam == VK_ESCAPE || (ctrl && wParam == VK_OEM_COMMA)) {
-            app.showSettings = false;
-            app.settingsAnimation = 0;
-            InvalidateRect(hwnd, nullptr, FALSE);
+            closeSettings(app, hwnd);
         }
         return false;
     }

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1227,6 +1227,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (button == 1) return HTMINBUTTON;
             if (button == 2) return HTMAXBUTTON;  // Win11 snap flyout
             if (button == 3) return HTCLOSE;
+            // The settings backdrop also owns clicks on empty caption space.
+            if (app->showSettings) return HTCLIENT;
             // The floating sheet rises past the strip (design 10a):
             // right of the source column the top band is desk gap and
             // page, both of which take normal clicks

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -2713,6 +2713,22 @@ void settingsChip(App& app, float& x, float y, const wchar_t* label, bool active
 
 } // namespace
 
+D2D1_RECT_F settingsPanelRect(const App& app) {
+    float w = std::min(dpi(app, 760.0f), app.width - dpi(app, 80.0f));
+    float h = std::min(dpi(app, 540.0f), app.height - dpi(app, 64.0f));
+    float x = (app.width - w) / 2;
+    float y = (app.height - h) / 2 + (1 - app.settingsAnimation) * dpi(app, 30.0f);
+    return D2D1::RectF(x, y, x + w, y + h);
+}
+
+D2D1_RECT_F settingsCloseButtonRect(const App& app) {
+    const auto panel = settingsPanelRect(app);
+    float size = dpi(app, 28.0f);
+    float right = panel.right - dpi(app, 16.0f);
+    float top = panel.top + dpi(app, 16.0f);
+    return D2D1::RectF(right - size, top, right, top + size);
+}
+
 void renderSettingsOverlay(App& app) {
     if (app.settingsAnimation < 1.0f) {
         float prev = app.settingsAnimation;
@@ -2731,10 +2747,12 @@ void renderSettingsOverlay(App& app) {
     app.renderTarget->FillRectangle(
         D2D1::RectF(0, 0, (float)app.width, (float)app.height), app.brush);
 
-    float panelW = std::min(dpi(app, 760.0f), app.width - dpi(app, 80.0f));
-    float panelH = std::min(dpi(app, 540.0f), app.height - dpi(app, 64.0f));
-    float px = (app.width - panelW) / 2;
-    float py = (app.height - panelH) / 2 + (1 - anim) * dpi(app, 30.0f);
+    const auto panelRect = settingsPanelRect(app);
+    float panelW = panelRect.right - panelRect.left;
+    float panelH = panelRect.bottom - panelRect.top;
+    float px = panelRect.left;
+    float py = panelRect.top;
+    const auto closeRect = settingsCloseButtonRect(app);
 
     // Elevated panel: soft drop shadow, lifted surface, hairline border
     for (int ring = 3; ring >= 1; ring--) {
@@ -2765,8 +2783,28 @@ void renderSettingsOverlay(App& app) {
         const wchar_t* title = tr(app, "settings.title");
         app.renderTarget->DrawText(title, (UINT32)wcslen(title), app.themeTitleFormat,
             D2D1::RectF(px + dpi(app, 24.0f), py + dpi(app, 16.0f),
-                        px + panelW, py + dpi(app, 56.0f)), app.brush);
+                        closeRect.left - dpi(app, 8.0f), py + dpi(app, 56.0f)), app.brush);
     }
+
+    bool closeHover = app.mouseX >= closeRect.left && app.mouseX <= closeRect.right &&
+                      app.mouseY >= closeRect.top && app.mouseY <= closeRect.bottom;
+    if (closeHover) {
+        D2D1_COLOR_F bg = app.theme.text; bg.a = 0.10f * anim;
+        app.brush->SetColor(bg);
+        app.renderTarget->FillRoundedRectangle(
+            D2D1::RoundedRect(closeRect, dpi(app, 5.0f), dpi(app, 5.0f)), app.brush);
+    }
+    D2D1_COLOR_F closeColor = app.theme.text;
+    closeColor.a = (closeHover ? 1.0f : 0.65f) * anim;
+    app.brush->SetColor(closeColor);
+    float closeX = (closeRect.left + closeRect.right) / 2;
+    float closeY = (closeRect.top + closeRect.bottom) / 2;
+    float arm = dpi(app, 4.0f);
+    app.renderTarget->DrawLine(D2D1::Point2F(closeX-arm, closeY-arm),
+        D2D1::Point2F(closeX+arm, closeY+arm), app.brush, dpi(app, 1.5f));
+    app.renderTarget->DrawLine(D2D1::Point2F(closeX+arm, closeY-arm),
+        D2D1::Point2F(closeX-arm, closeY+arm), app.brush, dpi(app, 1.5f));
+    app.settingsHits.push_back({closeRect, SET_CLOSE});
 
     // Section rail
     const wchar_t* sections[] = {tr(app, "settings.section.general"),

--- a/tests/fixtures/settings-dismissal.md
+++ b/tests/fixtures/settings-dismissal.md
@@ -1,0 +1,31 @@
+# Settings dismissal: $E = mc^2$
+
+Open **Settings** with **Ctrl+,** or the top-left icon menu.
+
+1. Click inside the dialog's blank space: it stays open.
+2. Click the dimmed document outside it: Settings closes and the click is consumed.
+3. Open Settings again, then click its small **×** in the top-right corner.
+4. Change a setting and close the dialog; the choice should remain applied.
+
+## Mixed Markdown stays intact
+
+| Feature | Example |
+| --- | --- |
+| Inline code | `settings_close` |
+| Math | $\frac{1}{2}$ |
+| Emphasis | **bold**, *italic*, and a [local link](settings-dismissal.md) |
+
+> A quote with `inline code` and $a+b=c$ keeps its corrected bar height.
+
+```text
+One code row without a phantom blank row.
+```
+
+- Repeat dismissal while editing an unsaved change; text and caret stay put.
+- Open a language dropdown. Clicking blank space inside Settings closes only the dropdown.
+- Drag the reading-width slider and release outside the dialog; this ends the drag.
+- Clicking outside Settings over the + button must not create a tab.
+
+$$
+\begin{bmatrix}1 & 2 \\ 3 & 4\end{bmatrix}
+$$

--- a/tests/input_tests.cpp
+++ b/tests/input_tests.cpp
@@ -1,4 +1,6 @@
 #include "input.h"
+#include "d2d_init.h"
+#include "overlays.h"
 #include "settings.h"
 
 #include <fstream>
@@ -18,9 +20,141 @@ void stroke(App& app, unsigned vk, unsigned character = 0) {
     bool consumed = handleKeyDown(app, app.hwnd, vk);
     if (!consumed && character) handleCharInput(app, app.hwnd, character);
 }
+
+void settingsDismissal() {
+    auto state = std::make_unique<App>();
+    App& app = *state;
+    app.hwnd = CreateWindowExW(0, L"STATIC", L"Settings input tests", WS_POPUP,
+        100, 100, 1050, 900, nullptr, nullptr, nullptr, nullptr);
+    if (!app.hwnd || !initD2D(app) || !createRenderTarget(app)) {
+        check(false, "settings native renderer initializes");
+        if (app.hwnd) DestroyWindow(app.hwnd);
+        return;
+    }
+    app.currentFile = TINTA_SHORTCUT_FIXTURE;
+    app.tabs.resize(1);
+    app.tabs[0].path = app.currentFile;
+    app.editorText = L"# Unsaved text\n\n$x^2$\n";
+    app.editorDirty = true;
+    app.editorCursorPos = 4;
+    app.editRailAnim = 1;
+    auto open = [&](int section = 0, float animation = 1.0f) {
+        app.showSettings = true;
+        app.settingsSection = section;
+        app.settingsAnimation = animation;
+        app.renderTarget->BeginDraw();
+        renderSettingsOverlay(app);
+        check(SUCCEEDED(app.renderTarget->EndDraw()), "settings panel renders");
+    };
+    auto click = [&](float x, float y) {
+        LPARAM point = MAKELPARAM((int)x, (int)y);
+        handleMouseDown(app, app.hwnd, MK_LBUTTON, point);
+        handleMouseUp(app, app.hwnd, 0, point);
+        check(app.editorText == L"# Unsaved text\n\n$x^2$\n" && app.editorCursorPos == 4 && app.editorDirty,
+              "settings clicks preserve editor text, cursor and unsaved changes");
+        check(!app.selecting && !app.editorSelecting && !app.createRefPending,
+              "settings dismissal cannot start document selection or activate a link");
+    };
+    for (int theme : {0, 5}) {
+        applyTheme(app, theme);
+        for (float scale : {1.0f, 1.5f, 2.0f}) {
+            app.contentScale = scale;
+            updateTextFormats(app);
+            for (int width : {650, 1050}) {
+                app.width = width;
+                app.height = width == 650 ? 600 : 900;
+                for (bool edit : {false, true}) {
+                    app.editMode = edit;
+                    for (float animation : {0.0f, 1.0f}) {
+                        open(0, animation);
+                        auto panel = settingsPanelRect(app);
+                        click(panel.left+8, (panel.top+panel.bottom)/2);
+                        check(app.showSettings, "blank panel space does not dismiss settings");
+                        const auto close = settingsCloseButtonRect(app);
+                        check(close.left > panel.left && close.right < panel.right &&
+                              close.top > panel.top && close.bottom < panel.bottom,
+                              "close button stays inside the animated/scaled panel");
+                        bool closeHit = false;
+                        for (const auto& hit : app.settingsHits)
+                            if (hit.second == SET_CLOSE) closeHit = true;
+                        check(closeHit, "renderer registers a close-button hit target");
+                        app.settingsLangOpen = app.settingsKeysOpen = true;
+                        click((close.left+close.right)/2, (close.top+close.bottom)/2);
+                        check(!app.showSettings && app.settingsAnimation == 0 &&
+                              !app.settingsLangOpen && !app.settingsKeysOpen && app.settingsHits.empty(),
+                              "close button clears transient dialog state");
+                        for (const auto point : {D2D1::Point2F(panel.left-5, (panel.top+panel.bottom)/2),
+                                D2D1::Point2F(panel.right+5, (panel.top+panel.bottom)/2),
+                                D2D1::Point2F(app.width/2.0f, panel.top-5),
+                                D2D1::Point2F(app.width/2.0f, panel.bottom+5)}) {
+                            open(0, animation);
+                            app.hoveredLink = "fileref-missing:must-not-be-created.md";
+                            click(point.x, point.y);
+                            check(!app.showSettings, "all four backdrop edges dismiss settings");
+                        }
+                    }
+                    open();
+                    // The backdrop also covers the icon and + tab control.
+                    app.tabHits = {{D2D1::RectF(dpi(app, 80), 0, dpi(app, 110), dpi(app, 40)), -2}};
+                    click(dpi(app, 90), dpi(app, 20));
+                    check(!app.showSettings && app.tabs.size() == 1,
+                          "backdrop click on + does not create a tab");
+                    open();
+                    click(dpi(app, 20), dpi(app, 20));
+                    check(!app.showSettings && !app.showContextMenu,
+                          "backdrop click on the icon does not open another menu");
+                }
+            }
+        }
+    }
+    app.width = 1050;
+    app.height = 900;
+    app.contentScale = 1;
+    updateTextFormats(app);
+    open();
+    const auto panel = settingsPanelRect(app);
+    // A dropdown row outside the panel is still part of the dialog.
+    app.settingsLangOpen = true;
+    app.settingsHits.push_back({D2D1::RectF(panel.left, panel.bottom+4, panel.left+100, panel.bottom+30), SET_LANG_PICK_BASE});
+    click(panel.left+30, panel.bottom+15);
+    check(app.showSettings && !app.settingsLangOpen && app.languageSetting == -1,
+          "an outlying language choice is selected before backdrop dismissal");
+    app.settingsLangOpen = true;
+    click(panel.left+8, panel.top+8);
+    check(app.showSettings && !app.settingsLangOpen, "inside blank space collapses only the dropdown");
+    open(1);
+    const auto track = app.settingsSliderTrack[0];
+    handleMouseDown(app, app.hwnd, MK_LBUTTON, MAKELPARAM((int)(track.left+10), (int)track.top));
+    check(app.settingsDragSlider != 0, "reading-width slider starts dragging");
+    handleMouseUp(app, app.hwnd, 0, MAKELPARAM(5, 500));
+    check(app.showSettings && !app.settingsDragSlider && GetCapture() != app.hwnd,
+          "releasing a slider outside keeps settings open and releases capture");
+    const int readingWidth = app.readingWidthPct;
+    app.settingsLangOpen = app.settingsKeysOpen = true;
+    app.settingsDragSlider = SET_SLIDER_READING;
+    SetCapture(app.hwnd);
+    stroke(app, VK_ESCAPE);
+    check(!app.showSettings && !app.settingsLangOpen && !app.settingsKeysOpen &&
+          !app.settingsDragSlider && GetCapture() != app.hwnd && app.readingWidthPct == readingWidth,
+          "Escape shares close cleanup without reverting settings");
+    openContextMenu(app, 4, chromeTopHeight(app), true);
+    const auto& entries = contextMenuEntries(app);
+    for (int row = 0; row < (int)entries.size(); ++row) {
+        if (entries[row].action != CTX_SETTINGS) continue;
+        click(app.contextMenuX+20, app.contextMenuY+contextMenuItemTop(app, row)+contextMenuItemHeight(app)/2);
+        check(app.showSettings && !app.showContextMenu && !app.swallowNextMouseUp,
+              "the icon menu's opening click cannot immediately dismiss settings");
+        break;
+    }
+    DestroyWindow(app.hwnd);
+    app.hwnd = nullptr;
+    state.reset();
+    CoUninitialize();
+}
 }
 
 int main() {
+    settingsDismissal();
     auto state = std::make_unique<App>();
     App& app = *state;
     app.hwnd = CreateWindowExW(0, L"STATIC", L"Tinta input tests", 0,

--- a/tests/render_settings_fixtures.ps1
+++ b/tests/render_settings_fixtures.ps1
@@ -1,0 +1,49 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/settings-dismiss/fixed'
+)
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskOutput = Join-Path $taskRepo $Output
+$taskBinary = if ([IO.Path]::IsPathRooted($Binary)) { $Binary } else { Join-Path $taskRepo $Binary }
+New-Item -ItemType Directory -Force "$taskOutput/runner" | Out-Null
+$taskExe = Join-Path $taskOutput 'runner/tinta.exe'
+Copy-Item -LiteralPath $taskBinary -Destination $taskExe -Force
+@'
+[Settings]
+themeIndex=0
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+'@ | Set-Content -LiteralPath "$taskOutput/runner/settings.ini"
+foreach ($taskName in @('settings-dismissal','copy-file-path','markdown-regression-control')) {
+    $taskSource = Join-Path $PSScriptRoot "fixtures/$taskName.md"
+    $taskDest = Join-Path $taskOutput $taskName
+    New-Item -ItemType Directory -Force $taskDest | Out-Null
+    foreach ($taskMode in @('printpages','exporthtml','exportdocx')) {
+        $taskTarget = switch ($taskMode) {
+            'printpages' { "$taskDest/pages" }
+            'exporthtml' { "$taskDest/document.html" }
+            'exportdocx' { "$taskDest/document.docx" }
+        }
+        $taskProcess = Start-Process -FilePath $taskExe -ArgumentList @('"'+$taskSource+'"',"--$taskMode",'"'+$taskTarget+'"') -WindowStyle Hidden -PassThru
+        if (!$taskProcess.WaitForExit(30000)) {
+            Stop-Process -Id $taskProcess.Id -Force
+            $taskProcess.WaitForExit()
+            throw "$taskName $taskMode timed out"
+        }
+        if ($taskProcess.ExitCode -ne 0 -or !(Test-Path -LiteralPath $taskTarget)) { throw "$taskName $taskMode failed" }
+    }
+    $taskHtml = Get-Content -LiteralPath "$taskDest/document.html" -Raw -Encoding UTF8
+    if ($taskHtml -notmatch '<blockquote' -or $taskHtml -notmatch '<table>' -or $taskHtml -notmatch '<h1') {
+        throw "$taskName lost mixed Markdown content"
+    }
+    if ($taskName -eq 'settings-dismissal' -and [regex]::Matches($taskHtml,'class="math-(inline|display)"').Count -ne 4) {
+        throw 'Settings fixture lost an equation'
+    }
+    $taskPages = @(Get-ChildItem -LiteralPath "$taskDest/pages" -Filter 'page-*.png')
+    if (!$taskPages.Count) { throw "$taskName produced no print pages" }
+    "$taskName : $($taskPages.Count) native pages, HTML and DOCX"
+}

--- a/tests/settings-dismissal-validation.md
+++ b/tests/settings-dismissal-validation.md
@@ -1,0 +1,53 @@
+# Settings dismissal validation
+
+Validated on Windows on 2026-09-09 against v3.6.7.
+
+## Behavior and native regression checks
+
+Settings now closes on a left-click outside the panel or on the small top-right
+close button. Blank space inside the panel keeps it open. Changes remain applied.
+Dismissal clears dropdown and slider state, just like Escape, and consumes the
+click so the editor, document links, app icon and tab controls cannot act beneath it.
+Window minimize, maximize and close controls retain their native behavior.
+
+Build all Release targets and run:
+
+```powershell
+cmake --build build --config Release --parallel 6
+ctest --test-dir build -C Release --output-on-failure
+```
+
+All 14 suites pass. The existing `input_shortcuts` executable now also renders
+the actual settings panel into a hidden native test window and exercises both
+mouse handlers. It checks:
+
+- Close-button hit registration and geometry during opening animation and at rest.
+- All four backdrop edges, blank panel space, and clicks over the icon and + tab control.
+- Preserving dirty editor text and the cursor; no selection or missing-file link activation.
+- Paper and Midnight, widths 650 and 1050, 100%/150%/200% scale, reading and editing modes.
+- Dropdown choices outside the panel still work; an inside blank click collapses only the dropdown.
+- Releasing a slider outside ends the drag without closing Settings; Escape clears capture and keeps the value.
+- The icon-menu click that opens Settings is consumed and does not immediately dismiss it.
+
+## Mixed Markdown and visual checks
+
+`fixtures/settings-dismissal.md` contains headings, a table, emphasis, a link,
+inline and fenced code, a quote, a list, and four equations.
+
+```powershell
+./tests/render_settings_fixtures.ps1
+./tests/render_settings_fixtures.ps1 -Binary ../tinta-3.6.7.exe -Output out/settings-dismiss/baseline
+```
+
+The new fixture, `copy-file-path.md` and `markdown-regression-control.md` were
+exported by both builds. All five native PNG pages and all HTML bytes and DOCX
+ZIP entries match v3.6.7. Generated files and the comparison script are under
+the ignored `out/settings-dismiss/` directory.
+
+Computer Use showed the mixed fixture and Settings in Paper at 1050 x 900,
+including the close button in the top-right corner. An outside click dismissed
+the panel without changing the document. The mixed fixture was also inspected
+in Midnight at 650 x 760. Subsequent live input was inconsistent and included
+user-input guard interruptions, so close-button activation, editing-mode
+dismissal and scaled/dark dialog geometry are verified by the native tests,
+not claimed as completed interactive checks.


### PR DESCRIPTION
Settings previously required Escape to dismiss it. Add a small top-right close button and close the panel when clicking its backdrop. The dismissing click is consumed, including over the app icon and tab controls, and settings changes stay applied.

Keep dropdown choices outside the panel usable and allow slider drags to end outside without dismissing the dialog. Escape and the new mouse actions share dropdown/capture cleanup.

Validation: all-target Release build and all 14 CTest suites pass. Native renderer/input checks cover both themes, two widths, three scales, animation, reading/editing modes and click-through prevention. Three mixed Markdown fixtures retain identical native PNG, HTML and DOCX contents compared with v3.6.7. Live Paper testing confirmed placement and outside-click dismissal; remaining interactive coverage is documented in `tests/settings-dismissal-validation.md`.
