### PR TITLE
Support H1-H6 Contents and resizable, cleaner side panels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SOURCES
     src/render.cpp
     src/file_utils.cpp
     src/overlays.cpp
+    src/sidepanels.cpp
     src/context_menu.cpp
     src/input.cpp
     src/editor.cpp
@@ -151,14 +152,19 @@ if(BUILD_TESTING)
     # window, including layout-dependent character sequences (#195).
     set(INPUT_TEST_SOURCES ${SOURCES})
     list(REMOVE_ITEM INPUT_TEST_SOURCES src/main_d2d.cpp)
-    add_executable(input_tests tests/input_tests.cpp tests/tab_drop_tests.cpp tests/superscript_tests.cpp ${INPUT_TEST_SOURCES})
+    add_executable(input_tests tests/input_tests.cpp tests/tab_drop_tests.cpp tests/superscript_tests.cpp tests/sidepanel_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(input_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
     target_link_libraries(input_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
     target_compile_definitions(input_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
         TINTA_SHORTCUT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/shortcuts-layouts.md"
         TINTA_TAB_DROP_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/tab-drop-position.md"
-        TINTA_SUPERSCRIPT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/superscript-subscript.md")
+        TINTA_SUPERSCRIPT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/superscript-subscript.md"
+        TINTA_PANEL_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/toc-browser-resize.md")
     add_test(NAME input_shortcuts COMMAND input_tests)
+    add_test(NAME contents_and_panel_resize COMMAND ${CMAKE_COMMAND}
+        -DTEST_BINARY=$<TARGET_FILE:input_tests>
+        -DTEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/sidepanel-test-$<CONFIG>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_sidepanel_tests.cmake)
     add_test(NAME superscript_and_learn COMMAND ${CMAKE_COMMAND}
         -DTEST_BINARY=$<TARGET_FILE:input_tests>
         -DTEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/superscript-test-$<CONFIG>

--- a/include/app.h
+++ b/include/app.h
@@ -18,6 +18,8 @@
 #include <chrono>
 #include <utility>
 #include <optional>
+#include <algorithm>
+#include <cmath>
 
 #include "markdown.h"
 #include "keymap.h"
@@ -158,6 +160,8 @@ int saveCustomTheme(const D2DTheme& t, const std::wstring& name,
                     const std::wstring& headingFontFamily = L"");
 
 // Persistent settings
+enum class SidePanel { None, Contents, Browser };
+
 struct Settings {
     int themeIndex = 5;          // Default to Midnight
     float zoomFactor = 1.0f;
@@ -205,6 +209,8 @@ struct Settings {
     // document clicks and hands the keyboard back to the document
     bool tocPinned = false;
     bool browserPinned = false;
+    float tocWidth = 280.0f;      // preferred logical pixels, independent of zoom
+    float browserWidth = 300.0f;
     // UI language id ("auto" follows the Windows display language; else a
     // registry id like "en"/"zh"/"de" — see i18n.h). Persisted as a string
     // because languages.ini languages have no stable numeric index.
@@ -730,6 +736,7 @@ struct App {
         // from documentViewportWidth, which in edit mode is the preview
         // pane — printing from the editor wrapped at half the page (#81)
         bool editMode = false;
+        bool showToc = false, showFolderBrowser = false;
     };
     bool showPrintPreview = false;
     PrintSavedView printSaved;
@@ -760,6 +767,13 @@ struct App {
     // the document keeps hover, selection, and the keyboard
     bool tocPinned = false;
     bool browserPinned = false;
+    float tocWidth = 280.0f;
+    float browserWidth = 300.0f;
+    struct PanelResize {
+        SidePanel panel = SidePanel::None;
+        float startX = 0, startWidth = 0;
+        float oldTocWidth = 0, oldBrowserWidth = 0;
+    } panelResize;
     float tocAnimation = 0.0f;  // 0 to 1 slide-in from the chosen side
     // A clicked heading stays the active row even when the scroll cannot
     // reach it (short documents); any real scroll hands back to the spy
@@ -1375,25 +1389,39 @@ inline float chromeTopHeight(const App& app) {
     return dpi(app, 40.0f);
 }
 
-inline float folderBrowserPanelWidth(const App& app) {
-    float cap = dpi(app, 300.0f);
-    float floor_ = dpi(app, 250.0f);
-    float w = app.width * 0.2f;
-    if (w < floor_) w = floor_;
-    if (w > cap) w = cap;
-    return w;
+inline float sidePanelBudget(const App& app) {
+    const float width = std::max(0.0f, static_cast<float>(app.width));
+    return width - std::min(dpi(app, 240.0f), width * 0.4f);
 }
 
-// TOC panel width — shared by input hit-testing, the panel renderer, and
-// the viewport shift
-inline float tocPanelWidth(const App& app) {
-    float cap = dpi(app, 280.0f);
-    float floor_ = dpi(app, 220.0f);
-    float w = app.width * 0.2f;
-    if (w < floor_) w = floor_;
-    if (w > cap) w = cap;
-    return w;
+struct SidePanelWidths { float toc = 0, browser = 0; };
+
+// Clamp the displayed widths together, without changing saved preferences
+// when a window shrinks. Keep room for the document even with both panels open.
+inline SidePanelWidths sidePanelWidths(const App& app) {
+    const float minToc = app.showToc ? dpi(app, 180.0f) : 0;
+    const float minBrowser = app.showFolderBrowser ? dpi(app, 200.0f) : 0;
+    SidePanelWidths widths{
+        app.showToc ? dpi(app, std::clamp(std::isfinite(app.tocWidth) ? app.tocWidth : 280.0f, 180.0f, 4000.0f)) : 0,
+        app.showFolderBrowser ? dpi(app, std::clamp(std::isfinite(app.browserWidth) ? app.browserWidth : 300.0f, 200.0f, 4000.0f)) : 0};
+    const float budget = sidePanelBudget(app);
+    if (widths.toc + widths.browser > budget) {
+        const float minimum = minToc + minBrowser;
+        if (budget <= minimum) {
+            const float ratio = minimum > 0 ? budget / minimum : 0;
+            widths = {minToc * ratio, minBrowser * ratio};
+        } else {
+            const float extra = widths.toc + widths.browser - minimum;
+            const float ratio = (budget - minimum) / extra;
+            widths = {minToc + (widths.toc - minToc) * ratio,
+                      minBrowser + (widths.browser - minBrowser) * ratio};
+        }
+    }
+    return widths;
 }
+
+inline float folderBrowserPanelWidth(const App& app) { return sidePanelWidths(app).browser; }
+inline float tocPanelWidth(const App& app) { return sidePanelWidths(app).toc; }
 
 inline float documentViewportX(const App& app) {
     if (!app.editMode) {

--- a/include/app.h
+++ b/include/app.h
@@ -807,6 +807,12 @@ struct App {
     float scrollbarDragStartScroll = 0;
     ULONGLONG lastPanelScrollActivity = 0;
     float panelObservedScrollX = 0, panelObservedScrollY = 0;
+    struct ScrollbarFade {
+        float opacity = 0, from = 0, target = 0;
+        ULONGLONG started = 0;
+        bool running = false;
+    } panelScrollbarFade;
+    bool panelScrollbarTimerActive = false;
 
     // Horizontal scrollbar
     bool hScrollbarHovered = false;

--- a/include/app.h
+++ b/include/app.h
@@ -41,6 +41,7 @@ inline int64_t usElapsed(Clock::time_point start) {
 #define TIMER_SELECT_SCROLL 8
 #define TIMER_LINK_PEEK 9
 #define TIMER_UPDATE_CHECK 10
+#define TIMER_SIDE_PANEL_SCROLLBARS 12
 
 // Posted to continue an incomplete document layout in time-budgeted chunks
 #define WM_APP_LAYOUT_CHUNK (WM_APP + 1)
@@ -804,6 +805,8 @@ struct App {
     float scrollbarContentHeight = 0.0f;
     float scrollbarDragStartY = 0;
     float scrollbarDragStartScroll = 0;
+    ULONGLONG lastPanelScrollActivity = 0;
+    float panelObservedScrollX = 0, panelObservedScrollY = 0;
 
     // Horizontal scrollbar
     bool hScrollbarHovered = false;

--- a/include/input.h
+++ b/include/input.h
@@ -9,6 +9,7 @@ void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam);
 void handleMouseMove(App& app, HWND hwnd, LPARAM lParam);
 void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam);
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam);
+void cancelDocumentScrollbarDrag(App& app, HWND hwnd);
 // True consumes this keystroke's character translation as well (#195).
 bool handleKeyDown(App& app, HWND hwnd, WPARAM wParam);
 void handleContextMenu(App& app, HWND hwnd, LPARAM lParam);

--- a/include/overlays.h
+++ b/include/overlays.h
@@ -48,6 +48,10 @@ float tocPanelX(const App& app, float panelWidth);
 // Heading index under a point in the floating Contents card, or -1 -
 // clicks hit-test their own coordinates (#114 pattern)
 int tocItemIndexAt(App& app, float x, float y);
+// The row viewport and indentation are shared with wheel handling and tests.
+D2D1_RECT_F tocListRect(const App& app);
+float tocHeadingIndent(const App& app, int level);
+float tocMaxScroll(const App& app);
 
 // Shared geometry for the floating file-browser card (t13 design 13b):
 // one source of truth for render, cursor, and click hit-tests

--- a/include/sidepanels.h
+++ b/include/sidepanels.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "app.h"
+
+SidePanel sidePanelResizeAt(const App& app, float x, float y);
+float sidePanelResizeEdge(const App& app, SidePanel panel);
+bool sidePanelResizeBegin(App& app, HWND hwnd, float x, float y);
+void sidePanelResizeMove(App& app, float x);
+void sidePanelResizeEnd(App& app, HWND hwnd, bool cancel);
+void renderSidePanelResizeGrip(App& app, SidePanel panel);

--- a/include/sidepanels.h
+++ b/include/sidepanels.h
@@ -9,4 +9,5 @@ void sidePanelResizeMove(App& app, float x);
 void sidePanelResizeEnd(App& app, HWND hwnd, bool cancel);
 void renderSidePanelResizeGrip(App& app, SidePanel panel);
 bool documentScrollbarEdgeHovered(const App& app);
-float sidePanelDocumentScrollbarOpacity(const App& app, ULONGLONG now);
+float sidePanelDocumentScrollbarOpacity(App& app, ULONGLONG now);
+bool sidePanelScrollbarNeedsTicks(const App& app, ULONGLONG now);

--- a/include/sidepanels.h
+++ b/include/sidepanels.h
@@ -8,3 +8,5 @@ bool sidePanelResizeBegin(App& app, HWND hwnd, float x, float y);
 void sidePanelResizeMove(App& app, float x);
 void sidePanelResizeEnd(App& app, HWND hwnd, bool cancel);
 void renderSidePanelResizeGrip(App& app, SidePanel panel);
+bool documentScrollbarEdgeHovered(const App& app);
+float sidePanelDocumentScrollbarOpacity(const App& app, ULONGLONG now);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -13,6 +13,7 @@
 #include "settings.h"
 #include "render.h"
 #include "overlays.h"
+#include "sidepanels.h"
 #include "signals.h"
 #include "tableedit.h"
 #include "pandoc.h"
@@ -870,11 +871,7 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
         float panelX = tocPanelX(app, panelWidth);
         if (app.mouseX >= panelX && app.mouseX <= panelX + panelWidth) {
             app.tocScroll -= delta * dpi(app, 60.0f);
-            float itemHeight = dpi(app, 28.0f);
-            float headerHeight = dpi(app, 48.0f);
-            float listHeight = app.height - headerHeight - dpi(app, 20.0f);
-            float totalItemsHeight = app.headings.size() * itemHeight;
-            float maxScroll = std::max(0.0f, totalItemsHeight - listHeight);
+            float maxScroll = tocMaxScroll(app);
             app.tocScroll = std::max(0.0f, std::min(app.tocScroll, maxScroll));
             InvalidateRect(hwnd, nullptr, FALSE);
             return;
@@ -919,6 +916,12 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     bool mouseMoved = app.mouseX != GET_X_LPARAM(lParam) || app.mouseY != GET_Y_LPARAM(lParam);
     app.mouseX = GET_X_LPARAM(lParam);
     app.mouseY = GET_Y_LPARAM(lParam);
+
+    if (app.panelResize.panel != SidePanel::None) {
+        sidePanelResizeMove(app, static_cast<float>(app.mouseX));
+        SetCursor(cursorSizeWE);
+        return;
+    }
 
     bool iconHover = appMenuButtonAt(app, (float)app.mouseX, (float)app.mouseY);
     if (iconHover != app.appMenuHover) {
@@ -1109,6 +1112,12 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         } else {
             setSearchCursor(app, (float)app.mouseX, (float)app.mouseY);
         }
+        return;
+    }
+
+    if (sidePanelResizeAt(app, static_cast<float>(app.mouseX), static_cast<float>(app.mouseY)) != SidePanel::None) {
+        SetCursor(cursorSizeWE);
+        if (mouseMoved) InvalidateRect(hwnd, nullptr, FALSE);
         return;
     }
 
@@ -1885,6 +1894,9 @@ void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     // The chooser acts on release; do not place an editor caret under it.
     if (app.showThemeChooser) return;
 
+    if (sidePanelResizeBegin(app, hwnd, static_cast<float>(GET_X_LPARAM(lParam)),
+                            static_cast<float>(GET_Y_LPARAM(lParam)))) return;
+
     // Edit mode: route to editor or preview
     if (app.editMode) {
         int x = GET_X_LPARAM(lParam);
@@ -2600,6 +2612,11 @@ static void toggleFitBlock(App& app, HWND hwnd, unsigned key) {
 }
 
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    if (app.panelResize.panel != SidePanel::None) {
+        sidePanelResizeMove(app, static_cast<float>(GET_X_LPARAM(lParam)));
+        sidePanelResizeEnd(app, hwnd, false);
+        return;  // the release must not select a heading or dismiss a panel
+    }
     // A tab drag ends on release (its press already consumed the click)
     if (app.tabDragIndex >= 0) {
         tabDragEnd(app, hwnd, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
@@ -3281,6 +3298,10 @@ static void toggleZenMode(App& app, HWND hwnd) {
 }
 
 bool handleKeyDown(App& app, HWND hwnd, WPARAM wParam) {
+    if (app.panelResize.panel != SidePanel::None) {
+        if (wParam == VK_ESCAPE) sidePanelResizeEnd(app, hwnd, true);
+        return true;
+    }
     float pageSize = app.height * 0.8f;
     float maxScroll = std::max(0.0f, app.contentHeight - app.height);
     bool ctrl = (GetKeyState(VK_CONTROL) & 0x8000) != 0;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -912,6 +912,53 @@ void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     InvalidateRect(hwnd, nullptr, FALSE);
 }
 
+static bool moveDocumentScrollbarDrag(App& app, HWND hwnd) {
+    if (!app.scrollbarDragging && !app.hScrollbarDragging) return false;
+    // Mouse capture owns this gesture across panels, title bars and window
+    // edges. Hover routing must never intercept movement during the drag.
+    SetCursor(cursorArrow);
+    if (app.scrollbarDragging) {
+        const float maxScroll = std::max(0.0f, app.contentHeight - app.height);
+        if (maxScroll > 0 && app.contentHeight > app.height) {
+            const float sbHeight = std::max((float)app.height / app.contentHeight * app.height, 30.0f);
+            const float trackHeight = app.height - sbHeight;
+            if (trackHeight > 0) {
+                const float deltaY = (float)app.mouseY - app.scrollbarDragStartY;
+                app.scrollY = std::clamp(app.scrollbarDragStartScroll + deltaY / trackHeight * maxScroll, 0.0f, maxScroll);
+                app.targetScrollY = app.scrollY;
+            }
+        }
+    } else {
+        const float viewportWidth = documentViewportWidth(app);
+        const float maxScroll = std::max(0.0f, app.contentWidth - viewportWidth);
+        if (maxScroll > 0 && app.contentWidth > viewportWidth) {
+            const float sbWidth = std::max(viewportWidth / app.contentWidth * viewportWidth, 30.0f);
+            const float trackWidth = viewportWidth - sbWidth;
+            if (trackWidth > 0) {
+                const float deltaX = (float)app.mouseX - app.hScrollbarDragStartX;
+                app.scrollX = std::clamp(app.hScrollbarDragStartScroll + deltaX / trackWidth * maxScroll, 0.0f, maxScroll);
+                app.targetScrollX = app.scrollX;
+            }
+        }
+    }
+    InvalidateRect(hwnd, nullptr, FALSE);
+    return true;
+}
+
+static void endDocumentScrollbarDrag(App& app, HWND hwnd, bool cancel) {
+    if (!app.scrollbarDragging && !app.hScrollbarDragging) return;
+    app.scrollbarDragging = app.hScrollbarDragging = false;
+    app.mouseDown = app.selecting = false;
+    app.swallowNextMouseUp = cancel;
+    // Clear state before ReleaseCapture synchronously sends WM_CAPTURECHANGED.
+    if (GetCapture() == hwnd) ReleaseCapture();
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
+void cancelDocumentScrollbarDrag(App& app, HWND hwnd) {
+    endDocumentScrollbarDrag(app, hwnd, true);
+}
+
 void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     bool mouseMoved = app.mouseX != GET_X_LPARAM(lParam) || app.mouseY != GET_Y_LPARAM(lParam);
     app.mouseX = GET_X_LPARAM(lParam);
@@ -928,6 +975,8 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
         SetCursor(cursorSizeWE);
         return;
     }
+
+    if (moveDocumentScrollbarDrag(app, hwnd)) return;
 
     bool iconHover = appMenuButtonAt(app, (float)app.mouseX, (float)app.mouseY);
     if (iconHover != app.appMenuHover) {
@@ -1269,43 +1318,6 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
             app.selFocus = off;
         }
         InvalidateRect(hwnd, nullptr, FALSE);
-        return;
-    }
-
-    // Vertical scrollbar dragging
-    if (app.scrollbarDragging) {
-        float maxScroll = std::max(0.0f, app.contentHeight - app.height);
-        if (maxScroll > 0 && app.contentHeight > app.height) {
-            float sbHeight = (float)app.height / app.contentHeight * app.height;
-            sbHeight = std::max(sbHeight, 30.0f);
-            float trackHeight = app.height - sbHeight;
-
-            float deltaY = (float)app.mouseY - app.scrollbarDragStartY;
-            float scrollDelta = (deltaY / trackHeight) * maxScroll;
-            app.scrollY = app.scrollbarDragStartScroll + scrollDelta;
-            app.scrollY = std::max(0.0f, std::min(app.scrollY, maxScroll));
-            app.targetScrollY = app.scrollY;
-            InvalidateRect(hwnd, nullptr, FALSE);
-        }
-        return;
-    }
-
-    // Horizontal scrollbar dragging
-    if (app.hScrollbarDragging) {
-        float viewportWidth = documentViewportWidth(app);
-        float maxScroll = std::max(0.0f, app.contentWidth - viewportWidth);
-        if (maxScroll > 0 && app.contentWidth > viewportWidth) {
-            float sbWidth = viewportWidth / app.contentWidth * viewportWidth;
-            sbWidth = std::max(sbWidth, 30.0f);
-            float trackWidth = viewportWidth - sbWidth;
-
-            float deltaX = (float)app.mouseX - app.hScrollbarDragStartX;
-            float scrollDelta = (deltaX / trackWidth) * maxScroll;
-            app.scrollX = app.hScrollbarDragStartScroll + scrollDelta;
-            app.scrollX = std::max(0.0f, std::min(app.scrollX, maxScroll));
-            app.targetScrollX = app.scrollX;
-            InvalidateRect(hwnd, nullptr, FALSE);
-        }
         return;
     }
 
@@ -1738,6 +1750,8 @@ static void toggleApplicationMenu(App& app, HWND hwnd, bool keyboard = false) {
 }
 
 void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    // A fresh press is a new gesture, even if a cancelled drag released elsewhere.
+    app.swallowNextMouseUp = false;
     // Settings owns the entire click, including the title strip behind it.
     // Sliders drag from the press; dismissal and other actions use release.
     if (app.showSettings) {
@@ -2618,6 +2632,13 @@ static void toggleFitBlock(App& app, HWND hwnd, unsigned key) {
 }
 
 void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+    if (app.scrollbarDragging || app.hScrollbarDragging) {
+        app.mouseX = GET_X_LPARAM(lParam);
+        app.mouseY = GET_Y_LPARAM(lParam);
+        moveDocumentScrollbarDrag(app, hwnd);
+        endDocumentScrollbarDrag(app, hwnd, false);
+        return;  // releasing over a panel must not activate its controls
+    }
     if (app.panelResize.panel != SidePanel::None) {
         sidePanelResizeMove(app, static_cast<float>(GET_X_LPARAM(lParam)));
         sidePanelResizeEnd(app, hwnd, false);
@@ -2907,18 +2928,6 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     }
 
     ReleaseCapture();
-
-    // A scrollbar drag ends at this release no matter where it lands -
-    // the panel branches below must not run first and leave the drag
-    // latched, which bound the scroll to plain mouse movement
-    if (app.scrollbarDragging || app.hScrollbarDragging) {
-        app.scrollbarDragging = false;
-        app.hScrollbarDragging = false;
-        app.mouseDown = false;
-        app.selecting = false;
-        InvalidateRect(hwnd, nullptr, FALSE);
-        return;
-    }
 
     // TOC click handling
     if (app.showToc) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -917,6 +917,12 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     app.mouseX = GET_X_LPARAM(lParam);
     app.mouseY = GET_Y_LPARAM(lParam);
 
+    if (app.showToc || app.showFolderBrowser) {
+        TRACKMOUSEEVENT tracking{sizeof(tracking), TME_LEAVE, hwnd, 0};
+        TrackMouseEvent(&tracking);
+        if (mouseMoved) InvalidateRect(hwnd, nullptr, FALSE);
+    }
+
     if (app.panelResize.panel != SidePanel::None) {
         sidePanelResizeMove(app, static_cast<float>(app.mouseX));
         SetCursor(cursorSizeWE);

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -27,6 +27,7 @@
 #include "render.h"
 #include "file_utils.h"
 #include "overlays.h"
+#include "sidepanels.h"
 #include "annotations.h"
 #include "drafts.h"
 #include "signals.h"
@@ -1268,6 +1269,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             break;
 
         case WM_KILLFOCUS:
+            if (app) sidePanelResizeEnd(*app, hwnd, true);
             if (app && app->showContextMenu) {
                 closeContextMenu(*app);
                 InvalidateRect(hwnd, nullptr, FALSE);
@@ -1384,6 +1386,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case WM_SIZE:
             if (app && app->d2dFactory) {
+                sidePanelResizeEnd(*app, hwnd, true);
                 closeContextMenu(*app);  // its anchor belongs to the old viewport
                 // The preview's geometry is stale after a resize: restore
                 // the document at the new size and close the overlay
@@ -1421,6 +1424,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case WM_DPICHANGED:
             if (app) {
+                sidePanelResizeEnd(*app, hwnd, true);
                 if (app->showPrintPreview) closePrintPreview(*app, hwnd);
                 UINT dpi = HIWORD(wParam);
                 app->contentScale = dpi / 96.0f;
@@ -1493,12 +1497,17 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             break;
 
         case WM_CAPTURECHANGED:
+            if (app && (HWND)lParam != hwnd) sidePanelResizeEnd(*app, hwnd, true);
             // Losing capture mid tab-drag (Alt+Tab, a popup stealing the
             // mouse) aborts the drag instead of leaving a stray ghost
             if (app && app->tabDragIndex >= 0 && (HWND)lParam != hwnd) {
                 tabDragCancel(*app, hwnd);
             }
             return 0;
+
+        case WM_CANCELMODE:
+            if (app) sidePanelResizeEnd(*app, hwnd, true);
+            break;
 
         case WM_SETCURSOR:
             if (app && LOWORD(lParam) == HTCLIENT) {
@@ -1843,6 +1852,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow
     app.tocOnLeft = savedSettings.tocOnLeft;
     app.tocPinned = savedSettings.tocPinned;
     app.browserPinned = savedSettings.browserPinned;
+    app.tocWidth = savedSettings.tocWidth;
+    app.browserWidth = savedSettings.browserWidth;
     app.languageSetting = savedSettings.language == "auto"
         ? -1 : languageIndexById(savedSettings.language);
     app.currentLanguageIndex = app.languageSetting >= 0

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -798,6 +798,18 @@ render_document:
     bool needsHScroll = app.contentWidth > documentWidth;
     float scrollbarSize = dpi(app, 14.0f);
 
+    // In the panel layout, scrollbars appear on activity and quietly fade out.
+    const ULONGLONG scrollNow = GetTickCount64();
+    if (std::abs(app.scrollX - app.panelObservedScrollX) > 0.1f ||
+        std::abs(app.scrollY - app.panelObservedScrollY) > 0.1f) {
+        app.panelObservedScrollX = app.scrollX;
+        app.panelObservedScrollY = app.scrollY;
+        app.lastPanelScrollActivity = scrollNow;
+        if (!app.editMode && (app.showToc || app.showFolderBrowser))
+            SetTimer(app.hwnd, TIMER_SIDE_PANEL_SCROLLBARS, 33, nullptr);
+    }
+    const float scrollbarOpacity = sidePanelDocumentScrollbarOpacity(app, scrollNow);
+
     // Scrollbar color: dark on light themes, light on dark themes
     float sbColorValue = app.theme.isDark ? 1.0f : 0.0f;
 
@@ -815,6 +827,7 @@ render_document:
 
         float sbWidth = (app.scrollbarHovered || app.scrollbarDragging) ? dpi(app, 10.0f) : dpi(app, 6.0f);
         float sbAlpha = (app.scrollbarHovered || app.scrollbarDragging) ? 0.5f : 0.3f;
+        sbAlpha *= scrollbarOpacity;
 
         app.brush->SetColor(D2D1::ColorF(sbColorValue, sbColorValue, sbColorValue, sbAlpha));
         app.renderTarget->FillRoundedRectangle(
@@ -880,6 +893,7 @@ render_document:
 
         float sbHeight = (app.hScrollbarHovered || app.hScrollbarDragging) ? dpi(app, 10.0f) : dpi(app, 6.0f);
         float sbAlpha = (app.hScrollbarHovered || app.hScrollbarDragging) ? 0.5f : 0.3f;
+        sbAlpha *= scrollbarOpacity;
 
         app.brush->SetColor(D2D1::ColorF(sbColorValue, sbColorValue, sbColorValue, sbAlpha));
         app.renderTarget->FillRoundedRectangle(
@@ -1509,6 +1523,14 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (app) sidePanelResizeEnd(*app, hwnd, true);
             break;
 
+        case WM_MOUSELEAVE:
+            if (app && GetCapture() != hwnd) {
+                app->mouseX = app->mouseY = -1;
+                app->scrollbarHovered = app->hScrollbarHovered = false;
+                InvalidateRect(hwnd, nullptr, FALSE);
+            }
+            return 0;
+
         case WM_SETCURSOR:
             if (app && LOWORD(lParam) == HTCLIENT) {
                 // We handle cursor in WM_MOUSEMOVE
@@ -1561,6 +1583,12 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             return 0;
 
         case WM_TIMER:
+            if (wParam == TIMER_SIDE_PANEL_SCROLLBARS && app) {
+                InvalidateRect(hwnd, nullptr, FALSE);
+                if (GetTickCount64() - app->lastPanelScrollActivity >= 1100 ||
+                    app->editMode || (!app->showToc && !app->showFolderBrowser))
+                    KillTimer(hwnd, TIMER_SIDE_PANEL_SCROLLBARS);
+            }
             if (wParam == TIMER_LINK_PEEK && app) handleLinkPeekTimer(*app, hwnd);
             if (wParam == TIMER_FILE_WATCH && app) handleFileWatchTimer(*app, hwnd);
             if (wParam == 2 && app) editorReparse(*app); // TIMER_EDITOR_REPARSE

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -805,10 +805,16 @@ render_document:
         app.panelObservedScrollX = app.scrollX;
         app.panelObservedScrollY = app.scrollY;
         app.lastPanelScrollActivity = scrollNow;
-        if (!app.editMode && (app.showToc || app.showFolderBrowser))
-            SetTimer(app.hwnd, TIMER_SIDE_PANEL_SCROLLBARS, 33, nullptr);
     }
     const float scrollbarOpacity = sidePanelDocumentScrollbarOpacity(app, scrollNow);
+    const bool scrollbarNeedsTicks = sidePanelScrollbarNeedsTicks(app, scrollNow);
+    if (scrollbarNeedsTicks && !app.panelScrollbarTimerActive) {
+        app.panelScrollbarTimerActive = SetTimer(app.hwnd, TIMER_SIDE_PANEL_SCROLLBARS, 16, nullptr) != 0;
+    } else if (!scrollbarNeedsTicks && app.panelScrollbarTimerActive) {
+        KillTimer(app.hwnd, TIMER_SIDE_PANEL_SCROLLBARS);
+        app.panelScrollbarTimerActive = false;
+    }
+    const bool quietScrollbars = !app.editMode && (app.showToc || app.showFolderBrowser);
 
     // Scrollbar color: dark on light themes, light on dark themes
     float sbColorValue = app.theme.isDark ? 1.0f : 0.0f;
@@ -825,14 +831,20 @@ render_document:
         float sbY = trackTop +
             ((maxScrollY > 0) ? (app.scrollY / maxScrollY * (trackHeight - sbHeight)) : 0);
 
-        float sbWidth = (app.scrollbarHovered || app.scrollbarDragging) ? dpi(app, 10.0f) : dpi(app, 6.0f);
-        float sbAlpha = (app.scrollbarHovered || app.scrollbarDragging) ? 0.5f : 0.3f;
+        float sbWidth = quietScrollbars ? dpi(app, 4.0f) :
+            ((app.scrollbarHovered || app.scrollbarDragging) ? dpi(app, 10.0f) : dpi(app, 6.0f));
+        float sbAlpha = quietScrollbars ? 0.32f :
+            ((app.scrollbarHovered || app.scrollbarDragging) ? 0.5f : 0.3f);
         sbAlpha *= scrollbarOpacity;
+        // Keep the thin thumb fully inside its hit band, clear of the adjacent
+        // divider's resize target. The existing 14-DIP scrollbar hit area stays.
+        const float sbInset = dpi(app, quietScrollbars ? 6.0f : 4.0f);
 
         app.brush->SetColor(D2D1::ColorF(sbColorValue, sbColorValue, sbColorValue, sbAlpha));
         app.renderTarget->FillRoundedRectangle(
-            D2D1::RoundedRect(D2D1::RectF(documentWidth - sbWidth - dpi(app, 4.0f), sbY,
-                                          documentWidth - dpi(app, 4.0f), sbY + sbHeight), 3, 3),
+            D2D1::RoundedRect(D2D1::RectF(documentWidth - sbWidth - sbInset, sbY,
+                                          documentWidth - sbInset, sbY + sbHeight),
+                             quietScrollbars ? sbWidth / 2 : 3, quietScrollbars ? sbWidth / 2 : 3),
             app.brush);
         app.drawCalls++;
 
@@ -891,14 +903,17 @@ render_document:
         sbWidth = std::max(sbWidth, dpi(app, 30.0f));
         float sbX = (maxScrollX > 0) ? (app.scrollX / maxScrollX * (trackWidth - sbWidth)) : 0;
 
-        float sbHeight = (app.hScrollbarHovered || app.hScrollbarDragging) ? dpi(app, 10.0f) : dpi(app, 6.0f);
-        float sbAlpha = (app.hScrollbarHovered || app.hScrollbarDragging) ? 0.5f : 0.3f;
+        float sbHeight = quietScrollbars ? dpi(app, 4.0f) :
+            ((app.hScrollbarHovered || app.hScrollbarDragging) ? dpi(app, 10.0f) : dpi(app, 6.0f));
+        float sbAlpha = quietScrollbars ? 0.32f :
+            ((app.hScrollbarHovered || app.hScrollbarDragging) ? 0.5f : 0.3f);
         sbAlpha *= scrollbarOpacity;
 
         app.brush->SetColor(D2D1::ColorF(sbColorValue, sbColorValue, sbColorValue, sbAlpha));
         app.renderTarget->FillRoundedRectangle(
             D2D1::RoundedRect(D2D1::RectF(sbX, app.height - sbHeight - dpi(app, 4.0f),
-                                          sbX + sbWidth, app.height - dpi(app, 4.0f)), 3, 3),
+                                          sbX + sbWidth, app.height - dpi(app, 4.0f)),
+                             quietScrollbars ? sbHeight / 2 : 3, quietScrollbars ? sbHeight / 2 : 3),
             app.brush);
         app.drawCalls++;
     }
@@ -1585,9 +1600,10 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
         case WM_TIMER:
             if (wParam == TIMER_SIDE_PANEL_SCROLLBARS && app) {
                 InvalidateRect(hwnd, nullptr, FALSE);
-                if (GetTickCount64() - app->lastPanelScrollActivity >= 1100 ||
-                    app->editMode || (!app->showToc && !app->showFolderBrowser))
+                if (app->editMode || app->showPrintPreview || (!app->showToc && !app->showFolderBrowser)) {
                     KillTimer(hwnd, TIMER_SIDE_PANEL_SCROLLBARS);
+                    app->panelScrollbarTimerActive = false;
+                }
             }
             if (wParam == TIMER_LINK_PEEK && app) handleLinkPeekTimer(*app, hwnd);
             if (wParam == TIMER_FILE_WATCH && app) handleFileWatchTimer(*app, hwnd);

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -1298,6 +1298,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             break;
 
         case WM_KILLFOCUS:
+            if (app) cancelDocumentScrollbarDrag(*app, hwnd);
             if (app) sidePanelResizeEnd(*app, hwnd, true);
             if (app && app->showContextMenu) {
                 closeContextMenu(*app);
@@ -1526,6 +1527,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             break;
 
         case WM_CAPTURECHANGED:
+            if (app && (HWND)lParam != hwnd) cancelDocumentScrollbarDrag(*app, hwnd);
             if (app && (HWND)lParam != hwnd) sidePanelResizeEnd(*app, hwnd, true);
             // Losing capture mid tab-drag (Alt+Tab, a popup stealing the
             // mouse) aborts the drag instead of leaving a stray ghost
@@ -1535,6 +1537,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             return 0;
 
         case WM_CANCELMODE:
+            if (app) cancelDocumentScrollbarDrag(*app, hwnd);
             if (app) sidePanelResizeEnd(*app, hwnd, true);
             break;
 

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -293,17 +293,16 @@ void renderSearchOverlay(App& app) {
     }
 }
 
-// One source of truth for the floating browser card's geometry (t13):
+// One source of truth for the docked browser panel's geometry:
 // render, cursor, and click hit-tests all read from here.
 FolderBrowserMetrics folderBrowserMetrics(const App& app) {
     FolderBrowserMetrics g;
     g.panelWidth = folderBrowserPanelWidth(app);
     g.panelX = -g.panelWidth * (1.0f - app.folderBrowserAnimation);
-    float m = dpi(app, 10.0f);
-    g.cardLeft = g.panelX + m;
-    g.cardRight = g.panelX + g.panelWidth - m;
-    g.cardTop = chromeTopHeight(app) + dpi(app, 10.0f);
-    g.cardBottom = (float)app.height - dpi(app, 12.0f);
+    g.cardLeft = g.panelX;
+    g.cardRight = g.panelX + g.panelWidth;
+    g.cardTop = chromeTopHeight(app);
+    g.cardBottom = (float)app.height;
     g.headerY = g.cardTop + dpi(app, 8.0f);
     g.headerH = dpi(app, 28.0f);
     g.btnSize = dpi(app, 22.0f);
@@ -423,28 +422,15 @@ void renderFolderBrowser(App& app) {
     }
     float anim = app.folderBrowserAnimation;
 
-    // Floating card inside the slide envelope (t13 design 13b)
+    // A docked surface shares one divider with the neighbouring pane.
     FolderBrowserMetrics g = folderBrowserMetrics(app);
     float panelWidth = g.panelWidth;
     float panelX = g.panelX;
     D2D1_RECT_F card = D2D1::RectF(g.cardLeft, g.cardTop, g.cardRight, g.cardBottom);
-    float radius = dpi(app, 12.0f);
-    promptChipShadow(app, card, radius);
     D2D1_COLOR_F panelBg = promptChipSurface(app);
-    panelBg.a = 0.96f;
+    panelBg.a = 1;
     app.brush->SetColor(panelBg);
-    app.renderTarget->FillRoundedRectangle(
-        D2D1::RoundedRect(card, radius, radius), app.brush);
-    D2D1_COLOR_F hi = D2D1::ColorF(1, 1, 1, app.theme.isDark ? 0.06f : 0.5f);
-    app.brush->SetColor(hi);
-    app.renderTarget->DrawLine(
-        D2D1::Point2F(g.cardLeft + radius, g.cardTop + 1.0f),
-        D2D1::Point2F(g.cardRight - radius, g.cardTop + 1.0f), app.brush, 1.0f);
-    D2D1_COLOR_F borderColor = app.theme.text;
-    borderColor.a = 0.13f;
-    app.brush->SetColor(borderColor);
-    app.renderTarget->DrawRoundedRectangle(
-        D2D1::RoundedRect(card, radius, radius), app.brush, 1.0f);
+    app.renderTarget->FillRectangle(card, app.brush);
 
     app.folderCrumbHits.clear();
     app.folderPinRect = D2D1_RECT_F{};
@@ -944,12 +930,12 @@ void renderFolderBrowser(App& app) {
 D2D1_RECT_F tocListRect(const App& app) {
     const float width = tocPanelWidth(app);
     const float x = tocPanelX(app, width);
-    return D2D1::RectF(x + dpi(app, 24.0f), chromeTopHeight(app) + dpi(app, 53.0f),
-                       x + width - dpi(app, 18.0f), app.height - dpi(app, 38.0f));
+    return D2D1::RectF(x + dpi(app, 14.0f), chromeTopHeight(app) + dpi(app, 43.0f),
+                       x + width - dpi(app, 8.0f), app.height - dpi(app, 26.0f));
 }
 
 float tocHeadingIndent(const App& app, int level) {
-    const float available = std::max(0.0f, tocPanelWidth(app) - dpi(app, 72.0f));
+    const float available = std::max(0.0f, tocPanelWidth(app) - dpi(app, 52.0f));
     const float step = std::min(dpi(app, 13.0f), available * 0.35f / 5);
     return std::clamp(level - 1, 0, 5) * step;
 }
@@ -995,35 +981,19 @@ void renderToc(App& app) {
     }
     float anim = app.tocAnimation;
 
-    // Floating outline card (t13 design 13a): the panel leaves its
-    // full-height slab and floats inside the slab's slide envelope
+    // Dock the outline directly against the document, without a second border.
     float panelWidth = tocPanelWidth(app);
     float panelX = tocPanelX(app, panelWidth);  // slides from the chosen side
-    float m = dpi(app, 10.0f);
-    float cardLeft = panelX + m;
-    float cardRight = panelX + panelWidth - m;
-    float cardTop = chromeTopHeight(app) + dpi(app, 10.0f);
-    float cardBottom = (float)app.height - dpi(app, 12.0f);
+    float cardLeft = panelX;
+    float cardRight = panelX + panelWidth;
+    float cardTop = chromeTopHeight(app);
+    float cardBottom = (float)app.height;
     D2D1_RECT_F card = D2D1::RectF(cardLeft, cardTop, cardRight, cardBottom);
-    float radius = dpi(app, 12.0f);
 
-    promptChipShadow(app, card, radius);
     D2D1_COLOR_F surf = promptChipSurface(app);
-    surf.a = 0.96f;
+    surf.a = 1;
     app.brush->SetColor(surf);
-    app.renderTarget->FillRoundedRectangle(
-        D2D1::RoundedRect(card, radius, radius), app.brush);
-    // Inset top highlight, then the hairline border
-    D2D1_COLOR_F hi = D2D1::ColorF(1, 1, 1, app.theme.isDark ? 0.06f : 0.5f);
-    app.brush->SetColor(hi);
-    app.renderTarget->DrawLine(
-        D2D1::Point2F(cardLeft + radius, cardTop + 1.0f),
-        D2D1::Point2F(cardRight - radius, cardTop + 1.0f), app.brush, 1.0f);
-    D2D1_COLOR_F borderColor = app.theme.text;
-    borderColor.a = 0.13f;
-    app.brush->SetColor(borderColor);
-    app.renderTarget->DrawRoundedRectangle(
-        D2D1::RoundedRect(card, radius, radius), app.brush, 1.0f);
+    app.renderTarget->FillRectangle(card, app.brush);
 
     app.tocCloseRect = D2D1_RECT_F{};
     app.tocPinRect = D2D1_RECT_F{};
@@ -1120,36 +1090,10 @@ void renderToc(App& app) {
             app.brush);
 
         // Items list between header and footer
-        float listStartY = dividerY + dpi(app, 8.0f);
-        float listBottom = cardBottom - footerHeight;
+        const auto listRect = tocListRect(app);
+        float listStartY = listRect.top;
+        float listBottom = listRect.bottom;
         float listHeight = listBottom - listStartY;
-
-        // Scroll-thread on the card edge: the document's viewport mapped
-        // onto the panel span (design 13a)
-        if (app.contentHeight > (float)app.height) {
-            float tx = cardLeft + dpi(app, 6.0f);
-            D2D1_RECT_F track = D2D1::RectF(tx, listStartY + dpi(app, 4.0f),
-                                            tx + dpi(app, 3.0f),
-                                            listBottom - dpi(app, 4.0f));
-            D2D1_COLOR_F tc = app.theme.text; tc.a = 0.08f * anim;
-            app.brush->SetColor(tc);
-            app.renderTarget->FillRoundedRectangle(
-                D2D1::RoundedRect(track, dpi(app, 1.5f), dpi(app, 1.5f)),
-                app.brush);
-            float span = track.bottom - track.top;
-            float docSpan = std::max(1.0f, app.contentHeight);
-            float segTop = track.top + span * (app.scrollY / docSpan);
-            float segH = std::max(dpi(app, 18.0f),
-                                  span * ((float)app.height / docSpan));
-            segTop = std::min(segTop, track.bottom - segH);
-            D2D1_COLOR_F ac = app.theme.accent; ac.a = anim;
-            app.brush->SetColor(ac);
-            app.renderTarget->FillRoundedRectangle(
-                D2D1::RoundedRect(D2D1::RectF(track.left, segTop,
-                                              track.right, segTop + segH),
-                                  dpi(app, 1.5f), dpi(app, 1.5f)),
-                app.brush);
-        }
 
         if (app.headings.empty()) {
             // "No headings" message
@@ -1229,8 +1173,8 @@ void renderToc(App& app) {
                     app.brush);
             }
 
-            float rowLeft = cardLeft + dpi(app, 14.0f);
-            float rowRight = cardRight - dpi(app, 8.0f);
+            float rowLeft = listRect.left;
+            float rowRight = listRect.right;
             app.renderTarget->PushAxisAlignedClip(
                 D2D1::RectF(cardLeft, listStartY, cardRight, listBottom),
                 D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -1,4 +1,5 @@
 #include "overlays.h"
+#include "sidepanels.h"
 #include "utils.h"
 #include "d2d_init.h"
 #include "editor.h"
@@ -20,6 +21,24 @@ static float promptKeycap(App& app, const wchar_t* label, float rightX,
 #include <algorithm>
 #include <cmath>
 #include <utility>
+
+// Panel footers stay on one line even at the minimum panel width.
+static void panelFooterText(App& app, const wchar_t* text, const D2D1_RECT_F& rect) {
+    if (!app.signalSmallFormat || rect.right <= rect.left || rect.bottom <= rect.top) return;
+    IDWriteTextLayout* layout = nullptr;
+    if (FAILED(app.dwriteFactory->CreateTextLayout(text, (UINT32)wcslen(text),
+        app.signalSmallFormat, rect.right - rect.left, rect.bottom - rect.top, &layout))) return;
+    layout->SetWordWrapping(DWRITE_WORD_WRAPPING_NO_WRAP);
+    DWRITE_TRIMMING trimming{DWRITE_TRIMMING_GRANULARITY_CHARACTER, 0, 0};
+    IDWriteInlineObject* ellipsis = nullptr;
+    if (SUCCEEDED(app.dwriteFactory->CreateEllipsisTrimmingSign(app.signalSmallFormat, &ellipsis))) {
+        layout->SetTrimming(&trimming, ellipsis);
+        ellipsis->Release();
+    }
+    app.renderTarget->DrawTextLayout(D2D1::Point2F(rect.left, rect.top), layout,
+                                    app.brush, D2D1_DRAW_TEXT_OPTIONS_CLIP);
+    layout->Release();
+}
 
 void renderSearchOverlay(App& app) {
     // Animate in (only invalidate if animation is still progressing)
@@ -576,12 +595,11 @@ void renderFolderBrowser(App& app) {
                 // give way when the row runs out
                 if (cx + segW > crumbMax) {
                     // Trim with an ellipsis; the leaf keeps a readable stub
-                    while (seg.size() > 4 &&
+                    while (!seg.empty() &&
                            cx + textWidth(seg + L"\u2026") > crumbMax) {
                         seg.pop_back();
                     }
-                    if (!crumbs[ci].leaf &&
-                        cx + textWidth(seg + L"\u2026") > crumbMax) {
+                    if (cx + textWidth(seg + L"\u2026") > crumbMax) {
                         break;
                     }
                     seg += L"\u2026";
@@ -594,7 +612,7 @@ void renderFolderBrowser(App& app) {
                 app.renderTarget->DrawText(seg.c_str(), (UINT32)seg.size(),
                     leaf && app.tocFormatBold ? app.tocFormatBold : browserFormat,
                     D2D1::RectF(cx, headerCenterY - dpi(app, 9.0f),
-                                cx + segW + dpi(app, 4.0f), headerY + g.headerH),
+                                std::min(crumbMax, cx + segW + dpi(app, 4.0f)), headerY + g.headerH),
                     app.brush);
                 if (!leaf && crumbs[ci].keep > 0) {
                     app.folderCrumbHits.push_back(
@@ -903,45 +921,57 @@ void renderFolderBrowser(App& app) {
                 swprintf_s(counts, tr(app, "browser.counts"), dirs,
                            (int)app.folderItems.size() - g.dirCount);
             }
-            app.renderTarget->DrawText(counts, (UINT32)wcslen(counts),
-                app.signalSmallFormat,
+            panelFooterText(app, counts,
                 D2D1::RectF(g.cardLeft + padding, footTop + dpi(app, 7.0f),
-                            g.cardRight - padding, g.cardBottom),
-                app.brush);
+                            g.cardRight - padding, g.cardBottom));
             const wchar_t* hint = tr(app, app.folderBrowserNaming != 0
                                               ? "browser.naming_hint"
                                               : "browser.hint");
             float hw = measureText(app, hint, app.signalSmallFormat);
-            app.renderTarget->DrawText(hint, (UINT32)wcslen(hint),
-                app.signalSmallFormat,
-                D2D1::RectF(g.cardRight - padding - hw, footTop + dpi(app, 7.0f),
-                            g.cardRight - padding + dpi(app, 2.0f), g.cardBottom),
-                app.brush);
+            if (measureText(app, counts, app.signalSmallFormat) + hw + dpi(app, 12.0f) <
+                g.cardRight - g.cardLeft - padding * 2) {
+                app.renderTarget->DrawText(hint, (UINT32)wcslen(hint),
+                    app.signalSmallFormat,
+                    D2D1::RectF(g.cardRight - padding - hw, footTop + dpi(app, 7.0f),
+                                g.cardRight - padding + dpi(app, 2.0f), g.cardBottom),
+                    app.brush, D2D1_DRAW_TEXT_OPTIONS_CLIP);
+            }
         }
     }
+    renderSidePanelResizeGrip(app, SidePanel::Browser);
+}
+
+D2D1_RECT_F tocListRect(const App& app) {
+    const float width = tocPanelWidth(app);
+    const float x = tocPanelX(app, width);
+    return D2D1::RectF(x + dpi(app, 24.0f), chromeTopHeight(app) + dpi(app, 53.0f),
+                       x + width - dpi(app, 18.0f), app.height - dpi(app, 38.0f));
+}
+
+float tocHeadingIndent(const App& app, int level) {
+    const float available = std::max(0.0f, tocPanelWidth(app) - dpi(app, 72.0f));
+    const float step = std::min(dpi(app, 13.0f), available * 0.35f / 5);
+    return std::clamp(level - 1, 0, 5) * step;
+}
+
+float tocMaxScroll(const App& app) {
+    const auto rect = tocListRect(app);
+    const auto needle = toLower(app.tocFilter);
+    size_t count = 0;
+    for (const auto& heading : app.headings)
+        if (needle.empty() || toLower(heading.text).find(needle) != std::wstring::npos) ++count;
+    return std::max(0.0f, count * dpi(app, 26.0f) - std::max(0.0f, rect.bottom - rect.top));
 }
 
 // Click hit-test sharing the renderer's card geometry (#114 pattern:
 // render-time hover must never drive click actions). Keep in step with
 // renderToc below.
 int tocItemIndexAt(App& app, float x, float y) {
-    float panelWidth = tocPanelWidth(app);
-    float panelX = tocPanelX(app, panelWidth);
-    float m = dpi(app, 10.0f);
-    float cardLeft = panelX + m;
-    float cardRight = panelX + panelWidth - m;
-    float cardTop = chromeTopHeight(app) + dpi(app, 10.0f);
-    float cardBottom = (float)app.height - dpi(app, 12.0f);
-    float headerY = cardTop + dpi(app, 9.0f);
-    float dividerY = headerY + dpi(app, 34.0f) - dpi(app, 8.0f);
-    float listStartY = dividerY + dpi(app, 8.0f);
-    float listBottom = cardBottom - dpi(app, 26.0f);
-    float rowLeft = cardLeft + dpi(app, 14.0f);
-    float rowRight = cardRight - dpi(app, 8.0f);
+    const auto rect = tocListRect(app);
     float itemHeight = dpi(app, 26.0f);
-    if (x < rowLeft || x > rowRight || y < listStartY || y > listBottom)
+    if (x < rect.left || x > rect.right || y < rect.top || y > rect.bottom)
         return -1;
-    int row = (int)((y - listStartY + app.tocScroll) / itemHeight);
+    int row = (int)((y - rect.top + app.tocScroll) / itemHeight);
     if (row < 0) return -1;
     std::wstring needle = toLower(app.tocFilter);
     int visIdx = -1;
@@ -1011,13 +1041,15 @@ void renderToc(App& app) {
         headerColor.a = anim;
         app.brush->SetColor(headerColor);
         const wchar_t* tocTitle = tr(app, "toc.title");
-        app.renderTarget->DrawText(tocTitle, (UINT32)wcslen(tocTitle), tocBold,
-            D2D1::RectF(cardLeft + padding, headerY, cardRight - padding,
-                        headerY + headerHeight),
-            app.brush);
+        const float titleRight = cardRight - padding - dpi(app, 40.0f);
+        if (app.tocFilter.empty()) {
+            app.renderTarget->DrawText(tocTitle, (UINT32)wcslen(tocTitle), tocBold,
+                D2D1::RectF(cardLeft + padding, headerY, titleRight, headerY + headerHeight),
+                app.brush, D2D1_DRAW_TEXT_OPTIONS_CLIP);
+        }
         float titleW = measureText(app, tocTitle, tocBold);
 
-        if (!app.headings.empty() && app.signalSmallFormat) {
+        if (app.tocFilter.empty() && !app.headings.empty() && app.signalSmallFormat) {
             wchar_t count[8];
             swprintf_s(count, L"%d", (int)app.headings.size());
             float cw = measureText(app, count, app.signalSmallFormat);
@@ -1026,18 +1058,20 @@ void renderToc(App& app) {
                 headerY + dpi(app, 2.0f),
                 cardLeft + padding + titleW + dpi(app, 8.0f) + cw + dpi(app, 11.0f),
                 headerY + dpi(app, 17.0f));
-            D2D1_COLOR_F bb = app.theme.text; bb.a = 0.07f * anim;
-            app.brush->SetColor(bb);
-            app.renderTarget->FillRoundedRectangle(
-                D2D1::RoundedRect(badge, dpi(app, 7.0f), dpi(app, 7.0f)),
-                app.brush);
-            D2D1_COLOR_F bi = app.theme.text; bi.a = 0.6f * anim;
-            app.brush->SetColor(bi);
-            app.renderTarget->DrawText(count, (UINT32)wcslen(count),
-                app.signalSmallFormat,
-                D2D1::RectF(badge.left + dpi(app, 5.5f), badge.top + dpi(app, 1.5f),
-                            badge.right, badge.bottom),
-                app.brush);
+            if (badge.right <= titleRight) {
+                D2D1_COLOR_F bb = app.theme.text; bb.a = 0.07f * anim;
+                app.brush->SetColor(bb);
+                app.renderTarget->FillRoundedRectangle(
+                    D2D1::RoundedRect(badge, dpi(app, 7.0f), dpi(app, 7.0f)),
+                    app.brush);
+                D2D1_COLOR_F bi = app.theme.text; bi.a = 0.6f * anim;
+                app.brush->SetColor(bi);
+                app.renderTarget->DrawText(count, (UINT32)wcslen(count),
+                    app.signalSmallFormat,
+                    D2D1::RectF(badge.left + dpi(app, 5.5f), badge.top + dpi(app, 1.5f),
+                                badge.right, badge.bottom),
+                    app.brush);
+            }
         }
 
         // Close cross at the right edge of the header
@@ -1064,24 +1098,16 @@ void renderToc(App& app) {
                                          headerY + dpi(app, 20.0f));
         }
 
-        // Active filter, right-aligned before the cross
-        if (!app.tocFilter.empty() && app.dwriteFactory) {
-            IDWriteTextLayout* filterLayout = nullptr;
-            app.dwriteFactory->CreateTextLayout(
-                app.tocFilter.c_str(), (UINT32)app.tocFilter.size(),
-                tocNormal, panelWidth, headerHeight, &filterLayout);
-            if (filterLayout) {
-                DWRITE_TEXT_METRICS fm{};
-                filterLayout->GetMetrics(&fm);
-                D2D1_COLOR_F filterColor = app.theme.accent;
-                filterColor.a = anim;
-                app.brush->SetColor(filterColor);
-                app.renderTarget->DrawTextLayout(
-                    D2D1::Point2F(cardRight - padding - dpi(app, 38.0f) - fm.width,
-                                  headerY + dpi(app, 1.0f)),
-                    filterLayout, app.brush);
-                filterLayout->Release();
-            }
+        // The active filter replaces the title, leaving room for the buttons.
+        if (!app.tocFilter.empty()) {
+            D2D1_COLOR_F filterColor = app.theme.accent;
+            filterColor.a = anim;
+            app.brush->SetColor(filterColor);
+            const std::wstring label = L"/ " + app.tocFilter;
+            app.renderTarget->DrawText(label.c_str(), (UINT32)label.size(), tocNormal,
+                D2D1::RectF(cardLeft + padding, headerY + dpi(app, 1.0f),
+                            titleRight, headerY + headerHeight),
+                app.brush, D2D1_DRAW_TEXT_OPTIONS_CLIP);
         }
 
         // Divider
@@ -1215,7 +1241,7 @@ void renderToc(App& app) {
                 if (itemY + itemHeight < listStartY || itemY > listBottom) continue;
 
                 const auto& heading = app.headings[visible[row]];
-                float indent = (heading.level - 1) * dpi(app, 13.0f);
+                float indent = tocHeadingIndent(app, heading.level);
                 float itemX = rowLeft + dpi(app, 10.0f) + indent;
                 bool isCurrent = visible[row] == currentIdx;
 
@@ -1257,7 +1283,7 @@ void renderToc(App& app) {
                         app.brush);
                 }
 
-                // Type scale by level: H1 bold heading ink, H2 body, H3 quiet
+                // H1 stays bold; deeper levels remain legible at compact widths.
                 IDWriteTextFormat* fmt =
                     (heading.level == 1 || isCurrent) ? tocBold : tocNormal;
                 D2D1_COLOR_F textColor;
@@ -1266,7 +1292,7 @@ void renderToc(App& app) {
                     textColor.a = anim;
                 } else if (heading.level >= 3) {
                     textColor = app.theme.text;
-                    textColor.a = 0.55f * anim;
+                    textColor.a = 0.72f * anim;
                 } else {
                     textColor = app.theme.text;
                     textColor.a = 0.82f * anim;
@@ -1306,7 +1332,7 @@ void renderToc(App& app) {
             }
         }
 
-        // Footer: the hint plus the T keycap
+        // Footer: the hint plus the active Contents shortcut
         float footTop = listBottom;
         app.brush->SetColor(div);
         app.renderTarget->FillRectangle(
@@ -1315,17 +1341,17 @@ void renderToc(App& app) {
             app.brush);
         if (app.signalSmallFormat) {
             const wchar_t* hint = tr(app, "toc.hint");
+            const std::wstring shortcut = keyLabel(app.keymap[KA_TOC]);
+            const float keyWidth = promptKeycap(app, shortcut.c_str(), cardRight - padding,
+                                               footTop + footerHeight * 0.5f);
             D2D1_COLOR_F hc = app.theme.text; hc.a = 0.48f * anim;
             app.brush->SetColor(hc);
-            app.renderTarget->DrawText(hint, (UINT32)wcslen(hint),
-                app.signalSmallFormat,
+            panelFooterText(app, hint,
                 D2D1::RectF(cardLeft + padding, footTop + dpi(app, 7.0f),
-                            cardRight - padding - dpi(app, 26.0f), cardBottom),
-                app.brush);
-            promptKeycap(app, L"T", cardRight - padding,
-                         footTop + footerHeight * 0.5f);
+                            cardRight - padding - keyWidth, cardBottom));
         }
     }
+    renderSidePanelResizeGrip(app, SidePanel::Contents);
 }
 
 // --- Link peek ---

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -58,8 +58,11 @@ void enterPrintLayout(App& app, SavedView& saved) {
     saved.targetScrollY = app.targetScrollY;
     saved.theme = app.theme;
     saved.editMode = app.editMode;
+    saved.showToc = app.showToc;
+    saved.showFolderBrowser = app.showFolderBrowser;
 
     app.editMode = false;  // layout width must be the page, not a pane (#81)
+    app.showToc = app.showFolderBrowser = false;  // panel widths belong to the screen
     app.contentScale = 1.0f;
     app.zoomFactor = 1.0f;
     app.theme = printTheme();
@@ -149,6 +152,8 @@ void layoutAtPrintWidth(App& app, float contentWidthDips) {
 
 void leavePrintLayout(App& app, const SavedView& saved) {
     app.editMode = saved.editMode;
+    app.showToc = saved.showToc;
+    app.showFolderBrowser = saved.showFolderBrowser;
     app.width = saved.width;
     app.height = saved.height;
     app.contentScale = saved.contentScale;

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -951,8 +951,8 @@ static void layoutHeading(App& app, const ElementPtr& elem, float& y, float inde
         y += 20 * scale;
     }
 
-    // Record heading for TOC (h1-h3 only)
-    if (elem->level <= 3) {
+    // All Markdown heading levels participate in Contents and anchor navigation (#210).
+    if (elem->level >= 1 && elem->level <= 6) {
         std::wstring headingText;
         std::function<void(const ElementPtr&)> extract = [&](const ElementPtr& e) {
             if (!e) return;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -60,6 +60,8 @@ void saveSettings(const Settings& settings) {
     file << "tocOnLeft=" << (settings.tocOnLeft ? 1 : 0) << "\n";
     file << "tocPinned=" << (settings.tocPinned ? 1 : 0) << "\n";
     file << "browserPinned=" << (settings.browserPinned ? 1 : 0) << "\n";
+    file << "tocWidth=" << settings.tocWidth << "\n";
+    file << "browserWidth=" << settings.browserWidth << "\n";
     file << "language=" << settings.language << "\n";
     file << "keyProfile=" << settings.keyProfile << "\n";
     file << "checkUpdates=" << (settings.checkUpdates ? 1 : 0) << "\n";
@@ -260,6 +262,16 @@ Settings loadSettings() {
             settings.tocPinned = (value == "1");
         } else if (key == "browserPinned") {
             settings.browserPinned = (value == "1");
+        } else if (key == "tocWidth" || key == "browserWidth") {
+            try {
+                size_t consumed = 0;
+                const float width = std::stof(value, &consumed);
+                if (consumed == value.size() && std::isfinite(width) &&
+                    width >= (key == "tocWidth" ? 180.0f : 200.0f) && width <= 4000.0f) {
+                    if (key == "tocWidth") settings.tocWidth = width;
+                    else settings.browserWidth = width;
+                }
+            } catch (const std::exception&) { /* Keep the default for malformed widths. */ }
         } else if (key == "language") {
             if (!value.empty()) settings.language = value;  // "auto" or an id
         } else if (key == "keyProfile") {

--- a/src/sidepanels.cpp
+++ b/src/sidepanels.cpp
@@ -1,0 +1,103 @@
+#include "sidepanels.h"
+#include "overlays.h"
+#include "settings.h"
+
+namespace {
+bool canResize(const App& app) {
+    return !app.editMode && !app.showSettings && !app.showThemeEditor &&
+        !app.showShortcutEditor && !app.showThemeChooser && !app.showHelp &&
+        !app.showPrintPreview && !app.showLightbox && !app.showContextMenu &&
+        !app.showTabMenu && !app.showTabSwitcher && !app.confirmExitPending &&
+        !app.createRefPending && !app.annotEditorOpen && !app.showSearch &&
+        !app.signalTrayOpen;
+}
+}
+
+float sidePanelResizeEdge(const App& app, SidePanel panel) {
+    if (panel == SidePanel::Browser)
+        return folderBrowserPanelWidth(app) * app.folderBrowserAnimation;
+    const float width = tocPanelWidth(app);
+    return tocPanelX(app, width) + (app.tocOnLeft ? width : 0);
+}
+
+SidePanel sidePanelResizeAt(const App& app, float x, float y) {
+    if (!canResize(app) || y < chromeTopHeight(app) + dpi(app, 16.0f) ||
+        y > app.height - dpi(app, 20.0f)) return SidePanel::None;
+    for (SidePanel panel : {SidePanel::Contents, SidePanel::Browser}) {
+        if (panel == SidePanel::Contents && (!app.showToc || app.tocAnimation < 1)) continue;
+        if (panel == SidePanel::Browser && (!app.showFolderBrowser || app.folderBrowserAnimation < 1)) continue;
+        if (std::abs(x - sidePanelResizeEdge(app, panel)) <= dpi(app, 5.0f)) return panel;
+    }
+    return SidePanel::None;
+}
+
+bool sidePanelResizeBegin(App& app, HWND hwnd, float x, float y) {
+    const SidePanel panel = sidePanelResizeAt(app, x, y);
+    if (panel == SidePanel::None) return false;
+    const auto widths = sidePanelWidths(app);
+    const float scale = std::max(0.01f, app.contentScale);
+    app.panelResize = {panel, x,
+        (panel == SidePanel::Contents ? widths.toc : widths.browser) / scale,
+        app.tocWidth, app.browserWidth};
+    // Start from the widths the user can see, holding the neighbouring
+    // panel steady throughout this explicit resize gesture.
+    if (app.showToc) app.tocWidth = widths.toc / scale;
+    if (app.showFolderBrowser) app.browserWidth = widths.browser / scale;
+    app.selecting = app.mouseDown = false;
+    app.swallowNextMouseUp = false;
+    SetCapture(hwnd);
+    InvalidateRect(hwnd, nullptr, FALSE);
+    return true;
+}
+
+void sidePanelResizeMove(App& app, float x) {
+    const SidePanel panel = app.panelResize.panel;
+    if (panel == SidePanel::None) return;
+    const float scale = std::max(0.01f, app.contentScale);
+    const float sign = panel == SidePanel::Contents && !app.tocOnLeft ? -1.0f : 1.0f;
+    const auto widths = sidePanelWidths(app);
+    const float other = panel == SidePanel::Contents ? widths.browser : widths.toc;
+    const float maximum = std::max(0.0f, (sidePanelBudget(app) - other) / scale);
+    const float minimum = std::min(maximum, panel == SidePanel::Contents ? 180.0f : 200.0f);
+    const float wanted = app.panelResize.startWidth + sign * (x - app.panelResize.startX) / scale;
+    const float width = std::clamp(wanted, minimum, std::min(4000.0f, std::max(minimum, maximum)));
+    if (panel == SidePanel::Contents) app.tocWidth = width;
+    else app.browserWidth = width;
+    app.layoutDirty = true;
+    InvalidateRect(app.hwnd, nullptr, FALSE);
+}
+
+void sidePanelResizeEnd(App& app, HWND hwnd, bool cancel) {
+    if (app.panelResize.panel == SidePanel::None) return;
+    if (cancel) {
+        app.tocWidth = app.panelResize.oldTocWidth;
+        app.browserWidth = app.panelResize.oldBrowserWidth;
+    } else {
+        app.tocWidth = std::clamp(app.tocWidth, 180.0f, 4000.0f);
+        app.browserWidth = std::clamp(app.browserWidth, 200.0f, 4000.0f);
+        Settings settings = loadSettings();
+        settings.tocWidth = app.tocWidth;
+        settings.browserWidth = app.browserWidth;
+        saveSettings(settings);
+    }
+    app.panelResize.panel = SidePanel::None;  // clear before ReleaseCapture sends WM_CAPTURECHANGED
+    app.swallowNextMouseUp = cancel;
+    if (GetCapture() == hwnd) ReleaseCapture();
+    app.layoutDirty = true;
+    InvalidateRect(hwnd, nullptr, FALSE);
+}
+
+void renderSidePanelResizeGrip(App& app, SidePanel panel) {
+    if (!canResize(app)) return;
+    const float x = sidePanelResizeEdge(app, panel);
+    const bool active = app.panelResize.panel == panel ||
+        sidePanelResizeAt(app, static_cast<float>(app.mouseX), static_cast<float>(app.mouseY)) == panel;
+    D2D1_COLOR_F color = active ? app.theme.accent : app.theme.text;
+    color.a = active ? 0.8f : 0.2f;
+    app.brush->SetColor(color);
+    const float cy = (chromeTopHeight(app) + app.height) * 0.5f;
+    app.renderTarget->FillRoundedRectangle(D2D1::RoundedRect(
+        D2D1::RectF(x - dpi(app, 1.5f), cy - dpi(app, 18.0f),
+                   x + dpi(app, 1.5f), cy + dpi(app, 18.0f)),
+        dpi(app, 1.5f), dpi(app, 1.5f)), app.brush);
+}

--- a/src/sidepanels.cpp
+++ b/src/sidepanels.cpp
@@ -113,12 +113,38 @@ bool documentScrollbarEdgeHovered(const App& app) {
     return vertical || horizontal;
 }
 
-float sidePanelDocumentScrollbarOpacity(const App& app, ULONGLONG now) {
-    if (app.editMode || (!app.showToc && !app.showFolderBrowser)) return 1;
-    if (app.panelResize.panel != SidePanel::None) return 0;
-    if (app.scrollbarDragging || app.hScrollbarDragging || documentScrollbarEdgeHovered(app) || app.showSearch) return 1;
-    if (!app.lastPanelScrollActivity) return 0;
-    const ULONGLONG age = now - app.lastPanelScrollActivity;
-    if (age <= 800) return 1;
-    return std::max(0.0f, 1.0f - (float)(age - 800) / 300.0f);
+float sidePanelDocumentScrollbarOpacity(App& app, ULONGLONG now) {
+    auto& fade = app.panelScrollbarFade;
+    if (app.editMode || (!app.showToc && !app.showFolderBrowser)) {
+        fade = {};
+        return 1;
+    }
+
+    // Advance the current transition before retargeting. A new wheel event or
+    // a quick pointer re-entry continues from the visible opacity, never a jump.
+    if (fade.running) {
+        const float duration = fade.target > fade.from ? 120.0f : 300.0f;
+        const float t = std::min(1.0f, (float)(now - fade.started) / duration);
+        const float eased = t * t * (3.0f - 2.0f * t);
+        fade.opacity = fade.from + (fade.target - fade.from) * eased;
+        if (t >= 1) fade.running = false;
+    }
+    const bool recentScroll = app.lastPanelScrollActivity && now - app.lastPanelScrollActivity <= 800;
+    const bool visible = app.panelResize.panel == SidePanel::None &&
+        (recentScroll || app.scrollbarDragging || app.hScrollbarDragging ||
+         documentScrollbarEdgeHovered(app) || app.showSearch);
+    const float target = visible ? 1.0f : 0.0f;
+    if (target != fade.target) {
+        fade.from = fade.opacity;
+        fade.target = target;
+        fade.started = now;
+        fade.running = fade.from != target;
+    }
+    return fade.opacity;
+}
+
+bool sidePanelScrollbarNeedsTicks(const App& app, ULONGLONG now) {
+    if (app.editMode || app.showPrintPreview || (!app.showToc && !app.showFolderBrowser)) return false;
+    return app.panelScrollbarFade.running ||
+        (app.lastPanelScrollActivity && now - app.lastPanelScrollActivity <= 800);
 }

--- a/src/sidepanels.cpp
+++ b/src/sidepanels.cpp
@@ -93,11 +93,32 @@ void renderSidePanelResizeGrip(App& app, SidePanel panel) {
     const bool active = app.panelResize.panel == panel ||
         sidePanelResizeAt(app, static_cast<float>(app.mouseX), static_cast<float>(app.mouseY)) == panel;
     D2D1_COLOR_F color = active ? app.theme.accent : app.theme.text;
-    color.a = active ? 0.8f : 0.2f;
+    color.a = active ? 0.55f : 0.10f;
     app.brush->SetColor(color);
-    const float cy = (chromeTopHeight(app) + app.height) * 0.5f;
-    app.renderTarget->FillRoundedRectangle(D2D1::RoundedRect(
-        D2D1::RectF(x - dpi(app, 1.5f), cy - dpi(app, 18.0f),
-                   x + dpi(app, 1.5f), cy + dpi(app, 18.0f)),
-        dpi(app, 1.5f), dpi(app, 1.5f)), app.brush);
+    const float left = std::floor(x) - (panel == SidePanel::Browser || app.tocOnLeft ? 1.0f : 0.0f);
+    app.renderTarget->FillRectangle(
+        D2D1::RectF(left, chromeTopHeight(app), left + 1, (float)app.height), app.brush);
+}
+
+bool documentScrollbarEdgeHovered(const App& app) {
+    if (app.mouseY < chromeTopHeight(app) || app.mouseY > app.height ||
+        app.panelResize.panel != SidePanel::None ||
+        sidePanelResizeAt(app, (float)app.mouseX, (float)app.mouseY) != SidePanel::None) return false;
+    const float left = documentViewportX(app);
+    const float width = documentViewportWidth(app);
+    const float right = left + width;
+    const bool vertical = app.verticalScrollbarVisible && app.mouseX >= right - dpi(app, 14) && app.mouseX < right;
+    const bool horizontal = app.contentWidth > width && app.mouseY >= app.height - dpi(app, 14) &&
+                            app.mouseX >= left && app.mouseX < right;
+    return vertical || horizontal;
+}
+
+float sidePanelDocumentScrollbarOpacity(const App& app, ULONGLONG now) {
+    if (app.editMode || (!app.showToc && !app.showFolderBrowser)) return 1;
+    if (app.panelResize.panel != SidePanel::None) return 0;
+    if (app.scrollbarDragging || app.hScrollbarDragging || documentScrollbarEdgeHovered(app) || app.showSearch) return 1;
+    if (!app.lastPanelScrollActivity) return 0;
+    const ULONGLONG age = now - app.lastPanelScrollActivity;
+    if (age <= 800) return 1;
+    return std::max(0.0f, 1.0f - (float)(age - 800) / 300.0f);
 }

--- a/tests/fixtures/sidebar-visual-prototype.md
+++ b/tests/fixtures/sidebar-visual-prototype.md
@@ -22,6 +22,17 @@ Repeat with a narrow window, in Paper and Midnight, and with the file browser
 or Contents open on either side. The table, quote and formula below should keep
 their usual layout while the scrollbar appears and disappears.
 
+### Drag across panel boundaries
+
+Hold the document scrollbar, move sideways into Contents, and continue moving
+up and down without releasing. Scrolling should continue smoothly. Try crossing
+the divider, the file browser, the title bar and the window edges too. Release
+over a Contents heading: scrolling should stop without navigating to that heading.
+
+For a horizontal scrollbar, move vertically away from its track while dragging,
+then keep moving left and right. It should keep tracking until release. Switching
+to another application during a drag should cancel it cleanly.
+
 ### Mixed formatting
 
 **Bold**, *italic*, `inline code`, x^2^, H~2~O, and $a+b=c$ should remain readable

--- a/tests/fixtures/sidebar-visual-prototype.md
+++ b/tests/fixtures/sidebar-visual-prototype.md
@@ -11,6 +11,17 @@ that divider to find the resize cursor, then drag to change the width.
 The document scrollbar appears when you scroll or hover near it, then fades.
 Contents marks the current heading with a short accent beside its row.
 
+### Gentle scrollbar transitions
+
+Scroll once, then pause. The thin scrollbar should fade in briefly, keep a
+steady width, and fade away after you stop. Hover near it and move away again:
+there should be no thick-to-thin jump. Its wider invisible drag area remains
+easy to grab. Try scrolling again while it fades out; it should return smoothly.
+
+Repeat with a narrow window, in Paper and Midnight, and with the file browser
+or Contents open on either side. The table, quote and formula below should keep
+their usual layout while the scrollbar appears and disappears.
+
 ### Mixed formatting
 
 **Bold**, *italic*, `inline code`, x^2^, H~2~O, and $a+b=c$ should remain readable

--- a/tests/fixtures/sidebar-visual-prototype.md
+++ b/tests/fixtures/sidebar-visual-prototype.md
@@ -1,0 +1,61 @@
+# A calmer reading space
+
+This document combines everyday Markdown with six heading levels. Open Contents
+with **Tab** and the file browser with **B**. Try both panels together.
+
+## Panel edges
+
+At rest, the document and side panels should meet at a thin divider. Hover over
+that divider to find the resize cursor, then drag to change the width.
+
+The document scrollbar appears when you scroll or hover near it, then fades.
+Contents marks the current heading with a short accent beside its row.
+
+### Mixed formatting
+
+**Bold**, *italic*, `inline code`, x^2^, H~2~O, and $a+b=c$ should remain readable
+when the document gets narrower.
+
+| Check | What to look for |
+| --- | --- |
+| Panel header | Title and buttons fit without overlapping |
+| Long headings | A single line with an ellipsis when needed |
+| Document | Tables and paragraphs reflow as the panels resize |
+| Math | $E=mc^2$ keeps its usual appearance |
+
+#### A quoted passage
+
+> A quote with **bold**, `code`, H~2~O, and $x^2$.
+>
+> This second paragraph should keep its normal spacing.
+
+##### A short reading list
+
+- Try the Contents panel on either side of the document.
+- Narrow and widen the window with both panels open.
+- Compare the same layout in Paper and Midnight.
+- [Jump to the conclusion](#conclusion).
+
+###### A deep heading with a deliberately long label to check the available space
+
+The deeper rows should remain readable and clickable, without a tall red rail
+beside the document scrollbar.
+
+```markdown
+###### A fenced heading must not become a Contents entry.
+```
+
+## Equations
+
+$$
+\frac{x^2+y^2}{H_2O}
+$$
+
+Move the divider past this formula and check the surrounding text as well.
+
+## Conclusion
+
+The short active-heading marker should follow your reading position. Resizing
+must not select text, open a file, or follow a link when you release the mouse.
+
+[Open the companion document](toc-browser-companion-with-a-long-file-name.md).

--- a/tests/fixtures/toc-browser-companion-with-a-long-file-name.md
+++ b/tests/fixtures/toc-browser-companion-with-a-long-file-name.md
@@ -1,0 +1,21 @@
+# Companion document
+
+[Return to the panel test](toc-browser-resize.md).
+
+###### Deep heading without intermediate levels
+
+This heading should appear in Contents even though H2 through H5 were skipped.
+
+| Content | Example |
+| --- | --- |
+| Scripts | x^2^ and H~2~O |
+| Math | $E=mc^2$ |
+
+> Quoted **bold** text and `inline code`.
+
+- One list item.
+- Another list item.
+
+```text
+###### This is code, not a heading.
+```

--- a/tests/fixtures/toc-browser-resize.md
+++ b/tests/fixtures/toc-browser-resize.md
@@ -1,0 +1,53 @@
+# Level one
+
+Open Contents with Tab and the file browser with B. Drag the small vertical
+handle on each panel's inner edge. Widths should survive closing and reopening
+Tinta; shrinking the window should leave space for this document.
+
+Jump to [level four](#level-four), [level five](#level-five), or [level six](#level-six).
+
+## Level two
+
+**Bold**, *italic*, `inline code`, x^2^, H~2~O and $a+b=c$.
+
+### Level three
+
+| Heading | Expected in Contents |
+| --- | --- |
+| H1 through H6 | All six levels |
+| A fenced fake heading | Excluded |
+
+#### Level four
+
+> A quote with **bold**, `code`, H~2~O and $x^2$.
+>
+> This second paragraph must keep its normal spacing.
+
+##### Level five
+
+- A list with a [level six link](#level-six).
+- A [companion document](toc-browser-companion-with-a-long-file-name.md).
+
+###### Level six
+
+```markdown
+#### This fenced heading must not appear in Contents
+```
+
+## Repeated title
+
+This heading shares its title with a deeper heading below. Jump to the
+[second occurrence](#repeated-title-1).
+
+#### Repeated title
+
+The second occurrence must have its own anchor and Contents row.
+
+#### A long deep heading with enough words to exercise a narrow Contents panel
+
+$$
+\frac{x^2 + y^2}{H_2O}
+$$
+
+Final paragraph with **bold** and ordinary text. Resizing panels must not edit
+this source, follow a link, select a heading, or open a file on mouse release.

--- a/tests/input_tests.cpp
+++ b/tests/input_tests.cpp
@@ -155,9 +155,11 @@ void settingsDismissal() {
 
 int runTabDropTests();
 int runSuperscriptTests();
+int runSidePanelTests();
 int runTabDropLaunchProbe();
 
 int main(int argc, char** argv) {
+    if (argc == 2 && std::string(argv[1]) == "--sidepanel-tests") return runSidePanelTests();
     if (argc == 2 && std::string(argv[1]) == "--superscript-tests") return runSuperscriptTests();
     if (argc == 2 && std::string(argv[1]) == "--tab-drop-tests") return runTabDropTests();
     if (argc == 7 && std::string(argv[1]) == "--cascade") return runTabDropLaunchProbe();

--- a/tests/render_sidepanel_fixtures.ps1
+++ b/tests/render_sidepanel_fixtures.ps1
@@ -18,7 +18,7 @@ openInTabs=0
 checkUpdates=0
 language=en
 '@ | Set-Content -LiteralPath "$taskOutput/runner/settings.ini"
-foreach ($taskName in @('toc-browser-resize','toc-browser-companion-with-a-long-file-name','markdown-regression-control','superscript-subscript')) {
+foreach ($taskName in @('toc-browser-resize','toc-browser-companion-with-a-long-file-name','markdown-regression-control','superscript-subscript','sidebar-visual-prototype')) {
     $taskSource = Join-Path $PSScriptRoot "fixtures/$taskName.md"
     $taskBefore = (Get-FileHash -LiteralPath $taskSource).Hash
     $taskDest = Join-Path $taskOutput $taskName

--- a/tests/render_sidepanel_fixtures.ps1
+++ b/tests/render_sidepanel_fixtures.ps1
@@ -1,0 +1,54 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/issue-210/fixed'
+)
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskOutput = Join-Path $taskRepo $Output
+$taskBinary = if ([IO.Path]::IsPathRooted($Binary)) { $Binary } else { Join-Path $taskRepo $Binary }
+New-Item -ItemType Directory -Force "$taskOutput/runner" | Out-Null
+$taskExe = Join-Path $taskOutput 'runner/tinta.exe'
+Copy-Item -LiteralPath $taskBinary -Destination $taskExe -Force
+@'
+[Settings]
+themeIndex=0
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+'@ | Set-Content -LiteralPath "$taskOutput/runner/settings.ini"
+foreach ($taskName in @('toc-browser-resize','toc-browser-companion-with-a-long-file-name','markdown-regression-control','superscript-subscript')) {
+    $taskSource = Join-Path $PSScriptRoot "fixtures/$taskName.md"
+    $taskBefore = (Get-FileHash -LiteralPath $taskSource).Hash
+    $taskDest = Join-Path $taskOutput $taskName
+    New-Item -ItemType Directory -Force $taskDest | Out-Null
+    foreach ($taskMode in @('printpages','exporthtml','exportdocx')) {
+        $taskTarget = switch ($taskMode) {
+            'printpages' { "$taskDest/pages" }
+            'exporthtml' { "$taskDest/document.html" }
+            'exportdocx' { "$taskDest/document.docx" }
+        }
+        $taskProcess = Start-Process -FilePath $taskExe -ArgumentList @(('"'+$taskSource+'"'),"--$taskMode",('"'+$taskTarget+'"')) -WindowStyle Hidden -PassThru
+        if (!$taskProcess.WaitForExit(30000)) {
+            Stop-Process -Id $taskProcess.Id -Force
+            $taskProcess.WaitForExit()
+            throw "$taskName $taskMode timed out"
+        }
+        if ($taskProcess.ExitCode -ne 0 -or !(Test-Path -LiteralPath $taskTarget)) { throw "$taskName $taskMode failed" }
+    }
+    $taskHtml = Get-Content -LiteralPath "$taskDest/document.html" -Raw -Encoding UTF8
+    if ($taskHtml -notmatch '<blockquote' -or $taskHtml -notmatch '<table>' -or $taskHtml -notmatch '<h1') {
+        throw "$taskName lost mixed Markdown content"
+    }
+    if ($taskName -eq 'toc-browser-resize') {
+        foreach ($taskLevel in 1..6) {
+            if ($taskHtml -notmatch "<h$taskLevel\b") { throw "Missing H$taskLevel export" }
+        }
+        if ([regex]::Matches($taskHtml, '<h[1-6]\b').Count -ne 9) { throw 'Heading count changed' }
+    }
+    if ((Get-FileHash -LiteralPath $taskSource).Hash -ne $taskBefore) { throw "$taskName source changed" }
+    $taskPages = @(Get-ChildItem -LiteralPath "$taskDest/pages" -Filter 'page-*.png')
+    if (!$taskPages.Count) { throw "$taskName produced no print pages" }
+    "$taskName : $($taskPages.Count) native pages, HTML and DOCX"
+}

--- a/tests/run_sidepanel_tests.cmake
+++ b/tests/run_sidepanel_tests.cmake
@@ -1,0 +1,11 @@
+if(NOT DEFINED TEST_BINARY OR NOT DEFINED TEST_DIR)
+    message(FATAL_ERROR "TEST_BINARY and TEST_DIR are required")
+endif()
+file(MAKE_DIRECTORY "${TEST_DIR}")
+configure_file("${TEST_BINARY}" "${TEST_DIR}/input_tests.exe" COPYONLY)
+file(WRITE "${TEST_DIR}/settings.ini" "; Isolated side-panel test configuration\n")
+execute_process(COMMAND "${TEST_DIR}/input_tests.exe" --sidepanel-tests
+    WORKING_DIRECTORY "${TEST_DIR}" RESULT_VARIABLE result)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Native side-panel test failed: ${result}")
+endif()

--- a/tests/sidepanel-validation.md
+++ b/tests/sidepanel-validation.md
@@ -29,3 +29,39 @@ the panels so their widths cannot change the page layout.
   Physical multi-monitor DPI transitions have not been manually exercised.
 
 The original visuals are checkpointed before the separate visual prototype.
+
+## Visual prototype
+
+The original checkpoint is `3448a168182a94a83c108c1b37e896445318d9d2` on
+`toc-browser-resize-210`; its executable is saved in
+`out/issue-210/visual-before/tinta.exe`. The prototype lives separately on
+`toc-sidebar-visual-prototype-210`. Reverting its single visual commit restores
+the original appearance while retaining H1-H6 support and resizing. The saved
+executable also allows restoring the dev builds without waiting for a rebuild.
+
+- Dock the panels without floating card borders, shadows or outer gaps. Each
+  boundary has one hairline that highlights on hover; the existing resize hit
+  area stays 10 logical pixels wide. This recovers 20 logical pixels within each
+  panel for labels and controls at the same preferred width.
+- Remove the duplicate document-position rail in Contents, retaining the short
+  active-heading marker and a separate Contents scrollbar when its list overflows.
+- With a side panel open, document scrollbars appear during scrolling, dragging,
+  search or edge hover. After 800 ms of inactivity they fade over 300 ms. A timer
+  stops after the fade. The editor and viewer without side panels retain their
+  previous scrollbar appearance.
+- Added `sidebar-visual-prototype.md`, with H1-H6, a table, quotes, lists, links,
+  code, scripts and equations. It is included in the native export runner.
+- Release build and **17/17 CTests passed**, including new interaction checks
+  for scrollbar dragging beside the resize target, fade timing, divider hover
+  and preserved ordinary-viewer behavior. Existing geometry, theme, scale and
+  print checks also pass.
+- All **19 export artifacts** (nine native PNG pages, five HTML and five DOCX
+  files) match the original-visual checkpoint byte for byte across five fixtures.
+- Computer-use screenshots inspected Paper at 1180x900 with browser left and
+  Contents right, and Midnight at 700x900 with both panels left. The shared
+  dividers, single-line footers, deep labels, active heading and surrounding
+  mixed content fit the intended layout. Automated native input tests provide
+  the deterministic resize/scrollbar interaction coverage.
+
+Generated preview builds, settings and export comparisons are isolated under
+`out/issue-210/`; physical monitor DPI transitions remain untested manually.

--- a/tests/sidepanel-validation.md
+++ b/tests/sidepanel-validation.md
@@ -65,3 +65,31 @@ executable also allows restoring the dev builds without waiting for a rebuild.
 
 Generated preview builds, settings and export comparisons are isolated under
 `out/issue-210/`; physical monitor DPI transitions remain untested manually.
+
+## Scrollbar refinement
+
+The document scrollbar in the sidebar layout now stays **4 logical pixels**
+wide on hover and while dragging. It keeps its existing 14-pixel hit area;
+the vertical thumb sits fully clear of the divider's resize target. Opacity
+is consistent across hover and ordinary scrolling, avoiding a second visual jump.
+
+Visibility eases in over **120 ms**, holds for **800 ms** after scrolling,
+then eases out over **300 ms**. Hover-only entry also animates. A new scroll
+during fade-out resumes from the current opacity instead of snapping to full
+visibility. The animation timer stops after settling, including when a panel
+closes or the editor/print preview opens.
+
+Release build and **17/17 CTests passed**. Native regression checks use controlled
+timestamps to cover the fade-in, hold, fade-out, hover-only entry, interruption,
+resize suppression, timer eligibility and reopening without stale opacity.
+Scrollbar-versus-divider hit testing and the existing theme/scale/layout checks
+also pass. `sidebar-visual-prototype.md` now contains a repeatable test sequence.
+
+All **20 artifacts** from the five mixed Markdown fixtures (ten PNG pages, five
+HTML and five DOCX files) match the pre-refinement executable byte for byte.
+The added instructions make the prototype sample three print pages in both
+builds. Source files remain unchanged by the export runner. Generated results
+are in `out/issue-210/scrollbar-baseline` and `out/issue-210/scrollbar-exports`;
+the preceding executable is in `out/issue-210/before-scrollbar-fade/tinta.exe`.
+Animation timing was verified by the native tests; perceived animation feel
+remains for the maintainer to review in the running app.

--- a/tests/sidepanel-validation.md
+++ b/tests/sidepanel-validation.md
@@ -1,0 +1,31 @@
+# Contents and panel resizing (#210)
+
+Validated on Windows on 2026-09-10. Reported by [@125Q](https://github.com/125Q)
+in [#210](https://github.com/oipoistar/tinta/issues/210).
+
+Contents includes H1-H6, with compact indentation, filtered navigation and
+distinct anchors for duplicate titles. Both panels resize from their inner
+edges and persist independent widths in logical pixels. Window resizing clamps
+the displayed widths while preserving the preferences. Escape and capture loss
+cancel a drag; mouse release cannot activate content. Printing temporarily hides
+the panels so their widths cannot change the page layout.
+
+## Verification of the original visual treatment
+
+- Release build and all 17 CTests passed. Native checks cover Paper/Midnight,
+  100/150/200% scale, narrow/wide geometry, both TOC sides, either/both panels,
+  capture/release/cancellation, persistence, malformed settings, filtering,
+  skipped levels, duplicate anchors and a 120-heading incremental document.
+- Native printing with both panels open versus closed produces identical pages.
+- `tests/render_sidepanel_fixtures.ps1` exported the two new mixed fixtures plus
+  `markdown-regression-control.md` and `superscript-subscript.md`. All seven PNG
+  pages and all four HTML/DOCX pairs match the preceding build byte for byte.
+  Source hashes remain unchanged. Generated files are under `out/issue-210/`.
+- Computer use checked Paper at 1180x900: browser/TOC drags, minimum widths,
+  deeper heading clicks and mixed content. The maintainer confirmed dragging
+  works, then requested a simpler visual treatment of the stacked edge controls.
+- Minimum-width footer wrapping was corrected and retested automatically;
+  computer use stopped on the maintainer's Escape before the final visual pass.
+  Physical multi-monitor DPI transitions have not been manually exercised.
+
+The original visuals are checkpointed before the separate visual prototype.

--- a/tests/sidepanel-validation.md
+++ b/tests/sidepanel-validation.md
@@ -93,3 +93,28 @@ are in `out/issue-210/scrollbar-baseline` and `out/issue-210/scrollbar-exports`;
 the preceding executable is in `out/issue-210/before-scrollbar-fade/tinta.exe`.
 Animation timing was verified by the native tests; perceived animation feel
 remains for the maintainer to review in the running app.
+
+## Captured scrollbar drags across panels
+
+The maintainer found that a held scrollbar stopped tracking while the pointer
+was over Contents. Panel hover routing returned before the scrollbar move
+handler. The new native regression reproduced this before the fix.
+
+An active document scrollbar now handles movement and release before panel,
+divider, title-bar and overlay hover/click routing. Both vertical and horizontal
+scrollbars keep tracking across panel and window boundaries. Release consumes
+the gesture without opening a file or jumping to a heading. Losing capture,
+focus or entering Windows cancel mode ends it cleanly; a subsequent fresh press
+does not inherit a swallowed release from the cancelled gesture.
+
+Release build and **17/17 CTests passed** after the implementation change.
+Additional title-bar and cancellation assertions were then added and the focused
+native panel test passed again. The checks cover 24 drag configurations across
+100/150/200% scale, left/right Contents, pinned/unpinned Contents and both scroll
+axes, including release over a real Contents row and movement after release.
+The browser remains pinned during these checks so it is present to cross.
+
+The mixed sample now includes a repeatable cross-panel drag sequence. All **20
+export artifacts** remain byte-identical to the preceding executable using the
+updated fixtures. Logs and exports are in `out/issue-210/capture-*`; the preceding
+executable is preserved in `out/issue-210/before-scrollbar-capture/tinta.exe`.

--- a/tests/sidepanel_tests.cpp
+++ b/tests/sidepanel_tests.cpp
@@ -157,6 +157,48 @@ void widthLimits(App& app) {
     }
 }
 
+void quietPanelEdges(App& app) {
+    app.contentScale = 1;
+    app.width = 1200;
+    app.height = 900;
+    app.showToc = app.showFolderBrowser = true;
+    app.tocOnLeft = false;
+    app.tocPinned = app.browserPinned = true;
+    app.tocAnimation = app.folderBrowserAnimation = 1;
+    app.tocWidth = 280;
+    app.browserWidth = 300;
+    app.verticalScrollbarVisible = true;
+    app.contentHeight = 2000;
+    app.lastPanelScrollActivity = 0;
+    app.mouseX = 500;
+    app.mouseY = 400;
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 2000), 0), "idle side-panel layout hides document scrollbars");
+    app.lastPanelScrollActivity = 1000;
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 1700), 1) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 1950), 0.5f) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 2100), 0), "scroll activity holds then fades the document scrollbar");
+    const float edge = sidePanelResizeEdge(app, SidePanel::Contents);
+    handleMouseMove(app, app.hwnd, MAKELPARAM((int)edge - 10, 400));
+    check(documentScrollbarEdgeHovered(app) && closeEnough(sidePanelDocumentScrollbarOpacity(app, 3000), 1),
+          "hover reveals the document scrollbar beside the divider");
+    handleMouseDown(app, app.hwnd, 0, MAKELPARAM((int)edge - 10, 400));
+    check(app.scrollbarDragging && app.panelResize.panel == SidePanel::None,
+          "the document scrollbar remains draggable beside the invisible resize target");
+    handleMouseUp(app, app.hwnd, 0, MAKELPARAM((int)edge - 10, 400));
+    app.mouseX = (int)edge;
+    check(!documentScrollbarEdgeHovered(app) && sidePanelResizeAt(app, edge, 400) == SidePanel::Contents,
+          "hover at the shared divider targets resizing only");
+    check(sidePanelResizeBegin(app, app.hwnd, edge, 400) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 1700), 0), "resizing does not display a second competing rail");
+    sidePanelResizeEnd(app, app.hwnd, true);
+    app.swallowNextMouseUp = false;
+    app.mouseX = app.mouseY = -1;
+    check(!documentScrollbarEdgeHovered(app), "leaving the window clears edge hover");
+    app.showToc = app.showFolderBrowser = false;
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 3000), 1), "ordinary viewer scrollbar appearance is preserved");
+    app.tocPinned = app.browserPinned = false;
+}
+
 void longContents(App& app) {
     app.contentScale = 1;
     updateTextFormats(app);
@@ -249,6 +291,7 @@ int runSidePanelTests() {
                 for (SidePanel panel : {SidePanel::Contents, SidePanel::Browser})
                     resizeGesture(app, panel, left, both, scale);
     widthLimits(app);
+    quietPanelEdges(app);
     longContents(app);
 
     app.contentScale = app.zoomFactor = 1;

--- a/tests/sidepanel_tests.cpp
+++ b/tests/sidepanel_tests.cpp
@@ -170,17 +170,27 @@ void quietPanelEdges(App& app) {
     app.verticalScrollbarVisible = true;
     app.contentHeight = 2000;
     app.lastPanelScrollActivity = 0;
+    app.panelScrollbarFade = {};
     app.mouseX = 500;
     app.mouseY = 400;
-    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 2000), 0), "idle side-panel layout hides document scrollbars");
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 900), 0) && !sidePanelScrollbarNeedsTicks(app, 900),
+          "idle side-panel layout hides scrollbars without a running animation timer");
     app.lastPanelScrollActivity = 1000;
-    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 1700), 1) &&
-          closeEnough(sidePanelDocumentScrollbarOpacity(app, 1950), 0.5f) &&
-          closeEnough(sidePanelDocumentScrollbarOpacity(app, 2100), 0), "scroll activity holds then fades the document scrollbar");
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 1000), 0) && sidePanelScrollbarNeedsTicks(app, 1000),
+          "new scroll activity starts a fade-in without an opacity jump");
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 1060), 0.5f) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 1120), 1) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 1700), 1), "scrollbar gently appears over 120ms then holds");
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 1801), 1) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 1951), 0.5f) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 2101), 0) && !sidePanelScrollbarNeedsTicks(app, 2101),
+          "scrollbar fades out after inactivity and its timer can stop");
     const float edge = sidePanelResizeEdge(app, SidePanel::Contents);
     handleMouseMove(app, app.hwnd, MAKELPARAM((int)edge - 10, 400));
-    check(documentScrollbarEdgeHovered(app) && closeEnough(sidePanelDocumentScrollbarOpacity(app, 3000), 1),
-          "hover reveals the document scrollbar beside the divider");
+    check(documentScrollbarEdgeHovered(app) && closeEnough(sidePanelDocumentScrollbarOpacity(app, 3000), 0) &&
+          sidePanelScrollbarNeedsTicks(app, 3000) && closeEnough(sidePanelDocumentScrollbarOpacity(app, 3060), 0.5f) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 3120), 1) && !sidePanelScrollbarNeedsTicks(app, 3120),
+          "hover alone fades in the scrollbar and stops ticking once fully visible");
     handleMouseDown(app, app.hwnd, 0, MAKELPARAM((int)edge - 10, 400));
     check(app.scrollbarDragging && app.panelResize.panel == SidePanel::None,
           "the document scrollbar remains draggable beside the invisible resize target");
@@ -188,14 +198,25 @@ void quietPanelEdges(App& app) {
     app.mouseX = (int)edge;
     check(!documentScrollbarEdgeHovered(app) && sidePanelResizeAt(app, edge, 400) == SidePanel::Contents,
           "hover at the shared divider targets resizing only");
+    sidePanelDocumentScrollbarOpacity(app, 3200);
+    const float fading = sidePanelDocumentScrollbarOpacity(app, 3350);
+    app.lastPanelScrollActivity = 3350;
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 3350), fading) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 3410), 0.75f) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 3470), 1),
+          "scrolling again during fade-out resumes smoothly from the current opacity");
     check(sidePanelResizeBegin(app, app.hwnd, edge, 400) &&
-          closeEnough(sidePanelDocumentScrollbarOpacity(app, 1700), 0), "resizing does not display a second competing rail");
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 3500), 1) &&
+          closeEnough(sidePanelDocumentScrollbarOpacity(app, 3800), 0), "resizing fades away the competing scrollbar");
     sidePanelResizeEnd(app, app.hwnd, true);
     app.swallowNextMouseUp = false;
     app.mouseX = app.mouseY = -1;
     check(!documentScrollbarEdgeHovered(app), "leaving the window clears edge hover");
     app.showToc = app.showFolderBrowser = false;
