### PR TITLE
Place transferred tabs at the drop position and simplify tear-off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,12 +151,17 @@ if(BUILD_TESTING)
     # window, including layout-dependent character sequences (#195).
     set(INPUT_TEST_SOURCES ${SOURCES})
     list(REMOVE_ITEM INPUT_TEST_SOURCES src/main_d2d.cpp)
-    add_executable(input_tests tests/input_tests.cpp ${INPUT_TEST_SOURCES})
+    add_executable(input_tests tests/input_tests.cpp tests/tab_drop_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(input_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
     target_link_libraries(input_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
     target_compile_definitions(input_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
-        TINTA_SHORTCUT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/shortcuts-layouts.md")
+        TINTA_SHORTCUT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/shortcuts-layouts.md"
+        TINTA_TAB_DROP_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/tab-drop-position.md")
     add_test(NAME input_shortcuts COMMAND input_tests)
+    add_test(NAME tab_drop_position COMMAND ${CMAKE_COMMAND}
+        -DTEST_BINARY=$<TARGET_FILE:input_tests>
+        -DTEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/tab-drop-test-$<CONFIG>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_tab_drop_tests.cmake)
 
     add_executable(file_path_tests tests/file_path_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(file_path_tests PRIVATE include ${md4c_SOURCE_DIR}/src)

--- a/include/tabs.h
+++ b/include/tabs.h
@@ -14,7 +14,11 @@ void tabsInit(App& app);                       // adopt the startup document
 void tabsSeedSession(App& app, const std::vector<std::string>& paths);
 void tabActivate(App& app, HWND hwnd, int index);
 void tabOpenPath(App& app, HWND hwnd, const std::string& utf8Path,
-                 bool activate = true);
+                 bool activate = true, int insertBefore = -1);
+// Cross-window drops use client-space tab midpoints; ordinary opens append.
+int tabDropInsertionIndex(const App& app, POINT clientPoint);
+bool tabReceiveCopyData(App& app, HWND hwnd, const COPYDATASTRUCT& data);
+bool tabSendDrop(HWND target, const std::string& utf8Path, POINT screenPoint);
 void tabCloseIndex(App& app, HWND hwnd, int index);
 void tabCycle(App& app, HWND hwnd, int direction);
 

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1374,13 +1374,9 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (app) {
                 COPYDATASTRUCT* data =
                     reinterpret_cast<COPYDATASTRUCT*>(lParam);
-                if (data && data->dwData == 1 && data->lpData &&
-                    data->cbData > 0) {
-                    std::string path(static_cast<const char*>(data->lpData),
-                                     data->cbData - 1);
+                if (data && tabReceiveCopyData(*app, hwnd, *data)) {
                     if (IsIconic(hwnd)) ShowWindow(hwnd, SW_RESTORE);
                     SetForegroundWindow(hwnd);
-                    tabOpenPath(*app, hwnd, path, true);
                     return TRUE;
                 }
             }

--- a/src/tabs.cpp
+++ b/src/tabs.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <shellapi.h>
 
 namespace {
@@ -178,7 +179,7 @@ void tabActivate(App& app, HWND hwnd, int index) {
 }
 
 void tabOpenPath(App& app, HWND hwnd, const std::string& utf8Path,
-                 bool activate) {
+                 bool activate, int insertBefore) {
     tabsInit(app);
     // A path that is already open switches to its tab instead of duplicating
     for (size_t i = 0; i < app.tabs.size(); i++) {
@@ -194,9 +195,14 @@ void tabOpenPath(App& app, HWND hwnd, const std::string& utf8Path,
     tab.id = ++app.tabIdCounter;
     tab.path = utf8Path;
     tab.title = titleForPath(app, utf8Path);
-    app.tabs.push_back(std::move(tab));
+    int index = insertBefore < 0 ? (int)app.tabs.size()
+                               : std::min(insertBefore, (int)app.tabs.size());
+    app.tabs.insert(app.tabs.begin() + index, std::move(tab));
+    // Keep the old active document attached to its tab until activation
+    // parks its editor buffer; insertion may have shifted that tab right.
+    if (app.activeTab >= index) ++app.activeTab;
     if (activate) {
-        tabActivate(app, hwnd, (int)app.tabs.size() - 1);
+        tabActivate(app, hwnd, index);
     } else {
         InvalidateRect(hwnd, nullptr, FALSE);
     }
@@ -401,6 +407,55 @@ StripMetrics stripMetrics(const App& app) {
 }
 
 }  // namespace
+
+int tabDropInsertionIndex(const App& app, POINT clientPoint) {
+    const int count = (int)app.tabs.size();
+    const auto m = stripMetrics(app);
+    if (!tabStripVisible(app) || clientPoint.y < 0 || clientPoint.y >= m.height ||
+        clientPoint.x < 0 || clientPoint.x >= captionIslandLeft(app) ||
+        (editorPreviewVisible(app) && clientPoint.x >= editorPaneWidth(app))) {
+        return count;
+    }
+    const float step = m.tabWidth + dpi(app, 2.0f);
+    for (int i = 0; i < count; ++i) {
+        if (clientPoint.x < m.tabsLeft + step * i + m.tabWidth / 2) return i;
+    }
+    return count;
+}
+
+bool tabReceiveCopyData(App& app, HWND hwnd, const COPYDATASTRUCT& data) {
+    // Type 1 is the existing path-only launch message. Type 2 adds a
+    // screen-space drop point, resolved using the destination's own DPI
+    // and tab widths before opening the document changes its layout.
+    if (!data.lpData || (data.dwData != 1 && data.dwData != 2)) return false;
+    const size_t prefix = data.dwData == 2 ? sizeof(POINT) : 0;
+    if (data.cbData <= prefix + 1) return false;
+    const char* bytes = static_cast<const char*>(data.lpData);
+    const char* path = bytes + prefix;
+    const size_t length = data.cbData - prefix - 1;
+    if (path[length] != '\0' || std::memchr(path, '\0', length)) return false;
+    int index = -1;
+    if (data.dwData == 2) {
+        POINT point;
+        std::memcpy(&point, bytes, sizeof(point));
+        if (!ScreenToClient(hwnd, &point)) return false;
+        index = tabDropInsertionIndex(app, point);
+    }
+    tabOpenPath(app, hwnd, std::string(path, length), true, index);
+    return true;
+}
+
+bool tabSendDrop(HWND target, const std::string& utf8Path, POINT screenPoint) {
+    std::string payload(sizeof(screenPoint), '\0');
+    std::memcpy(payload.data(), &screenPoint, sizeof(screenPoint));
+    payload += utf8Path;
+    payload += '\0';
+    COPYDATASTRUCT data{};
+    data.dwData = 2;
+    data.cbData = (DWORD)payload.size();
+    data.lpData = payload.data();
+    return SendMessageW(target, WM_COPYDATA, 0, (LPARAM)&data) != FALSE;
+}
 
 D2D1_RECT_F captionButtonRect(const App& app, int button) {
     float w = captionButtonWidth(app);
@@ -1633,28 +1688,25 @@ void tabDragEnd(App& app, HWND hwnd, int x, int y) {
         if (root && root != hwnd &&
             GetClassNameW(root, className, _countof(className)) &&
             wcscmp(className, L"Tinta") == 0) {
-            COPYDATASTRUCT data;
-            data.dwData = 1;
-            data.cbData = (DWORD)path.size() + 1;
-            data.lpData = (void*)path.c_str();
-            SendMessageW(root, WM_COPYDATA, 0, (LPARAM)&data);
-            SetForegroundWindow(root);
-            dragCloseLocal(app, hwnd, index);
-        } else if (root == hwnd) {
-            // Dropped back onto this window's content: snap home
+            if (tabSendDrop(root, path, screen)) {
+                SetForegroundWindow(root);
+                dragCloseLocal(app, hwnd, index);
+            }
         } else if (app.tabs.size() > 1) {
-            // Free drop: a new window appears where the ghost was
+            // Once clear of the strip, releasing over our own document
+            // also tears the tab off. Returning to the strip cancels the
+            // detached state in tabDragMove before we reach this branch.
             wchar_t exePath[MAX_PATH];
             if (GetModuleFileNameW(nullptr, exePath, MAX_PATH)) {
-                wchar_t args[MAX_PATH * 2];
-                swprintf_s(args, _countof(args),
-                           L"--cascade --tabbed --pos %d %d \"%hs\"",
-                           screen.x - (int)dpi(app, 120.0f),
-                           screen.y - (int)dpi(app, 20.0f), path.c_str());
-                ShellExecuteW(nullptr, L"open", exePath, args, nullptr,
-                              SW_SHOWNORMAL);
+                std::wstring args = L"--cascade --tabbed --pos " +
+                    std::to_wstring(screen.x - (int)dpi(app, 120.0f)) + L" " +
+                    std::to_wstring(screen.y - (int)dpi(app, 20.0f)) + L" \"" +
+                    toWide(path) + L"\"";
+                if ((INT_PTR)ShellExecuteW(nullptr, L"open", exePath, args.c_str(),
+                                          nullptr, SW_SHOWNORMAL) > 32) {
+                    dragCloseLocal(app, hwnd, index);
+                }
             }
-            dragCloseLocal(app, hwnd, index);
         }
     }
     InvalidateRect(hwnd, nullptr, FALSE);
@@ -1688,13 +1740,10 @@ void tabWindowDropMerge(App& app, HWND hwnd) {
     }
     if (!target) return;
 
-    COPYDATASTRUCT data;
-    data.dwData = 1;
-    data.cbData = (DWORD)path.size() + 1;
-    data.lpData = (void*)path.c_str();
-    SendMessageW(target, WM_COPYDATA, 0, (LPARAM)&data);
-    SetForegroundWindow(target);
-    PostMessageW(hwnd, WM_CLOSE, 0, 0);
+    if (tabSendDrop(target, path, cursor)) {
+        SetForegroundWindow(target);
+        PostMessageW(hwnd, WM_CLOSE, 0, 0);
+    }
 }
 
 void tabDragCancel(App& app, HWND hwnd) {

--- a/tests/fixtures/tab-drop-position.md
+++ b/tests/fixtures/tab-drop-position.md
@@ -1,0 +1,43 @@
+# Window-to-tab insertion: $A+B=C$
+
+Open copies named **A.md**, **B.md**, and **C.md** in one window, and
+**Incoming.md** in another. Drop Incoming between A and B: the order should be
+**A, Incoming, B, C**, with Incoming active.
+
+## Positions to check
+
+| Drop location | Expected order |
+| --- | --- |
+| Before A | Incoming, A, B, C |
+| Between A and B | A, Incoming, B, C |
+| Between B and C | A, B, Incoming, C |
+| After C | A, B, C, Incoming |
+
+Repeat with a detached tab dragged from another window. The left and right
+halves of a tab should select the gap before and after it.
+
+## Tear off without leaving the window
+
+Drag B about **50 pixels below the tab bar**, then release over this document.
+It should open in a separate window at the drop position. You do not need to
+drag past the window border. Repeat above the bar where screen space allows.
+Dragging back near the bar before release keeps B in the original window;
+Escape cancels the drag. Unsaved and untitled tabs remain protected.
+
+> Keep a **dirty editor buffer**, `inline code`, ==highlight== and $x^2$
+> intact while inserting a tab before the active editor tab.
+
+- Narrow and wide windows; Paper and Midnight.
+- Different monitor scales and a destination on the left-hand monitor.
+- A single-document destination and a crowded tab strip.
+- Dropping an already-open file activates its existing tab without a duplicate.
+- Opening a file normally still appends it.
+
+```cpp
+const char* expected = "A, Incoming, B, C";
+```
+
+### Mixed content after the transfer
+
+The [positions section](#positions-to-check), table and quote should remain
+readable. The equation $\frac{a}{b}$ must retain its baseline and spacing.

--- a/tests/input_tests.cpp
+++ b/tests/input_tests.cpp
@@ -153,7 +153,12 @@ void settingsDismissal() {
 }
 }
 
-int main() {
+int runTabDropTests();
+int runTabDropLaunchProbe();
+
+int main(int argc, char** argv) {
+    if (argc == 2 && std::string(argv[1]) == "--tab-drop-tests") return runTabDropTests();
+    if (argc == 7 && std::string(argv[1]) == "--cascade") return runTabDropLaunchProbe();
     settingsDismissal();
     auto state = std::make_unique<App>();
     App& app = *state;

--- a/tests/render_tab_drop_fixtures.ps1
+++ b/tests/render_tab_drop_fixtures.ps1
@@ -1,0 +1,51 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/tab-drop-position/fixed'
+)
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskOutput = Join-Path $taskRepo $Output
+$taskBinary = if ([IO.Path]::IsPathRooted($Binary)) { $Binary } else { Join-Path $taskRepo $Binary }
+New-Item -ItemType Directory -Force "$taskOutput/runner" | Out-Null
+$taskExe = Join-Path $taskOutput 'runner/tinta.exe'
+Copy-Item -LiteralPath $taskBinary -Destination $taskExe -Force
+@'
+[Settings]
+themeIndex=0
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+'@ | Set-Content -LiteralPath "$taskOutput/runner/settings.ini"
+foreach ($taskName in @('tab-drop-position','settings-dismissal','copy-file-path')) {
+    $taskSource = Join-Path $PSScriptRoot "fixtures/$taskName.md"
+    $taskBefore = (Get-FileHash -LiteralPath $taskSource).Hash
+    $taskDest = Join-Path $taskOutput $taskName
+    New-Item -ItemType Directory -Force $taskDest | Out-Null
+    foreach ($taskMode in @('printpages','exporthtml','exportdocx')) {
+        $taskTarget = switch ($taskMode) {
+            'printpages' { "$taskDest/pages" }
+            'exporthtml' { "$taskDest/document.html" }
+            'exportdocx' { "$taskDest/document.docx" }
+        }
+        $taskProcess = Start-Process -FilePath $taskExe -ArgumentList @('"'+$taskSource+'"',"--$taskMode",'"'+$taskTarget+'"') -WindowStyle Hidden -PassThru
+        if (!$taskProcess.WaitForExit(30000)) {
+            Stop-Process -Id $taskProcess.Id -Force
+            $taskProcess.WaitForExit()
+            throw "$taskName $taskMode timed out"
+        }
+        if ($taskProcess.ExitCode -ne 0 -or !(Test-Path -LiteralPath $taskTarget)) { throw "$taskName $taskMode failed" }
+    }
+    $taskHtml = Get-Content -LiteralPath "$taskDest/document.html" -Raw -Encoding UTF8
+    if ($taskHtml -notmatch '<blockquote' -or $taskHtml -notmatch '<table>' -or $taskHtml -notmatch '<h1') {
+        throw "$taskName lost mixed Markdown content"
+    }
+    if ($taskName -eq 'tab-drop-position' -and [regex]::Matches($taskHtml,'class="math-(inline|display)"').Count -ne 3) {
+        throw 'Tab-drop fixture lost an equation'
+    }
+    if ((Get-FileHash -LiteralPath $taskSource).Hash -ne $taskBefore) { throw "$taskName source changed" }
+    $taskPages = @(Get-ChildItem -LiteralPath "$taskDest/pages" -Filter 'page-*.png')
+    if (!$taskPages.Count) { throw "$taskName produced no print pages" }
+    "$taskName : $($taskPages.Count) native pages, HTML and DOCX"
+}

--- a/tests/run_tab_drop_tests.cmake
+++ b/tests/run_tab_drop_tests.cmake
@@ -1,0 +1,12 @@
+if(NOT DEFINED TEST_BINARY OR NOT DEFINED TEST_DIR)
+    message(FATAL_ERROR "TEST_BINARY and TEST_DIR are required")
+endif()
+file(MAKE_DIRECTORY "${TEST_DIR}")
+configure_file("${TEST_BINARY}" "${TEST_DIR}/input_tests.exe" COPYONLY)
+file(WRITE "${TEST_DIR}/settings.ini" "; Isolated tab drop test configuration\n")
+file(WRITE "${TEST_DIR}/launch-probe-guard.txt" "Tinta tab drop launch probe")
+execute_process(COMMAND "${TEST_DIR}/input_tests.exe" --tab-drop-tests
+    WORKING_DIRECTORY "${TEST_DIR}" RESULT_VARIABLE result)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Native tab drop test failed: ${result}")
+endif()

--- a/tests/tab-drop-position-validation.md
+++ b/tests/tab-drop-position-validation.md
@@ -1,0 +1,72 @@
+# Tab insertion and tear-off validation
+
+Validated on Windows on 2026-09-10. These changes are unreleased.
+
+## Behavior
+
+- A window or detached tab dropped on another tab strip inserts at the gap
+  selected by the pointer. Each tab's left/right half selects before/after it.
+- The receiving window computes the position using its own scale and layout.
+- Ordinary file opens and drops on document content still append. An already
+  open file activates its existing tab without duplication or reordering.
+- A saved tab pulled about 50 logical pixels above or below the tab bar can
+  be released over its own document to create a separate window. It no longer
+  needs to cross the window border. The existing threshold is 48 logical pixels.
+- Returning near the tab bar cancels detachment; Escape/capture cancellation
+  removes the ghost and keeps the tab. Dirty and untitled tabs retain their
+  existing protection against detachment.
+- The source removes the tab only after a receiving window acknowledges the
+  transfer or Windows reports that the new process launched. New-window
+  arguments preserve Unicode file paths.
+
+## Automated checks
+
+```powershell
+cmake --build build --config Release --parallel 6
+ctest --test-dir build -C Release --output-on-failure
+```
+
+The full Release build and all **15 CTest suites** pass. `tab_drop_position`
+reuses the existing input-test executable, staged in an isolated portable
+directory so test documents and reading-position persistence stay there.
+
+The native tests render tab strips at logical widths 650 and 1050, in Paper
+and Midnight, at 100%, 150% and 200% scale, in reading and editing layouts.
+They exercise the actual WM_COPYDATA sender/receiver, including negative
+screen coordinates, UTF-8 paths, first/middle/last insertion, duplicate paths,
+ordinary launch messages, and malformed/rejected messages. A dirty destination
+editor buffer and its cursor survive insertion before its tab and switching back.
+
+The drag tests call the real move/cancel/release handlers. They check the
+threshold on both sides of the strip and returning to the strip at three scales.
+For release, an off-screen native test window is visible only outside the virtual
+desktop, and WindowFromPoint confirms that the drop is over the source document.
+The real launch path starts a guarded test child that records its arguments.
+The test verifies the new-window position, Unicode document path, and removal
+of only the dragged tab. It injects no desktop mouse or keyboard input.
+
+## Mixed Markdown and manual coverage
+
+`fixtures/tab-drop-position.md` describes insertion and tear-off scenarios and
+mixes headings, a table, a quote, bold text, highlights, lists, links, inline and
+fenced code, and three equations.
+
+```powershell
+./tests/render_tab_drop_fixtures.ps1
+./tests/render_tab_drop_fixtures.ps1 -Binary out/tab-drop-position/baseline.exe -Output out/tab-drop-position/baseline
+```
+
+The new fixture and the existing Settings and file-path fixtures were exported
+with the pre-change and final builds. All **five native PNG pages**, HTML bytes
+and DOCX ZIP contents are identical. Original Markdown files remain unchanged.
+Generated evidence is under ignored `out/tab-drop-position/`.
+
+Computer Use showed the three-tab destination and mixed fixture, but the user
+stopped Computer Use with Escape before the live drag gesture. The user then
+tested the insertion build and confirmed that it works. The later tear-off
+refinement is validated by the native launch test; a live desktop drag and
+physical mixed-DPI monitor gesture are not claimed as completed checks.
+
+Use the current build in both windows. A window running an older binary does
+not understand the new positioned transfer message; the source keeps its tab
+when that recipient does not acknowledge the transfer.

--- a/tests/tab_drop_tests.cpp
+++ b/tests/tab_drop_tests.cpp
@@ -1,0 +1,255 @@
+#include "tabs.h"
+#include "d2d_init.h"
+#include "editor.h"
+#include "input.h"
+#include "settings.h"
+#include "utils.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <shellapi.h>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+std::string read(const std::filesystem::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return {(std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>()};
+}
+LRESULT CALLBACK dropTestProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
+    auto app = reinterpret_cast<App*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+    if (msg == WM_COPYDATA && app && lParam)
+        return tabReceiveCopyData(*app, hwnd, *reinterpret_cast<COPYDATASTRUCT*>(lParam));
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+std::vector<App::TabHit> renderTabs(App& app) {
+    app.renderTarget->BeginDraw();
+    renderTabStrip(app);
+    check(SUCCEEDED(app.renderTarget->EndDraw()), "native tab strip renders");
+    std::vector<App::TabHit> tabs;
+    for (const auto& hit : app.tabHits) if (hit.index >= 0) tabs.push_back(hit);
+    return tabs;
+}
+}
+
+// The real detach path relaunches its own executable. In this isolated
+// native test, that child records the launch arguments instead of opening
+// a user-facing editor or entering the test suite recursively.
+int runTabDropLaunchProbe() {
+    namespace fs = std::filesystem;
+    wchar_t exe[MAX_PATH]{};
+    GetModuleFileNameW(nullptr, exe, MAX_PATH);
+    const auto dir = fs::path(exe).parent_path();
+    if (!fs::equivalent(dir, fs::current_path()) ||
+        read(dir / "launch-probe-guard.txt") != "Tinta tab drop launch probe") return 2;
+    int count = 0;
+    auto args = CommandLineToArgvW(GetCommandLineW(), &count);
+    if (!args) return 2;
+    int result = 2;
+    if (count == 7 && std::wstring(args[1]) == L"--cascade" &&
+        std::wstring(args[2]) == L"--tabbed" && std::wstring(args[3]) == L"--pos") {
+        std::ofstream out(dir / "launch-result.txt", std::ios::binary);
+        out << toUtf8(args[4]) << '\n' << toUtf8(args[5]) << '\n' << toUtf8(args[6]);
+        result = out ? 0 : 1;
+    }
+    LocalFree(args);
+    return result;
+}
+
+int runTabDropTests() {
+    namespace fs = std::filesystem;
+    wchar_t exe[MAX_PATH]{};
+    GetModuleFileNameW(nullptr, exe, MAX_PATH);
+    const auto dir = fs::path(exe).parent_path();
+    const auto settings = read(dir / "settings.ini");
+    if (!fs::equivalent(dir, fs::current_path()) ||
+        (settings != "; Isolated tab drop test configuration\n" &&
+         settings != "; Isolated tab drop test configuration\r\n")) {
+        std::cerr << "Run through CTest's isolated tab-drop wrapper\n";
+        return 2;
+    }
+    check(fs::equivalent(tintaConfigDir(), dir), "all persistence stays in the test directory");
+    const std::string fixture = read(TINTA_TAB_DROP_FIXTURE);
+    check(!fixture.empty(), "mixed Markdown fixture loads");
+    const wchar_t* names[] = {L"A.md", L"B.md", L"C.md", L"Incoming \u03b4.md", L"First.md", L"Last.md", L"Normal.md", L"Content.md"};
+    std::vector<std::string> paths;
+    for (const auto name : names) {
+        const auto path = dir / name;
+        std::ofstream(path, std::ios::binary) << fixture;
+        paths.push_back(toUtf8(path.wstring()));
+    }
+    WNDCLASSW wc{};
+    wc.lpfnWndProc = dropTestProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = L"TintaTabDropTest";
+    RegisterClassW(&wc);
+    auto state = std::make_unique<App>();
+    App& app = *state;
+    app.hwnd = CreateWindowExW(0, wc.lpszClassName, L"Tab drop native tests", WS_POPUP,
+        -1200, 100, 1050, 900, nullptr, nullptr, wc.hInstance, nullptr);
+    if (!app.hwnd || !initD2D(app) || !createRenderTarget(app)) {
+        std::cerr << "Cannot initialize native tab-drop test window\n";
+        return 1;
+    }
+    SetWindowLongPtrW(app.hwnd, GWLP_USERDATA, (LONG_PTR)&app);
+    app.currentFile = paths[1];
+    tabsSeedSession(app, {paths[0], paths[1], paths[2]});
+    for (int theme : {0, 5}) {
+        applyTheme(app, theme);
+        for (float scale : {1.0f, 1.5f, 2.0f}) {
+            app.contentScale = scale;
+            updateTextFormats(app);
+            for (int width : {650, 1050}) {
+                app.width = (int)(width * scale);
+                app.height = (int)(900 * scale);
+                for (bool edit : {false, true}) {
+                    app.editMode = edit;
+                    app.editRailAnim = 1;
+                    const auto hits = renderTabs(app);
+                    check(hits.size() == 3, "all three existing tabs render");
+                    for (const auto& hit : hits) {
+                        const int middle = (int)((hit.rect.left + hit.rect.right) / 2);
+                        if (middle + 2 >= captionIslandLeft(app) ||
+                            (editorPreviewVisible(app) && middle + 2 >= editorPaneWidth(app))) continue;
+                        check(tabDropInsertionIndex(app, {middle-2, (LONG)dpi(app, 20)}) == hit.index,
+                              "left half inserts before the destination tab");
+                        check(tabDropInsertionIndex(app, {middle+2, (LONG)dpi(app, 20)}) == hit.index+1,
+                              "right half inserts after the destination tab");
+                    }
+                    check(tabDropInsertionIndex(app, {100, (LONG)chromeTopHeight(app)+20}) == 3,
+                          "content-area drops keep appending");
+                }
+            }
+        }
+    }
+    app.editMode = false;
+    app.width = 1050;
+    app.height = 900;
+    app.contentScale = 1;
+    updateTextFormats(app);
+    check(openDocumentInViewer(app, toWide(paths[1])), "active B document opens");
+    const std::wstring dirty = L"# Unsaved B\n\n| Keep | Value |\n| --- | --- |\n| Math | $x^2$ |\n";
+    restoreEditBuffer(app, dirty, true, 17.0f, 12);
+    auto sendAt = [&](const std::string& path, POINT client) {
+        POINT screen = client;
+        ClientToScreen(app.hwnd, &screen);
+        return tabSendDrop(app.hwnd, path, screen);
+    };
+    auto hits = renderTabs(app);
+    POINT gap{(LONG)((hits[0].rect.right+hits[1].rect.left)/2), 20};
+    check(sendAt(paths[3], gap), "positioned UTF-8 transfer is acknowledged via WM_COPYDATA");
+    check(app.tabs.size() == 4 && app.tabs[0].path == paths[0] && app.tabs[1].path == paths[3] &&
+          app.tabs[2].path == paths[1] && app.tabs[3].path == paths[2], "drop inserts A, Incoming, B, C");
+    check(app.activeTab == 1 && app.currentFile == paths[3], "incoming tab becomes active");
+    check(app.tabs[2].editorDirty && app.tabs[2].editorText == dirty && app.tabs[2].editorCursor == 12,
+          "insertion before active B parks its dirty buffer in B, not the incoming tab");
+    tabActivate(app, app.hwnd, 2);
+    check(app.editMode && app.editorDirty && app.editorText == dirty && app.editorCursorPos == 12,
+          "returning to B restores its unsaved text and cursor");
+    hits = renderTabs(app);
+    check(sendAt(paths[4], {(LONG)hits[0].rect.left+2, 20}), "drop before first tab succeeds");
+    check(app.tabs.front().path == paths[4] && app.activeTab == 0, "new tab can be first");
+    hits = renderTabs(app);
+    check(sendAt(paths[5], {(LONG)hits.back().rect.right+2, 20}), "drop after last tab succeeds");
+    check(app.tabs.back().path == paths[5] && app.activeTab == 5, "new tab can be last");
+    check(sendAt(paths[7], {900, 400}), "content drop succeeds");
+    check(app.tabs.back().path == paths[7] && app.activeTab == 6, "content drop still appends");
+    // Legacy launch messages append without interpreting the current cursor.
+    COPYDATASTRUCT legacy{1, (DWORD)paths[6].size()+1, paths[6].data()};
+    check(SendMessageW(app.hwnd, WM_COPYDATA, 0, (LPARAM)&legacy) != FALSE, "legacy path-only message accepted");
+    check(app.tabs.back().path == paths[6] && app.activeTab == 7, "ordinary launch still appends");
+    const auto count = app.tabs.size();
+    check(sendAt(paths[1], {42, 20}), "already-open path accepted");
+    check(app.tabs.size() == count && app.activeTab == 3 && app.editorDirty && app.editorText == dirty,
+          "duplicate drop activates the existing dirty tab without duplicating or moving it");
+    char malformed[] = "bad";
+    COPYDATASTRUCT invalid{2, 3, malformed};
+    check(!tabReceiveCopyData(app, app.hwnd, invalid), "truncated drop payload rejected");
+    invalid.dwData = 1;
+    check(!tabReceiveCopyData(app, app.hwnd, invalid), "unterminated path rejected");
+    invalid = {99, sizeof(malformed), malformed};
+    check(!tabReceiveCopyData(app, app.hwnd, invalid), "unknown message type rejected");
+    check(!tabSendDrop(nullptr, paths[0], {0, 0}), "unavailable recipient cannot acknowledge a transfer");
+    check(app.tabs.size() == count && app.editorText == dirty, "rejected transfers leave destination unchanged");
+
+    // Exercise the actual drag lifecycle, including its ghost, without
+    // injecting mouse input into any desktop window.
+    app.editMode = false;
+    app.editorDirty = false;
+    auto armDrag = [&]() {
+        app.currentFile = paths[3];
+        tabsSeedSession(app, {paths[0], paths[3], paths[2]});
+        const auto row = renderTabs(app);
+        int x = (int)((row[1].rect.left+row[1].rect.right)/2);
+        app.tabDragIndex = 1;
+        app.tabDragging = false;
+        app.tabDragStartX = x;
+        app.tabDragStartY = (int)dpi(app, 20);
+        return x;
+    };
+    for (float scale : {1.0f, 1.5f, 2.0f}) {
+        app.contentScale = scale;
+        app.width = (int)(1050*scale);
+        updateTextFormats(app);
+        const int x = armDrag();
+        const int edge = (int)chromeTopHeight(app);
+        tabDragMove(app, app.hwnd, x, edge+(int)dpi(app, 47));
+        check(!app.tabDragDetached, "staying near the tab bar does not detach");
+        tabDragMove(app, app.hwnd, x, edge+(int)dpi(app, 50));
+        check(app.tabDragDetached && app.tabGhostWnd, "about 50 pixels below the bar shows the drag ghost");
+        tabDragMove(app, app.hwnd, x, edge+(int)dpi(app, 10));
+        check(!app.tabDragDetached && !app.tabGhostWnd, "returning near the bar cancels detachment");
+        tabDragMove(app, app.hwnd, x, -(int)dpi(app, 50));
+        check(app.tabDragDetached, "about 50 pixels above the bar also detaches");
+        tabDragCancel(app, app.hwnd);
+        check(app.tabDragIndex == -1 && !app.tabGhostWnd && app.tabs.size() == 3,
+              "cancelling the drag keeps every tab and removes its ghost");
+    }
+    app.contentScale = 1;
+    app.width = 1050;
+    updateTextFormats(app);
+    const int detachX = armDrag();
+    // Put only our test window outside the virtual desktop. Making it
+    // visible there lets WindowFromPoint exercise the original snap-back
+    // bug while leaving the user's workspace and pointer alone.
+    SetWindowPos(app.hwnd, HWND_BOTTOM, GetSystemMetrics(SM_XVIRTUALSCREEN)-1600,
+        GetSystemMetrics(SM_YVIRTUALSCREEN)-1200, 1050, 900, SWP_NOACTIVATE|SWP_SHOWWINDOW);
+    const int detachY = (int)chromeTopHeight(app)+50;
+    POINT dropPoint{detachX, detachY};
+    ClientToScreen(app.hwnd, &dropPoint);
+    check(WindowFromPoint(dropPoint) == app.hwnd, "release point is over the source document, not outside its window");
+    fs::remove(dir / "launch-result.txt");
+    tabDragMove(app, app.hwnd, detachX, detachY);
+    tabDragEnd(app, app.hwnd, detachX, detachY);
+    const std::string expectedLaunch = std::to_string(dropPoint.x-120) + "\n" +
+        std::to_string(dropPoint.y-20) + "\n" + paths[3];
+    const auto deadline = GetTickCount64()+5000;
+    while (read(dir / "launch-result.txt") != expectedLaunch && GetTickCount64() < deadline) Sleep(10);
+    check(read(dir / "launch-result.txt") == expectedLaunch,
+          "releasing over the source content launches a positioned window with the Unicode path intact");
+    check(app.tabs.size() == 2 && app.tabs[0].path == paths[0] && app.tabs[1].path == paths[2],
+          "successful tear-off removes only the transferred tab");
+    ShowWindow(app.hwnd, SW_HIDE);
+    app.tabs.resize(1);
+    app.activeTab = 0;
+    app.forceTabStrip = false;
+    check(tabDropInsertionIndex(app, {45, 20}) == 1, "tabless destination keeps append behavior");
+    app.forceTabStrip = true;
+    hits = renderTabs(app);
+    check(tabDropInsertionIndex(app, {(LONG)hits[0].rect.left+2, 20}) == 0,
+          "single-tab satellite can accept insertion before its tab");
+    app.zenMode = true;
+    check(tabDropInsertionIndex(app, {45, 20}) == 1, "hidden zen strip has no insertion positions");
+    for (const auto& path : paths) check(read(fs::path(toWide(path))) == fixture, "document transfers do not modify Markdown on disk");
+    DestroyWindow(app.hwnd);
+    app.hwnd = nullptr;
+    state.reset();
+    CoUninitialize();
+    UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    std::cout << "Tab drops: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Dragging a window onto another window's tab strip always appended its document, because the transfer contained only a path. Include the pointer position and insert using the destination tab midpoints. Dropping between A and B now produces A, Incoming, B, C and activates Incoming, while preserving the destination's unsaved editor buffer.

Also let a tab pulled about 50 logical pixels away from the tab bar open as a separate window when released over its own document. Returning near the bar cancels detachment. Preserve Unicode paths in launch arguments and remove the source tab only after transfer acknowledgement or a successful process launch.

Validation: all-target Release build and all 15 CTest suites pass. Native tests cover positioned WM_COPYDATA, tab geometry across themes/scales/widths, unsaved buffers, and a real launch probe for release over the source document. Three mixed Markdown fixtures retain identical PNG pages, HTML and DOCX contents. The maintainer confirmed insertion manually; the tear-off refinement is covered by the native launch test. See `tests/tab-drop-position-validation.md` for coverage and limitations.

This PR is stacked on #209 to keep the current test build's Settings improvements. Its diff contains only the tab-drag changes; merge #209 first.
