### PR TITLE
Fix superscript rendering and editable Learn examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,13 +151,18 @@ if(BUILD_TESTING)
     # window, including layout-dependent character sequences (#195).
     set(INPUT_TEST_SOURCES ${SOURCES})
     list(REMOVE_ITEM INPUT_TEST_SOURCES src/main_d2d.cpp)
-    add_executable(input_tests tests/input_tests.cpp tests/tab_drop_tests.cpp ${INPUT_TEST_SOURCES})
+    add_executable(input_tests tests/input_tests.cpp tests/tab_drop_tests.cpp tests/superscript_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(input_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
     target_link_libraries(input_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
     target_compile_definitions(input_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
         TINTA_SHORTCUT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/shortcuts-layouts.md"
-        TINTA_TAB_DROP_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/tab-drop-position.md")
+        TINTA_TAB_DROP_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/tab-drop-position.md"
+        TINTA_SUPERSCRIPT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/superscript-subscript.md")
     add_test(NAME input_shortcuts COMMAND input_tests)
+    add_test(NAME superscript_and_learn COMMAND ${CMAKE_COMMAND}
+        -DTEST_BINARY=$<TARGET_FILE:input_tests>
+        -DTEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/superscript-test-$<CONFIG>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_superscript_tests.cmake)
     add_test(NAME tab_drop_position COMMAND ${CMAKE_COMMAND}
         -DTEST_BINARY=$<TARGET_FILE:input_tests>
         -DTEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/tab-drop-test-$<CONFIG>

--- a/include/app.h
+++ b/include/app.h
@@ -354,6 +354,7 @@ struct App {
     IDWriteFontFallback* fontFallback = nullptr;  // For emoji font fallback
     IDWriteTextAnalyzer* textAnalyzer = nullptr;  // UAX#14 line-break analysis
     IDWriteTextFormat* textFormat = nullptr;
+    IDWriteTextFormat* supSubFormat = nullptr;  // document font for ^sup^/~sub~
     IDWriteTextFormat* headingFormat = nullptr;
     IDWriteTextFormat* codeFormat = nullptr;
     IDWriteTextFormat* boldFormat = nullptr;
@@ -1210,7 +1211,6 @@ struct App {
     std::vector<EditAction> redoStack;
 
     // Editor text format (monospace)
-    IDWriteTextFormat* supSubFormat = nullptr;   // small size for ^sup^/~sub~
     IDWriteTextFormat* editorTextFormat = nullptr;
     float editorCharWidth = 0.0f; // Measured monospace char width
     // Slim in-editor line-number gutter (design t11)
@@ -1266,7 +1266,6 @@ struct App {
         if (tocFormat) { tocFormat->Release(); tocFormat = nullptr; }
         if (tocFormatBold) { tocFormatBold->Release(); tocFormatBold = nullptr; }
         if (statsFormat) { statsFormat->Release(); statsFormat = nullptr; }
-        if (supSubFormat) { supSubFormat->Release(); supSubFormat = nullptr; }
         if (editorTextFormat) { editorTextFormat->Release(); editorTextFormat = nullptr; }
         if (editorGutterFormat) { editorGutterFormat->Release(); editorGutterFormat = nullptr; }
         for (auto& fmt : themePreviewFormats) {
@@ -1314,6 +1313,7 @@ struct App {
         if (fontFallback) { fontFallback->Release(); fontFallback = nullptr; }
         if (textAnalyzer) { textAnalyzer->Release(); textAnalyzer = nullptr; }
         if (textFormat) { textFormat->Release(); textFormat = nullptr; }
+        if (supSubFormat) { supSubFormat->Release(); supSubFormat = nullptr; }
         if (headingFormat) { headingFormat->Release(); headingFormat = nullptr; }
         if (codeFormat) { codeFormat->Release(); codeFormat = nullptr; }
         if (boldFormat) { boldFormat->Release(); boldFormat = nullptr; }

--- a/include/startpage.h
+++ b/include/startpage.h
@@ -31,4 +31,4 @@ void startPageOpenEmbedded(App& app, HWND hwnd, int card);
 
 // The embedded sample document (the old bare-launch tutorial), still
 // used as the fallback when a requested file cannot be loaded
-const char* startPageSampleDoc();
+std::string startPageSampleDoc(const App& app);

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -921,6 +921,17 @@ void restoreEditBuffer(App& app, const std::wstring& text, bool dirty,
 
 void enterEditMode(App& app) {
     if (app.currentFile.empty()) {
+        if (app.startPageEmbeddedOpen) {
+            // Learn documents have no backing file. Edit an untitled copy;
+            // the first save asks for a path and the embedded original stays intact.
+            const std::string content = app.sourceText;
+            app.startPageEmbeddedOpen = false;
+            enterEditModeWithContent(app, content);
+            app.editorDirty = true;
+            editorReparse(app, true);
+            updateWindowTitle(app);
+            return;
+        }
         // Show brief "No file loaded" notification
         signalPushKey(app, SIG_WARN, SIGI_WARNING, "toast.no_file");
         InvalidateRect(app.hwnd, nullptr, FALSE);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -3523,7 +3523,9 @@ bool handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
             return false;
         }
         handleEditorKeyDown(app, hwnd, wParam);
-        return false;
+        // Save As runs a modal loop: Ctrl may already be released when it
+        // returns. Do not translate its original S into newly typed text (#206).
+        return ctrl && wParam == 'S';
     }
 
     // Folder browser path/name input captures the keyboard while active

--- a/src/startpage.cpp
+++ b/src/startpage.cpp
@@ -36,7 +36,7 @@ static const char* kSampleDocument = R"(# Welcome to Tinta
 
 - 10 beautiful themes — press **T** to choose
 - Native Mermaid flowchart rendering for `.mmd` files
-- Edit mode with live preview — press **:**
+- Edit mode with live preview — press **{{EDIT_KEY}}** to edit an untitled copy
 - Search — press **F**
 - Table of contents — press **Tab**
 - Text selection and copy
@@ -74,7 +74,7 @@ Press **?** at any time to see all shortcuts.
 
 ### Editing
 
-- **:** - Enter edit mode
+- **{{EDIT_KEY}}** - Enter edit mode
 - **Ctrl+S** - Save (in edit mode)
 - **ESC ESC** - Exit edit mode
 
@@ -110,7 +110,7 @@ sequenceDiagram
     participant Tinta
     You->>Tinta: Save the file
     Tinta-->>You: Re-renders instantly
-    You->>Tinta: Press : to edit
+    You->>Tinta: Press {{EDIT_KEY_PLAIN}} to edit
     Tinta-->>You: Live preview beside the text
 ```
 
@@ -145,8 +145,9 @@ as a diagram — no fences needed.
 
 static const char* kMarkdownBasics = R"(# Markdown basics
 
-Everything Tinta renders, in two minutes. Press **:** to open this file
-in the editor and watch the preview follow your keystrokes.
+Everything Tinta renders, in two minutes. Press **{{EDIT_KEY}}** to edit an
+untitled copy and watch the preview follow your keystrokes. Save it with
+**Ctrl+S** to a file of your own; the built-in example stays unchanged.
 
 ## Emphasis
 
@@ -198,7 +199,25 @@ ones offer to create the file.
 Inline $E = mc^2$ and block math render natively.
 )";
 
-const char* startPageSampleDoc() { return kSampleDocument; }
+static std::string embeddedContent(const App& app, const char* source) {
+    std::string content = source;
+    const std::string key = keyIniName(app.keymap[KA_EDIT]);
+    std::string markdownKey = key;
+    if (key.size() == 1 && std::string("\\`*_[]<>").find(key[0]) != std::string::npos)
+        markdownKey.insert(0, "\\");
+    const auto replace = [&](const std::string& marker, const std::string& value) {
+        size_t pos = 0;
+        while ((pos = content.find(marker, pos)) != std::string::npos) {
+            content.replace(pos, marker.size(), value);
+            pos += value.size();
+        }
+    };
+    replace("{{EDIT_KEY}}", markdownKey);
+    replace("{{EDIT_KEY_PLAIN}}", key);
+    return content;
+}
+
+std::string startPageSampleDoc(const App& app) { return embeddedContent(app, kSampleDocument); }
 
 // --- Small drawing helpers ----------------------------------------------
 
@@ -369,9 +388,9 @@ int startPageHitAt(const App& app, float x, float y) {
 }
 
 void startPageOpenEmbedded(App& app, HWND hwnd, int card) {
-    const char* content = card == 1   ? kMermaidTour
-                          : card == 2 ? kMarkdownBasics
-                                      : kSampleDocument;
+    const std::string content = embeddedContent(app, card == 1 ? kMermaidTour
+                                                   : card == 2 ? kMarkdownBasics
+                                                               : kSampleDocument);
     const char* titleKey = card == 1   ? "start.learn_mermaid"
                            : card == 2 ? "start.learn_md"
                                        : "start.learn_sample";

--- a/tests/fixtures/superscript-subscript.md
+++ b/tests/fixtures/superscript-subscript.md
@@ -1,0 +1,39 @@
+# Superscript x^2^ and subscript H~2~O
+
+Markdown scripts should use smaller text from the document font. Superscripts
+sit above the normal baseline; subscripts sit below it.
+
+Plain Markdown: x^2^ and H~2~O. Ordinary text: x2 and H2O.
+
+Unicode comparison: x² and H₂O. LaTeX comparison: $x^2$ and $H_2O$.
+
+Longer scripts: a^123^, a^word^, a~123~, and a~word~.
+
+## Mixed styles and links
+
+**Bold x^2^**, *italic H~2~O*, ~~struck x^2^~~, ==highlight==,
+and [linked x^2^](#mixed-styles-and-links). Inline code stays literal: `x^2^ H~2~O`.
+
+| Context | Superscript | Subscript | Math |
+| --- | --- | --- | --- |
+| Plain | x^2^ | H~2~O | $x^2$ |
+| Emphasis | **a^123^** | *a~word~* | $H_2O$ |
+
+> A quote with x^2^, H~2~O, **bold**, `code`, and $a+b=c$.
+>
+> This second paragraph must keep its normal spacing.
+
+- List item with x^2^ and H~2~O.
+- A [link](#mixed-styles-and-links), **bold**, and *italic* beside a^word^.
+
+### Smaller heading x^2^ and H~2~O
+
+```text
+x^2^ and H~2~O remain literal inside code fences.
+```
+
+$$
+\frac{x^2 + y^2}{H_2O}
+$$
+
+All surrounding content must remain visible, including this final paragraph.

--- a/tests/input_tests.cpp
+++ b/tests/input_tests.cpp
@@ -154,9 +154,11 @@ void settingsDismissal() {
 }
 
 int runTabDropTests();
+int runSuperscriptTests();
 int runTabDropLaunchProbe();
 
 int main(int argc, char** argv) {
+    if (argc == 2 && std::string(argv[1]) == "--superscript-tests") return runSuperscriptTests();
     if (argc == 2 && std::string(argv[1]) == "--tab-drop-tests") return runTabDropTests();
     if (argc == 7 && std::string(argv[1]) == "--cascade") return runTabDropLaunchProbe();
     settingsDismissal();

--- a/tests/render_superscript_fixtures.ps1
+++ b/tests/render_superscript_fixtures.ps1
@@ -1,0 +1,53 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/issue-206/fixed'
+)
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskOutput = Join-Path $taskRepo $Output
+$taskBinary = if ([IO.Path]::IsPathRooted($Binary)) { $Binary } else { Join-Path $taskRepo $Binary }
+New-Item -ItemType Directory -Force "$taskOutput/runner" | Out-Null
+$taskExe = Join-Path $taskOutput 'runner/tinta.exe'
+Copy-Item -LiteralPath $taskBinary -Destination $taskExe -Force
+@'
+[Settings]
+themeIndex=0
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+'@ | Set-Content -LiteralPath "$taskOutput/runner/settings.ini"
+foreach ($taskName in @('superscript-subscript','markdown-regression-control','tab-drop-position')) {
+    $taskSource = Join-Path $PSScriptRoot "fixtures/$taskName.md"
+    $taskBefore = (Get-FileHash -LiteralPath $taskSource).Hash
+    $taskDest = Join-Path $taskOutput $taskName
+    New-Item -ItemType Directory -Force $taskDest | Out-Null
+    foreach ($taskMode in @('printpages','exporthtml','exportdocx')) {
+        $taskTarget = switch ($taskMode) {
+            'printpages' { "$taskDest/pages" }
+            'exporthtml' { "$taskDest/document.html" }
+            'exportdocx' { "$taskDest/document.docx" }
+        }
+        $taskProcess = Start-Process -FilePath $taskExe -ArgumentList @('"'+$taskSource+'"',"--$taskMode",'"'+$taskTarget+'"') -WindowStyle Hidden -PassThru
+        if (!$taskProcess.WaitForExit(30000)) {
+            Stop-Process -Id $taskProcess.Id -Force
+            $taskProcess.WaitForExit()
+            throw "$taskName $taskMode timed out"
+        }
+        if ($taskProcess.ExitCode -ne 0 -or !(Test-Path -LiteralPath $taskTarget)) { throw "$taskName $taskMode failed" }
+    }
+    $taskHtml = Get-Content -LiteralPath "$taskDest/document.html" -Raw -Encoding UTF8
+    if ($taskHtml -notmatch '<blockquote' -or $taskHtml -notmatch '<table>' -or $taskHtml -notmatch '<h1') {
+        throw "$taskName lost mixed Markdown content"
+    }
+    if ($taskName -eq 'superscript-subscript' -and
+        ($taskHtml -notmatch '<sup>2</sup>' -or $taskHtml -notmatch '<sub>2</sub>' -or
+         [regex]::Matches($taskHtml,'class="math-(inline|display)"').Count -ne 6)) {
+        throw 'Script fixture lost a script or equation'
+    }
+    if ((Get-FileHash -LiteralPath $taskSource).Hash -ne $taskBefore) { throw "$taskName source changed" }
+    $taskPages = @(Get-ChildItem -LiteralPath "$taskDest/pages" -Filter 'page-*.png')
+    if (!$taskPages.Count) { throw "$taskName produced no print pages" }
+    "$taskName : $($taskPages.Count) native pages, HTML and DOCX"
+}

--- a/tests/run_superscript_tests.cmake
+++ b/tests/run_superscript_tests.cmake
@@ -1,0 +1,11 @@
+if(NOT DEFINED TEST_BINARY OR NOT DEFINED TEST_DIR)
+    message(FATAL_ERROR "TEST_BINARY and TEST_DIR are required")
+endif()
+file(MAKE_DIRECTORY "${TEST_DIR}")
+configure_file("${TEST_BINARY}" "${TEST_DIR}/input_tests.exe" COPYONLY)
+file(WRITE "${TEST_DIR}/settings.ini" "; Isolated superscript test configuration\n")
+execute_process(COMMAND "${TEST_DIR}/input_tests.exe" --superscript-tests
+    WORKING_DIRECTORY "${TEST_DIR}" RESULT_VARIABLE result)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Native superscript test failed: ${result}")
+endif()

--- a/tests/superscript-validation.md
+++ b/tests/superscript-validation.md
@@ -1,0 +1,67 @@
+# Issue #206 validation
+
+Validated on Windows on 2026-09-10. Reported by [@Ra0EL](https://github.com/Ra0EL)
+in [#206](https://github.com/oipoistar/tinta/issues/206).
+
+## Changes
+
+- Keep the superscript/subscript document format alive when overlay fonts refresh;
+  release it with the other document formats at shutdown. Existing theme fonts
+  and the existing 68% body-font sizing are retained; no font asset is added.
+- Open any Learn example in the editor as a dirty untitled copy. Normal Save As,
+  tab parking and unsaved-content confirmation apply; embedded originals remain intact.
+- Resolve example edit hints from the active keymap, escaping Markdown punctuation.
+- Consume the editor's Save shortcut before its native modal dialog can release
+  Ctrl and allow the original S to be translated into a stray editor character.
+
+## Automated checks
+
+`cmake --build build --config Release --parallel 6` and
+`ctest --test-dir build -C Release --output-on-failure`: **16/16 passed**.
+
+The new `superscript_and_learn` test uses real DirectWrite formats and layouts:
+
+- Paper and Midnight; 100%, 150%, 200% DPI scale; 80%, 100%, 150% zoom;
+  650 and 1050 logical-pixel widths (36 combinations).
+- Small font size, selected font family, overlay refresh lifetime, native body
+  baselines, script runs inside headings, tables, quotes, lists, emphasis and links.
+- Mixed fixture table, code fence, literal inline code and final paragraph.
+- All three Learn cards with Windows, Vim and custom F2 shortcuts; custom `*`
+  hint rendering; editor source, untitled title, tab round trips, close/Keep editing,
+  ordinary save writer, Save-key consumption, unchanged embedded originals.
+- Empty launcher remains unchanged; shutdown releases the script format.
+
+Tests run inside an isolated portable directory and never use the user's settings.
+
+## Native app and exports
+
+`tests/render_superscript_fixtures.ps1` renders `superscript-subscript.md`,
+`markdown-regression-control.md` and `tab-drop-position.md` through Tinta's
+native print-pages, HTML and DOCX commands. Each produced two PNG pages.
+
+Compared with the pre-fix executable at commit `4f18026`:
+
+- Both control documents: every PNG, HTML and DOCX is byte-identical.
+- Script fixture: page 1 changes where the scripts are repaired; page 2,
+  HTML and DOCX are byte-identical. All six equations and surrounding blocks remain.
+- Both script print pages were visually inspected.
+
+Computer Use verified the actual built application: Markdown basics displays
+raised/lowered small text and the E hint; E opens its source and preview as Untitled;
+Ctrl+S opens Save As; saving `out/issue-206/ui/Learn final.md` leaves the editor
+clean with no extra S. The resulting file contains the original example source.
+The mixed fixture was inspected in Paper at 1050px and Midnight at 650px,
+including its final display equation and paragraph. Native layout tests additionally
+cover both widths in both themes and the DPI/zoom combinations above.
+
+Artifacts are ignored under `out/issue-206/`; the runnable Markdown fixture and
+render script are tracked. The live test copies use isolated settings.
+
+## Scope limits
+
+Scripts nested inside `==highlight==` or `~~strikethrough~~` still have the existing
+parser limitation (inner delimiters remain literal). This change restores the
+font lifecycle and example editing; it does not rewrite nested extension parsing.
+The frontmatter property strip also uses this document small font and now retains
+its intended smaller size. Physical printer output and switching between actual
+monitors were not tested; native print output and simulated DPI layout were tested.

--- a/tests/superscript_tests.cpp
+++ b/tests/superscript_tests.cpp
@@ -1,0 +1,217 @@
+#include "d2d_init.h"
+#include "editor.h"
+#include "i18n.h"
+#include "input.h"
+#include "render.h"
+#include "settings.h"
+#include "startpage.h"
+#include "tabs.h"
+#include "utils.h"
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+std::string read(const std::filesystem::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return {(std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>()};
+}
+bool closeEnough(float a, float b) { return std::abs(a-b) < 0.05f; }
+void layout(App& app, const std::string& source) {
+    const auto doc = app.parser.parse(source);
+    check(doc.success, "script source parses");
+    app.root = doc.root;
+    layoutDocument(app);
+}
+const App::LayoutTextRun* runFor(const App& app, const std::wstring& text) {
+    for (const auto& run : app.layoutTextRuns)
+        if (run.docLength && app.docText.substr(run.docStart, run.docLength) == text) return &run;
+    return nullptr;
+}
+float baseline(const App::LayoutTextRun& run) {
+    UINT32 count = 0;
+    run.layout->GetLineMetrics(nullptr, 0, &count);
+    std::vector<DWRITE_LINE_METRICS> lines(count);
+    if (!count || FAILED(run.layout->GetLineMetrics(lines.data(), count, &count))) {
+        check(false, "DirectWrite supplies line metrics");
+        return 0;
+    }
+    return run.pos.y + lines.front().baseline;
+}
+void scriptLayout(App& app, const std::string& fixture) {
+    const float smallSize = 16.0f * app.contentScale * app.zoomFactor * 0.68f;
+    check(app.supSubFormat && closeEnough(app.supSubFormat->GetFontSize(), smallSize),
+          "document format refresh retains the small script font (#206)");
+    auto* original = app.supSubFormat;
+    updateOverlayFormats(app);
+    check(original && app.supSubFormat == original,
+          "overlay refresh cannot release the document script font");
+    if (app.supSubFormat) {
+        wchar_t font[256]{};
+        app.supSubFormat->GetFontFamilyName(font, 256);
+        check(std::wstring(font) == app.theme.fontFamily, "scripts use the selected document font");
+    }
+    for (const char* source : {
+        "base^SUP^ base~SUB~\n", "# base^SUP^ base~SUB~\n",
+        "### base^SUP^ base~SUB~\n", "> base^SUP^ base~SUB~\n",
+        "- base^SUP^ base~SUB~\n", "**base^SUP^** *base~SUB~*\n",
+        "[base^SUP^](#target) base~SUB~\n",
+        "| Header |\n| --- |\n| base^SUP^ base~SUB~ |\n"}) {
+        layout(app, source);
+        const auto* sup = runFor(app, L"SUP");
+        const auto* sub = runFor(app, L"SUB");
+        check(sup && sub, "both script runs survive the surrounding Markdown");
+        if (sup && sub) {
+            check(closeEnough(sup->layout->GetFontSize(), smallSize) && closeEnough(sub->layout->GetFontSize(), smallSize),
+                  "native heading, table, quote, list and nested runs use small text");
+            check(baseline(*sub) > baseline(*sup), "subscript is lower than superscript");
+        }
+    }
+    layout(app, "base^SUP^ base~SUB~\n");
+    const auto* normal = runFor(app, L"base");
+    const auto* sup = runFor(app, L"SUP");
+    const auto* sub = runFor(app, L"SUB");
+    check(normal && sup && sub, "baseline comparison contains all three runs");
+    if (normal && sup && sub) {
+        check(baseline(*sup) < baseline(*normal), "superscript rises above the normal baseline");
+        check(baseline(*sub) > baseline(*normal), "subscript falls below the normal baseline");
+    }
+    layout(app, fixture);
+    check(app.tableRects.size() == 1 && app.codeBlocks.size() == 1,
+          "mixed table and code fence remain intact");
+    check(app.docText.find(L"All surrounding content") != std::wstring::npos,
+          "mixed fixture renders through the final paragraph");
+    check(app.docText.find(L"x^2^ H~2~O") != std::wstring::npos,
+          "inline code keeps script delimiters literal");
+}
+void learnCopies(App& app, const std::filesystem::path& dir) {
+    for (const char* profile : {"windows", "vim", "custom"}) {
+        Settings settings;
+        settings.keyProfile = profile;
+        settings.keyOverrides = {{"edit", "F2"}};
+        applyKeymap(app, settings);
+        const std::string label = toUtf8(keyLabel(app.keymap[KA_EDIT]));
+        for (int card = 0; card < 3; ++card) {
+            tabBecomeStartPage(app, app.hwnd);
+            startPageOpenEmbedded(app, app.hwnd, card);
+            const std::string original = app.sourceText;
+            const std::string hint = card == 1 ? "Press " + label + " to edit" : "**" + label + "**";
+            check(original.find(hint) != std::string::npos && original.find("{{EDIT_KEY}}") == std::string::npos,
+                  "Learn edit hint matches Windows, Vim and custom keymaps");
+            const auto key = app.keymap[KA_EDIT];
+            if (key.isChar) handleCharInput(app, app.hwnd, key.key);
+            else handleKeyDown(app, app.hwnd, key.key);
+            check(app.editMode && app.editorDirty && app.currentFile.empty() && !app.startPageEmbeddedOpen,
+                  "the configured shortcut opens an unsaved untitled Learn copy");
+            check(toUtf8(app.editorText) == original, "editable source matches the displayed example");
+            wchar_t title[256]{};
+            GetWindowTextW(app.hwnd, title, 256);
+            check(std::wstring(title).find(tr(app, "title.untitled")) != std::wstring::npos,
+                  "Learn copy uses the untitled window title");
+            editorReplaceRangeExternal(app, app.editorText.size(), app.editorText.size(), L"\nMy change: z^3^.\n");
+            const std::wstring edited = app.editorText;
+            const int copyTab = app.activeTab;
+            tabOpenStartPage(app, app.hwnd);
+            tabActivate(app, app.hwnd, copyTab);
+            check(app.editMode && app.editorDirty && app.editorText == edited,
+                  "switching tabs preserves the unsaved Learn copy");
+            tabCloseIndex(app, app.hwnd, copyTab);
+            check(app.confirmExitPending && app.pendingTabClose == copyTab,
+                  "closing a Learn copy asks about its unsaved content");
+            confirmExitAction(app, app.hwnd, 3);
+            check(app.editMode && app.editorText == edited && !app.confirmExitPending,
+                  "Keep editing retains the entire Learn copy");
+
+            // Supply the path a Save As selection would return; do not open
+            // a native modal dialog in the unattended test executable.
+            const auto saved = dir / (std::string(profile) + "-learn-" + std::to_string(card) + ".md");
+            app.currentFile = toUtf8(saved.wstring());
+            saveEditorFile(app, app.hwnd);
+            check(!app.editorDirty && read(saved) == toUtf8(edited), "Learn copy saves through the normal file writer");
+            BYTE previousKeys[256]{};
+            GetKeyboardState(previousKeys);
+            BYTE saveKeys[256]{};
+            saveKeys[VK_CONTROL] = 0x80;
+            SetKeyboardState(saveKeys);
+            const bool consumed = handleKeyDown(app, app.hwnd, 'S');
+            SetKeyboardState(previousKeys);
+            check(consumed, "Save consumes S before a released Ctrl can turn it into editor text");
+            if (!consumed) handleCharInput(app, app.hwnd, 's');
+            check(!app.editorDirty && app.editorText == edited, "saving cannot append a stray shortcut character");
+            exitEditMode(app);
+            tabBecomeStartPage(app, app.hwnd);
+            startPageOpenEmbedded(app, app.hwnd, card);
+            check(app.sourceText == original, "reopening Learn preserves its embedded original");
+        }
+    }
+    Settings punctuation;
+    punctuation.keyProfile = "custom";
+    punctuation.keyOverrides = {{"edit", "*"}};
+    applyKeymap(app, punctuation);
+    tabBecomeStartPage(app, app.hwnd);
+    startPageOpenEmbedded(app, app.hwnd, 2);
+    layoutDocument(app);
+    check(app.docText.find(L"Press * to edit") != std::wstring::npos,
+          "custom punctuation shortcut cannot become Markdown formatting");
+    tabBecomeStartPage(app, app.hwnd);
+    enterEditMode(app);
+    check(!app.editMode && startPageActive(app), "empty launcher still has no example to edit");
+}
+}
+
+int runSuperscriptTests() {
+    namespace fs = std::filesystem;
+    wchar_t exe[MAX_PATH]{};
+    GetModuleFileNameW(nullptr, exe, MAX_PATH);
+    const auto dir = fs::path(exe).parent_path();
+    const auto settings = read(dir / "settings.ini");
+    if (!fs::equivalent(dir, fs::current_path()) ||
+        (settings != "; Isolated superscript test configuration\n" &&
+         settings != "; Isolated superscript test configuration\r\n")) {
+        std::cerr << "Run through CTest's isolated superscript wrapper\n";
+        return 2;
+    }
+    check(fs::equivalent(tintaConfigDir(), dir), "test persistence stays in its portable directory");
+    const auto fixture = read(TINTA_SUPERSCRIPT_FIXTURE);
+    check(!fixture.empty(), "mixed script fixture loads");
+    {
+        auto state = std::make_unique<App>();
+        App& app = *state;
+        app.hwnd = CreateWindowExW(0, L"STATIC", L"Superscript tests", WS_POPUP,
+            0, 0, 1050, 900, nullptr, nullptr, GetModuleHandleW(nullptr), nullptr);
+        if (!app.hwnd || !initD2D(app)) return 2;
+        app.readingWidthPct = 100;
+        for (int theme : {0, 5}) {
+            applyTheme(app, theme);
+            for (float scale : {1.0f, 1.5f, 2.0f}) {
+                app.contentScale = scale;
+                for (float zoom : {0.8f, 1.0f, 1.5f}) {
+                    app.zoomFactor = zoom;
+                    updateTextFormats(app);
+                    for (int width : {650, 1050}) {
+                        app.width = static_cast<int>(width * scale);
+                        app.height = static_cast<int>(900 * scale);
+                        scriptLayout(app, fixture);
+                    }
+                }
+            }
+        }
+        app.contentScale = app.zoomFactor = 1;
+        updateTextFormats(app);
+        learnCopies(app, dir);
+        DestroyWindow(app.hwnd);
+        app.hwnd = nullptr;
+        app.shutdown();
+        check(!app.supSubFormat, "shutdown releases the document script font");
+    }
+    CoUninitialize();
+    std::cout << "Superscripts and Learn copies: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Superscript such as `x^2^` rendered at the normal baseline because overlay-font
cleanup released the document's small script font immediately after creation.
Keep that format with document resources so superscripts and subscripts render
at their intended size after startup, theme changes, zoom and DPI updates.

Learn examples now open in the editor as unsaved untitled copies, with edit hints
derived from the selected keymap. Saving uses the existing Save As flow and
preserves the embedded original. Consume the Save shortcut so closing its modal
dialog cannot insert a stray `s` into the copy.

Reported by @Ra0EL. Fixes #206. No additional font is bundled.

Validation: Release build and 16/16 CTests passed, including real DirectWrite
lifetime/baseline checks across two themes, three DPI scales, three zoom levels
and two widths. Native tests cover all three Learn cards, keymaps, tab parking,
unsaved close, saving and unchanged originals. Computer Use verified Learn → Edit
→ Save As with a clean saved copy, and mixed Markdown at normal/narrow widths.
Native PNG/HTML/DOCX controls remain byte-identical; only the expected script
print page changes. Details: `tests/superscript-validation.md`.

Existing script nesting limitations inside highlights/strikethrough remain out
of scope. This PR is stacked on #211 (`tab-drop-position`), which is stacked on #209.