-    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 3000), 1), "ordinary viewer scrollbar appearance is preserved");
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 4000), 1) && !sidePanelScrollbarNeedsTicks(app, 4000),
+          "ordinary viewer scrollbar appearance is preserved without an animation timer");
+    app.showToc = true;
+    check(closeEnough(sidePanelDocumentScrollbarOpacity(app, 5000), 0), "reopening the panel does not reuse stale visible opacity");
     app.tocPinned = app.browserPinned = false;
 }
 

--- a/tests/sidepanel_tests.cpp
+++ b/tests/sidepanel_tests.cpp
@@ -26,8 +26,12 @@ std::string read(const std::filesystem::path& path) {
 }
 LRESULT CALLBACK testProc(HWND hwnd, UINT message, WPARAM w, LPARAM l) {
     auto* app = reinterpret_cast<App*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
-    if (app && message == WM_CAPTURECHANGED && reinterpret_cast<HWND>(l) != hwnd)
+    if (app && message == WM_CAPTURECHANGED && reinterpret_cast<HWND>(l) != hwnd) {
         sidePanelResizeEnd(*app, hwnd, true);
+        cancelDocumentScrollbarDrag(*app, hwnd);
+    }
+    if (app && (message == WM_KILLFOCUS || message == WM_CANCELMODE))
+        cancelDocumentScrollbarDrag(*app, hwnd);
     return DefWindowProcW(hwnd, message, w, l);
 }
 void layout(App& app, const std::string& source) {
@@ -220,6 +224,101 @@ void quietPanelEdges(App& app) {
     app.tocPinned = app.browserPinned = false;
 }
 
+void scrollbarAcrossPanels(App& app) {
+    for (float scale : {1.0f, 1.5f, 2.0f}) {
+        for (bool left : {false, true}) {
+            for (bool pinned : {false, true}) {
+                app.contentScale = scale;
+                app.width = (int)dpi(app, 1200);
+                app.height = (int)dpi(app, 900);
+                app.showToc = app.showFolderBrowser = true;
+                app.tocPinned = pinned;
+                app.browserPinned = true;
+                app.tocOnLeft = left;
+                app.tocWidth = 280;
+                app.browserWidth = 300;
+                app.tocAnimation = app.folderBrowserAnimation = 1;
+                app.tocScroll = app.folderBrowserScroll = 0;
+                app.tocSpyOverride = -1;
+                app.swallowNextMouseUp = false;
+                updateTextFormats(app);
+                layout(app, read(TINTA_PANEL_FIXTURE));
+                // Keep real mixed-content rows for click guards, with ample
+                // scroll ranges for deterministic movement in either direction.
+                const float viewport = documentViewportWidth(app);
+                const float docLeft = documentViewportX(app);
+                const float docRight = docLeft + viewport;
+                app.contentHeight = dpi(app, 6000);
+                app.contentWidth = viewport * 4;
+                app.verticalScrollbarVisible = true;
+                app.scrollY = app.targetScrollY = dpi(app, 400);
+                app.scrollX = app.targetScrollX = viewport * 1.5f;
+                const float tocCenter = tocPanelX(app, tocPanelWidth(app)) + tocPanelWidth(app) / 2;
+                const float browserCenter = folderBrowserPanelWidth(app) / 2;
+                const auto originalPath = app.currentFile;
+                for (bool horizontal : {false, true}) {
+                    const int startX = (int)(horizontal ? docLeft + viewport / 2 : docRight - dpi(app, 9));
+                    const int startY = (int)(horizontal ? app.height - dpi(app, 8) : dpi(app, 200));
+                    handleMouseMove(app, app.hwnd, MAKELPARAM(startX, startY));
+                    handleMouseDown(app, app.hwnd, 0, MAKELPARAM(startX, startY));
+                    check((horizontal ? app.hScrollbarDragging : app.scrollbarDragging) && GetCapture() == app.hwnd,
+                          "scrollbar drag captures before crossing panels");
+                    int step = 0;
+                    float previousX = (float)startX;
+                    for (float x : {sidePanelResizeEdge(app, SidePanel::Contents), tocCenter,
+                                    browserCenter, -dpi(app, 50), app.width + dpi(app, 50), dpi(app, 20)}) {
+                        const float before = horizontal ? app.scrollX : app.scrollY;
+                        const int y = (int)dpi(app, 250 + 40 * step++);
+                        handleMouseMove(app, app.hwnd, MAKELPARAM((int)x, y));
+                        const float after = horizontal ? app.scrollX : app.scrollY;
+                        if (!horizontal || (x > previousX && before < app.contentWidth - viewport - 1))
+                            check(after > before, "captured scrollbar keeps moving over dividers, Contents, browser and outside the window");
+                        else if (x < previousX && before > 1)
+                            check(after < before, "horizontal scrollbar also follows movement across panels");
+                        check(app.panelResize.panel == SidePanel::None && app.tocSpyOverride == -1 &&
+                              closeEnough(app.tocScroll, 0) && closeEnough(app.folderBrowserScroll, 0),
+                              "scrollbar drag cannot resize or scroll the side panels");
+                        previousX = x;
+                    }
+                    const float beforeTitle = horizontal ? app.scrollX : app.scrollY;
+                    const int titleX = (int)(horizontal ? docLeft + viewport * 0.75f : dpi(app, 20));
+                    handleMouseMove(app, app.hwnd, MAKELPARAM(titleX, (int)dpi(app, 20)));
+                    check(horizontal ? app.scrollX > beforeTitle : app.scrollY < beforeTitle,
+                          "the title bar and application icon cannot intercept a captured scrollbar drag");
+                    const auto list = tocListRect(app);
+                    handleMouseUp(app, app.hwnd, 0, MAKELPARAM((int)tocCenter, (int)list.top + 10));
+                    check(!app.scrollbarDragging && !app.hScrollbarDragging && GetCapture() != app.hwnd &&
+                          app.currentFile == originalPath && app.tocSpyOverride == -1 && app.showToc && app.showFolderBrowser,
+                          "release over a Contents row ends the drag without activating anything");
+                    const float stoppedX = app.scrollX, stoppedY = app.scrollY;
+                    handleMouseMove(app, app.hwnd, MAKELPARAM((int)(docLeft + viewport / 2), (int)dpi(app, 400)));
+                    check(closeEnough(app.scrollX, stoppedX) && closeEnough(app.scrollY, stoppedY),
+                          "ordinary movement after release no longer scrolls");
+                    for (int cancelMode = 0; cancelMode < 3; ++cancelMode) {
+                        handleMouseMove(app, app.hwnd, MAKELPARAM(startX, startY));
+                        handleMouseDown(app, app.hwnd, 0, MAKELPARAM(startX, startY));
+                        check(GetCapture() == app.hwnd, "another scrollbar drag can start");
+                        if (cancelMode == 0) ReleaseCapture();
+                        else SendMessage(app.hwnd, cancelMode == 1 ? WM_KILLFOCUS : WM_CANCELMODE, 0, 0);
+                        check(!app.scrollbarDragging && !app.hScrollbarDragging && GetCapture() != app.hwnd,
+                              "lost capture, focus loss and cancel mode clear the scrollbar gesture");
+                        if (cancelMode == 2) {
+                            // The cancelled release may have gone to another window.
+                            handleMouseDown(app, app.hwnd, 0, MAKELPARAM(startX, startY));
+                            check(!app.swallowNextMouseUp && GetCapture() == app.hwnd,
+                                  "a fresh press is not swallowed after cancellation elsewhere");
+                        }
+                        handleMouseUp(app, app.hwnd, 0, MAKELPARAM((int)tocCenter, (int)list.top + 10));
+                        check(app.tocSpyOverride == -1 && app.currentFile == originalPath && app.showToc,
+                              "release after cancellation cannot activate a Contents heading");
+                    }
+                }
+            }
+        }
+    }
+    app.tocPinned = app.browserPinned = false;
+}
+
 void longContents(App& app) {
     app.contentScale = 1;
     updateTextFormats(app);
@@ -313,6 +412,7 @@ int runSidePanelTests() {
                     resizeGesture(app, panel, left, both, scale);
     widthLimits(app);
     quietPanelEdges(app);
+    scrollbarAcrossPanels(app);
     longContents(app);
 
     app.contentScale = app.zoomFactor = 1;

--- a/tests/sidepanel_tests.cpp
+++ b/tests/sidepanel_tests.cpp
@@ -1,0 +1,284 @@
+#include "sidepanels.h"
+#include "d2d_init.h"
+#include "file_utils.h"
+#include "input.h"
+#include "overlays.h"
+#include "print.h"
+#include "render.h"
+#include "settings.h"
+#include "utils.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <windowsx.h>
+
+namespace {
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+bool closeEnough(float a, float b) { return std::abs(a-b) < 0.1f; }
+std::string read(const std::filesystem::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    return {(std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>()};
+}
+LRESULT CALLBACK testProc(HWND hwnd, UINT message, WPARAM w, LPARAM l) {
+    auto* app = reinterpret_cast<App*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+    if (app && message == WM_CAPTURECHANGED && reinterpret_cast<HWND>(l) != hwnd)
+        sidePanelResizeEnd(*app, hwnd, true);
+    return DefWindowProcW(hwnd, message, w, l);
+}
+void layout(App& app, const std::string& source) {
+    const auto result = app.parser.parse(source);
+    check(result.success, "panel fixture parses");
+    app.root = result.root;
+    layoutDocument(app);
+}
+void renderPanels(App& app) {
+    app.renderTarget->BeginDraw();
+    if (app.showFolderBrowser) renderFolderBrowser(app);
+    if (app.showToc) renderToc(app);
+    check(SUCCEEDED(app.renderTarget->EndDraw()), "native panels render after resize");
+}
+void headings(App& app, const std::string& source) {
+    layout(app, source);
+    check(app.headings.size() == 9, "all H1-H6 and repeated headings enter Contents (#210)");
+    if (app.headings.size() != 9) return;
+    for (int level = 1; level <= 6; ++level)
+        check(app.headings[level-1].level == level, "heading order and original levels are retained");
+    check(app.headings[6].id == "repeated-title" && app.headings[7].id == "repeated-title-1",
+          "duplicate titles across heading levels receive distinct anchors");
+    check(scrollToHeadingId(app, "level-four") && scrollToHeadingId(app, "level-five") &&
+          scrollToHeadingId(app, "level-six") && scrollToHeadingId(app, "repeated-title-1"),
+          "deep headings and duplicate titles support anchor navigation");
+    check(app.tableRects.size() == 1 && app.codeBlocks.size() == 1 &&
+          app.docText.find(L"Final paragraph") != std::wstring::npos,
+          "mixed Markdown table, code, math and final text survive layout");
+    app.showToc = true;
+    app.tocAnimation = 1;
+    app.tocFilter = L"level six";
+    app.tocScroll = 0;
+    const auto list = tocListRect(app);
+    check(tocItemIndexAt(app, list.left + 15, list.top + 10) == 5,
+          "filtered Contents hit-testing finds an H6 row");
+    app.tocPinned = true;
+    handleMouseUp(app, app.hwnd, 0, MAKELPARAM((int)list.left + 15, (int)list.top + 10));
+    check(app.tocSpyOverride == 5 && app.showToc, "clicking H6 navigates and preserves a pinned Contents panel");
+    check(closeEnough(tocMaxScroll(app), 0), "filtered short Contents has no excess scrolling");
+    app.tocFilter.clear();
+    app.tocPinned = false;
+
+    // Reflow completion must not skip or register a heading twice.
+    app.layoutDirty = true;
+    layoutDocumentViewportFirst(app);
+    ensureLayoutComplete(app);
+    check(app.headings.size() == 9 && app.headings[7].id == "repeated-title-1",
+          "incremental layout preserves heading identities");
+}
+void resizeGesture(App& app, SidePanel panel, bool onLeft, bool both, float scale) {
+    app.contentScale = scale;
+    app.width = static_cast<int>(1200 * scale);
+    app.height = static_cast<int>(900 * scale);
+    app.showToc = both || panel == SidePanel::Contents;
+    app.showFolderBrowser = both || panel == SidePanel::Browser;
+    app.tocOnLeft = onLeft;
+    app.tocAnimation = app.folderBrowserAnimation = 1;
+    app.tocWidth = 280;
+    app.browserWidth = 300;
+    app.tocSpyOverride = -1;
+    app.swallowNextMouseUp = false;
+    const std::string path = app.currentFile;
+    const float start = sidePanelResizeEdge(app, panel);
+    const float y = dpi(app, 300);
+    const float direction = panel == SidePanel::Contents && !onLeft ? -1 : 1;
+    const float target = start + direction * dpi(app, 100);
+    handleMouseDown(app, app.hwnd, 0, MAKELPARAM((int)start, (int)y));
+    check(app.panelResize.panel == panel && GetCapture() == app.hwnd, "panel edge captures the drag");
+    handleMouseMove(app, app.hwnd, MAKELPARAM((int)target, (int)y));
+    check(closeEnough(sidePanelResizeEdge(app, panel), target), "dragged edge follows the pointer at monitor DPI");
+    handleMouseUp(app, app.hwnd, 0, MAKELPARAM((int)target, (int)y));
+    check(app.panelResize.panel == SidePanel::None && GetCapture() != app.hwnd,
+          "release ends resizing and releases capture");
+    check(app.currentFile == path && app.tocSpyOverride == -1 && !app.selecting,
+          "resize release cannot open a file, navigate a heading or select document text");
+    check(app.showToc == (both || panel == SidePanel::Contents) &&
+          app.showFolderBrowser == (both || panel == SidePanel::Browser), "resize does not dismiss either panel");
+    const Settings saved = loadSettings();
+    check(closeEnough(saved.tocWidth, app.tocWidth) && closeEnough(saved.browserWidth, app.browserWidth),
+          "both widths persist after a completed resize");
+    const float oldToc = app.tocWidth, oldBrowser = app.browserWidth;
+    for (bool escape : {false, true}) {
+        const float edge = sidePanelResizeEdge(app, panel);
+        check(sidePanelResizeBegin(app, app.hwnd, edge, y), "a second resize can start");
+        sidePanelResizeMove(app, edge + direction * dpi(app, 80));
+        if (escape) handleKeyDown(app, app.hwnd, VK_ESCAPE);
+        else ReleaseCapture();
+        check(app.panelResize.panel == SidePanel::None && GetCapture() != app.hwnd &&
+              closeEnough(app.tocWidth, oldToc) && closeEnough(app.browserWidth, oldBrowser),
+              "Escape or lost capture cancels and restores both widths");
+        handleMouseUp(app, app.hwnd, 0, MAKELPARAM((int)edge, (int)y));
+        check(app.currentFile == path, "cancelled resize release cannot activate content");
+    }
+    app.showSettings = true;
+    check(sidePanelResizeAt(app, sidePanelResizeEdge(app, panel), y) == SidePanel::None,
+          "modal settings block the panel handle");
+    app.showSettings = false;
+    app.editMode = true;
+    check(sidePanelResizeAt(app, sidePanelResizeEdge(app, panel), y) == SidePanel::None,
+          "panel resizing cannot steal the editor split handle");
+    app.editMode = false;
+}
+void widthLimits(App& app) {
+    app.showToc = app.showFolderBrowser = true;
+    for (float scale : {1.0f, 1.5f, 2.0f}) {
+        app.contentScale = scale;
+        for (int width : {300, 480, 650, 1050, 1600}) {
+            app.width = static_cast<int>(width * scale);
+            for (float wanted : {180.0f, 280.0f, 600.0f, 4000.0f}) {
+                app.tocWidth = wanted;
+                app.browserWidth = wanted + 20;
+                const auto sizes = sidePanelWidths(app);
+                check(sizes.toc >= 0 && sizes.browser >= 0 &&
+                      sizes.toc + sizes.browser <= sidePanelBudget(app) + 0.1f &&
+                      documentViewportWidth(app) >= std::min(dpi(app, 240), app.width * 0.4f) - 0.1f,
+                      "both panels fit and reserve document space on narrow windows");
+                app.zoomFactor = 1.5f;
+                check(closeEnough(tocPanelWidth(app), sizes.toc) && closeEnough(folderBrowserPanelWidth(app), sizes.browser),
+                      "document zoom cannot resize the side panels");
+                app.zoomFactor = 1;
+                check(closeEnough(app.tocWidth, wanted), "window clamping does not overwrite the preferred width");
+                const float fullIndent = tocHeadingIndent(app, 6);
+                check(fullIndent >= tocHeadingIndent(app, 3) && fullIndent < sizes.toc * 0.36f,
+                      "deep indentation leaves room for heading text");
+            }
+        }
+    }
+}
+
+void longContents(App& app) {
+    app.contentScale = 1;
+    updateTextFormats(app);
+    app.width = 1050;
+    app.height = 400;
+    app.showFolderBrowser = false;
+    app.showToc = true;
+    app.tocWidth = 180;
+    app.tocAnimation = 1;
+    app.tocFilter.clear();
+    std::string source;
+    for (int i = 0; i < 120; ++i)
+        source += std::string(i % 6 + 1, '#') + " Section " + std::to_string(i) +
+                  "\n\nA paragraph with **bold**, `code` and $x^2$.\n\n";
+    app.root = app.parser.parse(source).root;
+    app.scrollY = app.targetScrollY = 0;
+    app.layoutDirty = true;
+    layoutDocumentViewportFirst(app);
+    ensureLayoutComplete(app);
+    check(app.headings.size() == 120 && app.headings.back().level == 6 &&
+          app.headings.back().id == "section-119", "incremental long documents retain every deep heading");
+    const auto rect = tocListRect(app);
+    app.tocScroll = tocMaxScroll(app) - 1;
+    app.mouseX = (int)(rect.left + 20);
+    app.mouseY = (int)(rect.top + 20);
+    handleMouseWheel(app, app.hwnd, MAKEWPARAM(0, (WORD)-WHEEL_DELTA), 0);
+    check(closeEnough(app.tocScroll, tocMaxScroll(app)) &&
+          tocItemIndexAt(app, rect.left + 20, rect.bottom - 13) == 119,
+          "wheel scrolling reaches the final H6 row without excess blank space");
+    app.tocFilter = L"section 119";
+    app.tocScroll = 0;
+    check(tocItemIndexAt(app, rect.left + 20, rect.top + 13) == 119 &&
+          closeEnough(tocMaxScroll(app), 0), "filtering a long Contents uses the filtered row count");
+    app.tocFilter.clear();
+    const auto companion = std::filesystem::path(TINTA_PANEL_FIXTURE).parent_path() /
+                           "toc-browser-companion-with-a-long-file-name.md";
+    layout(app, read(companion));
+    check(app.headings.size() == 2 && app.headings[1].level == 6,
+          "H6 appears when intermediate heading levels are skipped");
+}
+}
+
+int runSidePanelTests() {
+    namespace fs = std::filesystem;
+    wchar_t exe[MAX_PATH]{};
+    GetModuleFileNameW(nullptr, exe, MAX_PATH);
+    const auto dir = fs::path(exe).parent_path();
+    const auto marker = read(dir / "settings.ini");
+    if (!fs::equivalent(dir, fs::current_path()) ||
+        (marker != "; Isolated side-panel test configuration\n" &&
+         marker != "; Isolated side-panel test configuration\r\n")) return 2;
+    check(fs::equivalent(tintaConfigDir(), dir), "all settings writes stay in the portable test directory");
+    auto state = std::make_unique<App>();
+    App& app = *state;
+    WNDCLASSW wc{};
+    wc.lpfnWndProc = testProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = L"TintaSidePanelTest";
+    RegisterClassW(&wc);
+    app.hwnd = CreateWindowExW(0, wc.lpszClassName, L"Panel tests", WS_POPUP,
+        0, 0, 1050, 900, nullptr, nullptr, wc.hInstance, nullptr);
+    SetWindowLongPtrW(app.hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(&app));
+    if (!app.hwnd || !initD2D(app) || !createRenderTarget(app)) return 2;
+    const auto source = read(TINTA_PANEL_FIXTURE);
+    check(!source.empty(), "mixed panel fixture loads");
+    app.currentFile = TINTA_PANEL_FIXTURE;
+    app.folderBrowserPath = fs::path(TINTA_PANEL_FIXTURE).parent_path().wstring();
+    populateFolderItems(app);
+    for (int theme : {0, 5}) {
+        applyTheme(app, theme);
+        for (float scale : {1.0f, 1.5f, 2.0f}) {
+            app.contentScale = scale;
+            updateTextFormats(app);
+            for (int width : {650, 1050}) {
+                app.width = static_cast<int>(width * scale);
+                app.height = static_cast<int>(900 * scale);
+                for (bool left : {false, true}) {
+                    app.tocOnLeft = left;
+                    app.showFolderBrowser = true;
+                    app.folderBrowserAnimation = 1;
+                    headings(app, source);
+                    renderPanels(app);
+                }
+            }
+        }
+    }
+    for (float scale : {1.0f, 1.5f, 2.0f})
+        for (bool left : {false, true})
+            for (bool both : {false, true})
+                for (SidePanel panel : {SidePanel::Contents, SidePanel::Browser})
+                    resizeGesture(app, panel, left, both, scale);
+    widthLimits(app);
+    longContents(app);
+
+    app.contentScale = app.zoomFactor = 1;
+    app.width = 1050;
+    app.height = 900;
+    app.showToc = app.showFolderBrowser = false;
+    layout(app, source);
+    const int plainPages = printDebugPages(app, (dir / "plain-pages").wstring());
+    app.showToc = app.showFolderBrowser = true;
+    app.tocWidth = 500;
+    app.browserWidth = 400;
+    const int panelPages = printDebugPages(app, (dir / "panel-pages").wstring());
+    check(plainPages > 0 && plainPages == panelPages, "open resized panels do not alter print pagination");
+    for (int page = 1; page <= plainPages && page <= panelPages; ++page) {
+        const auto name = "page-" + std::to_string(page) + ".png";
+        check(read(dir / "plain-pages" / name) == read(dir / "panel-pages" / name),
+              "print pixels are identical with resized panels open or closed");
+    }
+    check(app.showToc && app.showFolderBrowser && closeEnough(app.tocWidth, 500) && closeEnough(app.browserWidth, 400),
+          "printing restores panel visibility and preferred widths");
+    {
+        std::ofstream(dir / "settings.ini") << "tocWidth=bad\nbrowserWidth=nan\n";
+        const auto saved = loadSettings();
+        check(closeEnough(saved.tocWidth, 280) && closeEnough(saved.browserWidth, 300),
+              "invalid saved panel widths safely use defaults");
+    }
+    DestroyWindow(app.hwnd);
+    app.hwnd = nullptr;
+    state.reset();
+    CoUninitialize();
+    std::cout << "Contents and resizable panels: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Contents omitted H4-H6 even though the parser retained them. This change includes all six levels in the outline, filtering and heading navigation, with compact indentation and bounded labels. Thanks to @125Q for reporting this in #210.

Both Contents and the file browser can be resized from their inner divider. Preferred widths persist independently of document zoom and clamp together in narrow windows. Docked surfaces use one divider, a short active-heading marker and slim document scrollbars that fade in/out smoothly. A captured scrollbar drag continues across side panels and window edges; release or capture/focus loss ends it without activating content. Printing temporarily suspends side panels so their widths cannot change page layout.

Validation: Release build and all 17 CTests passed. The cross-panel drag regression failed before the fix and passes afterward, covering both axes, panel sides, pin states, 100/150/200% scale and capture cancellation. Five mixed Markdown fixtures preserve all 20 native PNG/HTML/DOCX export artifacts byte for byte. Earlier computer-use checks inspected Paper at normal width and Midnight with both panels left at narrow width. Validation details are in tests/sidepanel-validation.md.

The original resizable-panel appearance is preserved in commit 3448a16 and a local executable backup for quick rollback. The visual prototype and refinements are separate commits. This draft is stacked on #212; no release or reporter reply has been posted.

Fixes #210.
