### PR TITLE
Add native syntax highlighting for nine more languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCES
     src/tableedit.cpp
     src/d2d_init.cpp
     src/syntax.cpp
+    src/syntax_extended.cpp
     src/utils.cpp
     src/search.cpp
     src/render.cpp
@@ -186,6 +187,13 @@ if(BUILD_TESTING)
     target_compile_definitions(code_block_layout_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
         TINTA_CODE_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/code-block-spacing.md")
     add_test(NAME code_block_layout COMMAND code_block_layout_tests)
+
+    add_executable(syntax_tests tests/syntax_tests.cpp ${INPUT_TEST_SOURCES})
+    target_include_directories(syntax_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(syntax_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
+    target_compile_definitions(syntax_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
+        TINTA_SYNTAX_FIXTURES="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures")
+    add_test(NAME syntax_highlighting COMMAND syntax_tests)
 
     add_executable(blockquote_layout_tests tests/blockquote_layout_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(blockquote_layout_tests PRIVATE include ${md4c_SOURCE_DIR}/src)

--- a/README.md
+++ b/README.md
@@ -279,6 +279,9 @@ keeps its own colors. Without `inlinecode`, inline code uses `code` as before.
 The override is preserved when saving a theme from the editor and applies to
 HTML and DOCX exports. Native printing keeps Tinta's existing light print palette.
 
+For supported code-fence languages and aliases, including SQL, PowerShell, Java,
+PHP, HTML/XML, CSS, YAML and Markdown, see [Syntax highlighting](docs/syntax-highlighting.md).
+
 ## Dependencies
 
 - [MD4C](https://github.com/mity/md4c) - Fast markdown parser (fetched automatically by CMake)

--- a/docs/syntax-highlighting.md
+++ b/docs/syntax-highlighting.md
@@ -1,0 +1,61 @@
+# Code syntax highlighting
+
+Add a language after the opening Markdown fence to colour code in Tinta:
+
+````markdown
+```sql
+SELECT employee_id FROM employees WHERE active = 1;
+```
+````
+
+Language labels are case-insensitive. Labels that Tinta does not recognise,
+and fences without a language, display as plain code.
+
+| Language | Fence labels |
+| :--- | :--- |
+| C / C++ | `c`, `cpp`, `c++`, `h`, `hpp`, `cxx` |
+| C# | `csharp`, `cs`, `c#` |
+| Python | `python`, `py` |
+| JavaScript / TypeScript | `javascript`, `js`, `jsx`, `typescript`, `ts`, `tsx` |
+| JSON | `json` (JavaScript rules) |
+| Rust | `rust`, `rs` |
+| Go | `go`, `golang` |
+| Shell | `bash`, `shell`, `sh`, `zsh` |
+| SQL | `sql` |
+| PowerShell | `powershell`, `ps`, `pwsh` |
+| Java | `java` |
+| PHP | `php` |
+| HTML | `html`, `htm` |
+| XML | `xml` |
+| CSS | `css` |
+| YAML | `yaml`, `yml` |
+| Markdown | `markdown`, `md` |
+
+The nine languages added for [#207](https://github.com/oipoistar/tinta/issues/207)
+recognise common keywords, types, calls, numbers, strings and comments where
+applicable. Markup adds tags, attributes and entities; CSS adds selectors,
+properties and values; YAML adds keys, anchors, aliases and block scalars;
+Markdown adds headings, lists, emphasis, code and links.
+
+Multiline support includes SQL comments, quoted strings and dollar-quoted strings;
+PowerShell comments and here-strings; Java text blocks; PHP heredocs and nowdocs;
+HTML/XML comments, quoted attributes and CDATA; CSS comments; YAML quoted and
+block values; and fenced examples inside Markdown. State resets at every outer
+Markdown code fence. Copying and searching use the original code text.
+
+Custom themes continue to use `syntaxkeyword`, `syntaxstring`, `syntaxcomment`,
+`syntaxnumber`, `syntaxfunction`, `syntaxtype` and `syntaxcontrolflow`. Variables,
+attributes and mapping keys use the type colour; plain code and punctuation use
+`code`. No additional fonts, packages or runtime are required.
+
+These are lexical colour rules, not a compiler or complete grammar for every
+dialect. Calls and type names use heuristics. Interpolation inside strings keeps
+the string colour; HTML script/style bodies stay plain, and inner Markdown code
+fences use the string colour. Embedded PHP/HTML switching, full XML DTDs and
+complete CommonMark parsing inside code blocks are outside this extension.
+HTML and DOCX exports retain their existing plain-code formatting; native viewing
+and printing use syntax colours.
+
+Open [the mixed language sample](../tests/fixtures/syntax-languages.md) or
+[the multiline and alias sample](../tests/fixtures/syntax-multiline.md) in Tinta
+to try the new rules.

--- a/include/syntax.h
+++ b/include/syntax.h
@@ -13,6 +13,34 @@ struct SyntaxToken {
     SyntaxTokenType tokenType;
 };
 
+// Keep the original language IDs stable; the extended lexers share block-local
+// state, never state between unrelated fenced blocks.
+enum SyntaxLanguage {
+    LanguageSql = 8, LanguagePowerShell, LanguageJava, LanguagePhp,
+    LanguageHtml, LanguageXml, LanguageCss, LanguageYaml, LanguageMarkdown
+};
+
+struct SyntaxState {
+    enum class Mode { Normal, Comment, Quote, Delimited, HereString, Heredoc,
+                      YamlBlock, MarkdownFence };
+    Mode mode = Mode::Normal;
+    bool inBlockComment = false; // Original language lexers.
+    std::wstring delimiter;
+    std::wstring commentOpen;
+    int commentDepth = 0;
+    wchar_t escape = 0;
+    bool doubledQuote = false;
+    bool inTag = false;
+    bool tagName = false;
+    bool closingTag = false;
+    std::wstring tag;
+    std::wstring rawTag;
+    int braceDepth = 0;
+    bool cssValue = false;
+    size_t blockIndent = 0;
+    size_t explicitIndent = 0;
+};
+
 // Language keyword sets
 extern const std::unordered_set<std::wstring> CPP_KEYWORDS;
 extern const std::unordered_set<std::wstring> CPP_TYPES;
@@ -27,7 +55,8 @@ extern const std::unordered_set<std::wstring> CSHARP_TYPES;
 
 int detectLanguage(const std::wstring& lang);
 const std::unordered_set<std::wstring>* getKeywordsForLanguage(int lang);
-std::vector<SyntaxToken> tokenizeLine(const std::wstring& line, int language, bool& inBlockComment);
+std::vector<SyntaxToken> tokenizeLine(const std::wstring& line, int language, SyntaxState& state);
+std::vector<SyntaxToken> tokenizeExtendedLine(const std::wstring& line, int language, SyntaxState& state);
 D2D1_COLOR_F getTokenColor(const D2DTheme& theme, SyntaxTokenType ttype);
 
 #endif // TINTA_SYNTAX_H

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -2121,7 +2121,7 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
         wcode
     });
     float textY = y + padding;
-    bool inBlockComment = false;
+    SyntaxState syntaxState;
     size_t codeDocStart = app.docText.size();
     size_t lineStart = 0;
     float maxLineWidth = 0.0f;
@@ -2138,7 +2138,7 @@ static void layoutCodeBlock(App& app, const ElementPtr& elem, float& y, float in
         size_t lineRun = (size_t)-1;
 
         if (language > 0) {
-            std::vector<SyntaxToken> tokens = tokenizeLine(wline, language, inBlockComment);
+            std::vector<SyntaxToken> tokens = tokenizeLine(wline, language, syntaxState);
             float tokenX = indent + padding;
 
             // Merge consecutive same-color tokens into one layout — a line

--- a/src/startpage.cpp
+++ b/src/startpage.cpp
@@ -40,7 +40,7 @@ static const char* kSampleDocument = R"(# Welcome to Tinta
 - Search — press **F**
 - Table of contents — press **Tab**
 - Text selection and copy
-- Syntax highlighting in code blocks for C/C++, C#, Python, JavaScript, Rust, Go, and Bash
+- Syntax highlighting in code blocks for C/C++, C#, Python, JavaScript/TypeScript, Rust, Go, Bash, SQL, PowerShell, Java, PHP, HTML/XML, CSS, YAML, and Markdown
 
 ## Code Example
 

--- a/src/syntax.cpp
+++ b/src/syntax.cpp
@@ -150,6 +150,15 @@ int detectLanguage(const std::wstring& lang) {
         return 6;  // Bash/Shell
     if (lower == L"csharp" || lower == L"cs" || lower == L"c#")
         return 7;  // C#
+    if (lower == L"sql") return LanguageSql;
+    if (lower == L"powershell" || lower == L"ps" || lower == L"pwsh") return LanguagePowerShell;
+    if (lower == L"java") return LanguageJava;
+    if (lower == L"php") return LanguagePhp;
+    if (lower == L"html" || lower == L"htm") return LanguageHtml;
+    if (lower == L"xml") return LanguageXml;
+    if (lower == L"css") return LanguageCss;
+    if (lower == L"yaml" || lower == L"yml") return LanguageYaml;
+    if (lower == L"markdown" || lower == L"md") return LanguageMarkdown;
     return 0;  // Unknown
 }
 
@@ -166,7 +175,10 @@ const std::unordered_set<std::wstring>* getKeywordsForLanguage(int lang) {
     }
 }
 
-std::vector<SyntaxToken> tokenizeLine(const std::wstring& line, int language, bool& inBlockComment) {
+std::vector<SyntaxToken> tokenizeLine(const std::wstring& line, int language, SyntaxState& state) {
+    if (language >= LanguageSql && language <= LanguageMarkdown)
+        return tokenizeExtendedLine(line, language, state);
+    bool& inBlockComment = state.inBlockComment;
     std::vector<SyntaxToken> tokens;
     const std::unordered_set<std::wstring>* keywords = getKeywordsForLanguage(language);
 

--- a/src/syntax_extended.cpp
+++ b/src/syntax_extended.cpp
@@ -1,0 +1,555 @@
+#include "syntax.h"
+#include <cwctype>
+
+namespace {
+using Type = SyntaxTokenType;
+using Mode = SyntaxState::Mode;
+using View = std::wstring_view;
+using Words = std::unordered_set<std::wstring>;
+
+Words words(View text) {
+    Words result;
+    size_t i = 0;
+    while (i < text.size()) {
+        size_t end = text.find(L' ', i);
+        if (end == View::npos) end = text.size();
+        if (end > i) result.emplace(text.substr(i, end - i));
+        i = end + 1;
+    }
+    return result;
+}
+std::wstring lower(View text) {
+    std::wstring result(text);
+    for (auto& c : result) c = towlower(c);
+    return result;
+}
+bool identifier(wchar_t c) { return iswalnum(c) || c == L'_'; }
+bool nameStart(wchar_t c) { return iswalpha(c) || c == L'_'; }
+
+struct Rules { Words keywords, control, types; };
+const Rules& rules(int language) {
+    static const Rules sql {
+        words(L"select from where as distinct all join inner outer left right full cross on using group by having order asc desc limit offset fetch first next rows only union intersect except insert into values update set delete merge returning output create alter drop truncate table view index database schema sequence procedure function trigger replace temporary temp primary foreign key references unique not null default check constraint with recursive materialized exists in between like ilike is and or xor true false unknown over partition range preceding following current row unbounded exclude window filter within lateral natural top percent ties identity auto_increment generated cascade restrict if begin end commit rollback transaction grant revoke explain analyze vacuum use show describe delimiter collate cast convert coalesce nullif"),
+        words(L"case when then else end if loop while return declare do exception raise"),
+        words(L"int integer smallint bigint tinyint serial bigserial decimal numeric number real float double precision money boolean bool bit char varchar nvarchar nchar text ntext clob blob binary varbinary bytea date datetime datetime2 timestamp timestamptz time interval uuid json jsonb xml")
+    };
+    static const Rules ps {
+        words(L"function filter param begin process end dynamicparam class enum interface hidden static using module namespace assembly data workflow configuration parallel sequence in true false null mandatory validateset validaterange cmdletbinding"),
+        words(L"if else elseif switch foreach for while do until break continue return throw try catch finally trap exit") ,
+        words(L"string char int int32 int64 long double float decimal bool boolean byte array hashtable object datetime scriptblock psobject pscustomobject void")
+    };
+    static const Rules java {
+        words(L"abstract assert boolean byte char class const double enum exports extends final float implements import instanceof int interface long module native new non-sealed open opens package permits private protected provides public record requires sealed short static strictfp super synchronized this to transient transitive uses var void volatile with true false null"),
+        words(L"break case catch continue default do else finally for if return switch throw throws try while yield"),
+        words(L"boolean byte char double float int long short void String Object Boolean Byte Character Double Float Integer Long Short Number Class System Math List ArrayList Map HashMap Set HashSet Optional Stream Exception RuntimeException")
+    };
+    static const Rules php {
+        words(L"abstract and array as callable class clone const declare echo enum extends final fn function global implements include include_once instanceof insteadof interface isset list namespace new or print private protected public readonly require require_once static trait unset use var xor yield true false null self parent match __class__ __dir__ __file__ __function__ __line__ __method__ __namespace__ __trait__"),
+        words(L"break case catch continue default die do else elseif empty enddeclare endfor endforeach endif endswitch endwhile exit finally for foreach goto if return switch throw try while"),
+        words(L"array bool boolean callable double false float int integer iterable mixed never null object resource string true void")
+    };
+    switch (language) {
+        case LanguageSql: return sql;
+        case LanguagePowerShell: return ps;
+        case LanguageJava: return java;
+        default: return php;
+    }
+}
+
+// Every token is a slice of the caller's line. A single advancing cursor makes
+// source preservation independent of which language rule matched.
+struct Lexer {
+    View line;
+    SyntaxState& state;
+    int language;
+    size_t i = 0;
+    std::vector<SyntaxToken> tokens;
+
+    bool at(View text, size_t pos) const { return line.substr(pos, text.size()) == text; }
+    bool at(View text) const { return at(text, i); }
+    size_t nonspace(size_t pos) const {
+        while (pos < line.size() && iswspace(line[pos])) ++pos;
+        return pos;
+    }
+    void emit(size_t end, Type type) {
+        if (end > i) tokens.push_back({line.substr(i, end - i), type});
+        i = end;
+    }
+    void clearMode() { state.mode = Mode::Normal; state.delimiter.clear(); }
+
+    void continueComment(size_t scan) {
+        while (scan < line.size()) {
+            if (!state.commentOpen.empty() && at(state.commentOpen, scan)) {
+                ++state.commentDepth;
+                scan += state.commentOpen.size();
+            } else if (at(state.delimiter, scan)) {
+                scan += state.delimiter.size();
+                if (--state.commentDepth == 0) {
+                    clearMode();
+                    emit(scan, Type::Comment);
+                    return;
+                }
+            } else ++scan;
+        }
+        emit(line.size(), Type::Comment);
+    }
+    void comment(View open, View close, bool nested = false) {
+        state.mode = Mode::Comment;
+        state.delimiter = close;
+        state.commentOpen = nested ? std::wstring(open) : L"";
+        state.commentDepth = 1;
+        continueComment(i + open.size());
+    }
+    void continueString(size_t scan) {
+        while (scan < line.size()) {
+            if (state.escape && line[scan] == state.escape) {
+                scan += (scan + 1 < line.size() ? 2 : 1);
+            } else if (at(state.delimiter, scan)) {
+                scan += state.delimiter.size();
+                if (state.doubledQuote && at(state.delimiter, scan)) {
+                    scan += state.delimiter.size();
+                    continue;
+                }
+                clearMode();
+                emit(scan, Type::String);
+                return;
+            } else ++scan;
+        }
+        emit(line.size(), Type::String);
+    }
+    void quoted(size_t prefix, wchar_t escape, bool doubled = false) {
+        state.mode = Mode::Quote;
+        state.delimiter.assign(1, line[i + prefix]);
+        state.escape = escape;
+        state.doubledQuote = doubled;
+        continueString(i + prefix + 1);
+    }
+    void delimited(View delimiter, wchar_t escape = 0) {
+        state.mode = Mode::Delimited;
+        state.delimiter = delimiter;
+        state.escape = escape;
+        state.doubledQuote = false;
+        continueString(i + delimiter.size());
+    }
+    bool continuation() {
+        switch (state.mode) {
+            case Mode::Comment: continueComment(i); return true;
+            case Mode::Quote:
+            case Mode::Delimited: continueString(i); return true;
+            case Mode::HereString:
+            case Mode::Heredoc: {
+                // PowerShell terminators start in column zero; PHP permits
+                // indentation and punctuation following the identifier.
+                size_t start = state.mode == Mode::Heredoc ? nonspace(0) : 0;
+                size_t end = start + state.delimiter.size();
+                bool closes = at(state.delimiter, start) &&
+                    (state.mode == Mode::HereString || end == line.size() || !identifier(line[end]));
+                if (closes) { clearMode(); emit(end, Type::String); }
+                else emit(line.size(), Type::String);
+                return true;
+            }
+            default: return false;
+        }
+    }
+    size_t numberEnd(size_t start) const {
+        size_t end = start;
+        if (at(L"0x", end) || at(L"0X", end) || at(L"0b", end) || at(L"0B", end) || at(L"0o", end)) {
+            end += 2;
+            while (end < line.size() && (iswxdigit(line[end]) || line[end] == L'_')) ++end;
+        } else {
+            while (end < line.size() && (iswdigit(line[end]) || line[end] == L'_' || line[end] == L'.')) ++end;
+            if (end < line.size() && (line[end] == L'e' || line[end] == L'E')) {
+                size_t exponent = end + 1;
+                if (exponent < line.size() && (line[exponent] == L'+' || line[exponent] == L'-')) ++exponent;
+                if (exponent < line.size() && iswdigit(line[exponent])) {
+                    end = exponent + 1;
+                    while (end < line.size() && (iswdigit(line[end]) || line[end] == L'_')) ++end;
+                }
+            }
+        }
+        if (language == LanguageJava || language == LanguagePowerShell || language == LanguageCss)
+            while (end < line.size() && (iswalpha(line[end]) || line[end] == L'%')) ++end;
+        return end;
+    }
+    void program() {
+        const bool sql = language == LanguageSql, ps = language == LanguagePowerShell;
+        const bool java = language == LanguageJava, php = language == LanguagePhp;
+        const auto& rule = rules(language);
+        while (i < line.size()) {
+            if (continuation()) continue;
+            wchar_t c = line[i];
+            if (iswspace(c)) { emit(nonspace(i), Type::Plain); continue; }
+            if ((sql && at(L"--")) || ((java || php) && at(L"//")) ||
+                ((ps || php) && c == L'#' && !(php && at(L"#[")))) {
+                emit(line.size(), Type::Comment); continue;
+            }
+            if ((!ps && at(L"/*")) || (ps && at(L"<#"))) {
+                comment(ps ? L"<#" : L"/*", ps ? L"#>" : L"*/", sql || ps); continue;
+            }
+            if (ps && (at(L"@\"") || at(L"@'")) && nonspace(i + 2) == line.size()) {
+                state.mode = Mode::HereString;
+                state.delimiter = std::wstring(1, line[i + 1]) + L"@";
+                emit(line.size(), Type::String); continue;
+            }
+            if (php && at(L"<<<")) {
+                size_t start = nonspace(i + 3), end = start;
+                wchar_t quote = 0;
+                if (end < line.size() && (line[end] == L'\'' || line[end] == L'"')) quote = line[end++];
+                start = end;
+                if (end < line.size() && nameStart(line[end])) {
+                    while (end < line.size() && identifier(line[end])) ++end;
+                    size_t tail = end;
+                    if (quote && tail < line.size() && line[tail] == quote) ++tail;
+                    else if (quote) tail = line.size() + 1;
+                    if (tail <= line.size() && nonspace(tail) == line.size()) {
+                        state.mode = Mode::Heredoc;
+                        state.delimiter = line.substr(start, end - start);
+                        emit(line.size(), Type::String); continue;
+                    }
+                }
+            }
+            if (java && at(L"\"\"\"")) { delimited(L"\"\"\"", L'\\'); continue; }
+            if (sql && c == L'$') {
+                size_t end = i + 1;
+                if (end < line.size() && nameStart(line[end]))
+                    while (end < line.size() && identifier(line[end])) ++end;
+                if (end < line.size() && line[end] == L'$') {
+                    delimited(line.substr(i, end + 1 - i)); continue;
+                }
+            }
+            if (c == L'\'' || c == L'"' || ((sql || php) && c == L'`')) {
+                quoted(0, ps ? (c == L'"' ? L'`' : 0) : sql ? 0 : L'\\', sql || (ps && c == L'\''));
+                // Ordinary Java strings cannot consume the next source line.
+                if (java) clearMode();
+                continue;
+            }
+            if (sql && c == L'[') {
+                state.mode = Mode::Quote; state.delimiter = L"]";
+                state.escape = 0; state.doubledQuote = true;
+                continueString(i + 1); continue;
+            }
+            if (ps && c == L'[') {
+                size_t end = line.find(L']', i + 1);
+                if (end != View::npos) { emit(end + 1, Type::TypeName); continue; }
+            }
+            if ((ps || php) && c == L'$') {
+                size_t end = i + 1;
+                if (end < line.size() && line[end] == L'{') {
+                    size_t close = line.find(L'}', end + 1);
+                    end = close == View::npos ? line.size() : close + 1;
+                } else {
+                    while (end < line.size() && (identifier(line[end]) || (ps && line[end] == L':'))) ++end;
+                }
+                auto name = lower(line.substr(i + 1, end - i - 1));
+                emit(end, ps && (name == L"true" || name == L"false" || name == L"null") ? Type::Keyword : Type::TypeName);
+                continue;
+            }
+            if (php && (at(L"<?") || at(L"?>"))) {
+                size_t end = i + 2;
+                if (at(L"<?", i)) {
+                    if (lower(line.substr(end, 3)) == L"php") end += 3;
+                    else if (end < line.size() && line[end] == L'=') ++end;
+                }
+                emit(end, Type::Keyword); continue;
+            }
+            if (iswdigit(c) || (c == L'.' && i + 1 < line.size() && iswdigit(line[i + 1]))) {
+                emit(numberEnd(i), Type::Number); continue;
+            }
+            if ((ps && c == L'-' && i + 1 < line.size() && nameStart(line[i + 1])) ||
+                (java && c == L'@')) {
+                size_t end = i + 1;
+                while (end < line.size() && (identifier(line[end]) || (java && line[end] == L'.'))) ++end;
+                emit(end, java ? Type::TypeName : Type::Keyword); continue;
+            }
+            if (nameStart(c)) {
+                size_t end = i + 1;
+                while (end < line.size() && (identifier(line[end]) || (ps && line[end] == L'-') || (java && line[end] == L'$'))) ++end;
+                auto text = line.substr(i, end - i);
+                auto name = java ? std::wstring(text) : lower(text);
+                size_t next = nonspace(end);
+                Type type = Type::Plain;
+                if (rule.control.count(name)) type = Type::ControlFlow;
+                else if (rule.types.count(name)) type = Type::TypeName;
+                else if (rule.keywords.count(name)) type = Type::Keyword;
+                else if ((next < line.size() && line[next] == L'(') || (ps && text.find(L'-') != View::npos)) type = Type::Function;
+                else if ((java || php) && iswupper(c)) type = Type::TypeName;
+                emit(end, type); continue;
+            }
+            emit(i + 1, Type::Operator);
+        }
+    }
+
+    void markup() {
+        while (i < line.size()) {
+            if (continuation()) continue;
+            if (!state.rawTag.empty()) {
+                // Embedded script/style bodies are plain text. Do not mistake
+                // comparison operators inside them for markup tag openings.
+                auto folded = lower(line.substr(i));
+                size_t close = folded.find(L"</" + state.rawTag);
+                while (close != View::npos) {
+                    size_t end = close + state.rawTag.size() + 2;
+                    if (end == folded.size() || iswspace(folded[end]) || folded[end] == L'>') break;
+                    close = folded.find(L"</" + state.rawTag, close + 1);
+                }
+                if (close == View::npos) { emit(line.size(), Type::Plain); continue; }
+                if (close) emit(i + close, Type::Plain);
+                state.rawTag.clear();
+            }
+            if (at(L"<!--")) { comment(L"<!--", L"-->"); continue; }
+            if (at(L"<![CDATA[")) {
+                state.mode = Mode::Delimited; state.delimiter = L"]]>";
+                state.escape = 0; state.doubledQuote = false;
+                continueString(i + 9); continue;
+            }
+            wchar_t c = line[i];
+            if (!state.inTag && c == L'<' && i + 1 < line.size() &&
+                (nameStart(line[i + 1]) || line[i + 1] == L'/' || line[i + 1] == L'!' || line[i + 1] == L'?')) {
+                state.inTag = state.tagName = true;
+                state.closingTag = line[i + 1] == L'/';
+                state.tag.clear();
+                emit(i + (nameStart(line[i + 1]) ? 1 : 2), Type::Keyword); continue;
+            }
+            if (state.inTag) {
+                if (at(L"/>") || at(L"?>") || c == L'>') {
+                    bool selfClosing = c != L'>';
+                    if (!selfClosing && !state.closingTag && language == LanguageHtml &&
+                        (state.tag == L"script" || state.tag == L"style")) state.rawTag = state.tag;
+                    state.inTag = false;
+                    emit(i + (selfClosing ? 2 : 1), Type::Keyword); continue;
+                }
+                if (c == L'\'' || c == L'"') { quoted(0, 0); continue; }
+                if (iswspace(c)) { emit(nonspace(i), Type::Plain); continue; }
+                if (identifier(c) || c == L':' || c == L'-') {
+                    size_t end = i + 1;
+                    while (end < line.size() && (identifier(line[end]) || line[end] == L':' || line[end] == L'-' || line[end] == L'.')) ++end;
+                    Type type = state.tagName ? Type::Keyword : Type::TypeName;
+                    if (state.tagName) { state.tag = lower(line.substr(i, end - i)); state.tagName = false; }
+                    emit(end, type); continue;
+                }
+                emit(i + 1, Type::Operator); continue;
+            }
+            if (c == L'&') {
+                size_t end = i + 1;
+                while (end < line.size() && (identifier(line[end]) || line[end] == L'#')) ++end;
+                if (end > i + 1 && end < line.size() && line[end] == L';') { emit(end + 1, Type::Number); continue; }
+            }
+            emit(i + 1, Type::Plain);
+        }
+    }
+
+    void css() {
+        static const Words values = words(L"important inherit initial unset revert revert-layer none auto normal block inline inline-block flex grid contents hidden visible solid relative absolute fixed sticky transparent currentcolor true false and not only or from to");
+        while (i < line.size()) {
+            if (continuation()) continue;
+            wchar_t c = line[i];
+            if (iswspace(c)) { emit(nonspace(i), Type::Plain); continue; }
+            if (at(L"/*")) { comment(L"/*", L"*/"); continue; }
+            if (c == L'\'' || c == L'"') { quoted(0, L'\\'); continue; }
+            if (c == L'{') { ++state.braceDepth; state.cssValue = false; }
+            if (c == L'}') { if (state.braceDepth) --state.braceDepth; state.cssValue = false; }
+            if (c == L';') state.cssValue = false;
+            if (c == L':' && state.braceDepth) state.cssValue = true;
+            if (c == L'#' && state.cssValue) {
+                size_t end = i + 1;
+                while (end < line.size() && iswxdigit(line[end])) ++end;
+                if (end > i + 1) { emit(end, Type::Number); continue; }
+            }
+            if (iswdigit(c) || (c == L'.' && i + 1 < line.size() && iswdigit(line[i + 1]))) {
+                emit(numberEnd(i), Type::Number); continue;
+            }
+            if (nameStart(c) || c == L'-' || c == L'@' || c == L'#' || c == L'.') {
+                size_t end = i + 1;
+                while (end < line.size() && (identifier(line[end]) || line[end] == L'-')) ++end;
+                size_t next = nonspace(end);
+                auto name = lower(line.substr(i, end - i));
+                Type type = Type::Plain;
+                if (c == L'@' || values.count(name)) type = Type::Keyword;
+                else if (next < line.size() && line[next] == L'(') type = Type::Function;
+                else if (!state.cssValue || at(L"--")) type = Type::TypeName;
+                emit(end, type);
+                if (name == L"url" && next < line.size() && line[next] == L'(') {
+                    emit(next + 1, Type::Operator);
+                    size_t content = nonspace(i);
+                    if (content > i) emit(content, Type::Plain);
+                    if (i < line.size() && line[i] != L'\'' && line[i] != L'"') {
+                        state.mode = Mode::Delimited; state.delimiter = L")";
+                        state.escape = L'\\'; state.doubledQuote = false;
+                        continueString(i);
+                    }
+                }
+                continue;
+            }
+            emit(i + 1, Type::Operator);
+        }
+    }
+
+    void yaml() {
+        size_t indent = nonspace(0);
+        size_t parentIndent = indent;
+        if (state.mode == Mode::YamlBlock) {
+            bool content = indent == line.size() || (state.explicitIndent ? indent >= state.explicitIndent : indent > state.blockIndent);
+            if (content) {
+                // Infer indentation from the first nonempty content line. A
+                // sibling key in a sequence can be indented beyond the dash
+                // while still being outside this scalar.
+                if (!state.explicitIndent && indent < line.size()) state.explicitIndent = indent;
+                emit(line.size(), Type::String); return;
+            }
+            clearMode();
+        }
+        while (i < line.size()) {
+            if (continuation()) continue;
+            wchar_t c = line[i];
+            if (iswspace(c)) { emit(nonspace(i), Type::Plain); continue; }
+            if (c == L'#' && (i == 0 || iswspace(line[i - 1]))) { emit(line.size(), Type::Comment); continue; }
+            if (c == L'\'' || c == L'"') {
+                // Quoted mapping keys use the same type colour as plain keys.
+                size_t firstToken = tokens.size();
+                size_t keyIndent = i;
+                quoted(0, c == L'"' ? L'\\' : 0, c == L'\'');
+                size_t next = nonspace(i);
+                if (state.mode == Mode::Normal && next < line.size() && line[next] == L':') {
+                    parentIndent = keyIndent;
+                    for (size_t t = firstToken; t < tokens.size(); ++t) tokens[t].tokenType = Type::TypeName;
+                }
+                continue;
+            }
+            if ((at(L"---") || at(L"...")) && i == 0 && (i + 3 == line.size() || iswspace(line[i + 3]))) {
+                emit(i + 3, Type::Keyword); continue;
+            }
+            if (c == L'%' && i == 0) { emit(line.size(), Type::Keyword); continue; }
+            if (c == L'|' || c == L'>') {
+                size_t end = i + 1, extraIndent = 0;
+                while (end < line.size() && (line[end] == L'+' || line[end] == L'-' || (line[end] >= L'1' && line[end] <= L'9'))) {
+                    if (iswdigit(line[end])) extraIndent = line[end] - L'0';
+                    ++end;
+                }
+                size_t tail = nonspace(end);
+                if (tail == line.size() || line[tail] == L'#') {
+                    state.mode = Mode::YamlBlock; state.blockIndent = parentIndent;
+                    state.explicitIndent = extraIndent ? parentIndent + extraIndent : 0;
+                    emit(end, Type::Keyword);
+                    if (tail > i) emit(tail, Type::Plain);
+                    emit(line.size(), Type::Comment); return;
+                }
+            }
+            if (c == L'&' || c == L'*' || c == L'!') {
+                size_t end = i + 1;
+                while (end < line.size() && !iswspace(line[end]) && View(L",[]{}").find(line[end]) == View::npos) ++end;
+                emit(end, Type::TypeName); continue;
+            }
+            if (View(L"{}[],:?").find(c) != View::npos || (c == L'-' && (i + 1 == line.size() || iswspace(line[i + 1])))) {
+                emit(i + 1, Type::Operator); continue;
+            }
+            // A plain scalar is scanned as a unit so URLs, dates, hyphens and
+            // fragments such as https://host/#part never become comments.
+            size_t end = i + 1;
+            while (end < line.size()) {
+                if (View(L",[]{}").find(line[end]) != View::npos ||
+                    (line[end] == L':' && (end + 1 == line.size() || iswspace(line[end + 1]) || View(L",[]{}").find(line[end + 1]) != View::npos)) ||
+                    (line[end] == L'#' && iswspace(line[end - 1]))) break;
+                ++end;
+            }
+            size_t textEnd = end;
+            while (textEnd > i && iswspace(line[textEnd - 1])) --textEnd;
+            auto name = lower(line.substr(i, textEnd - i));
+            Type type = Type::Plain;
+            if (end < line.size() && line[end] == L':') { type = Type::TypeName; parentIndent = i; }
+            else if (name == L"true" || name == L"false" || name == L"null" || name == L"~") type = Type::Keyword;
+            else {
+                size_t start = i + ((c == L'+' || c == L'-') ? 1 : 0);
+                if ((start < textEnd && iswdigit(line[start]) && numberEnd(start) == textEnd) ||
+                    name == L".inf" || name == L"-.inf" || name == L"+.inf" || name == L".nan") type = Type::Number;
+            }
+            emit(textEnd, type);
+            if (end > i) emit(end, Type::Plain);
+        }
+    }
+
+    void markdown() {
+        size_t start = nonspace(0);
+        if (state.mode == Mode::MarkdownFence) {
+            size_t end = start;
+            while (end < line.size() && line[end] == state.delimiter[0]) ++end;
+            bool closes = start <= 3 && end - start >= state.delimiter.size() && nonspace(end) == line.size();
+            emit(line.size(), closes ? Type::Keyword : Type::String);
+            if (closes) clearMode();
+            return;
+        }
+        if (state.mode == Mode::Normal && start <= 3 && start < line.size()) {
+            wchar_t c = line[start];
+            size_t end = start;
+            while (end < line.size() && line[end] == c) ++end;
+            if ((c == L'`' || c == L'~') && end - start >= 3) {
+                state.mode = Mode::MarkdownFence;
+                state.delimiter = line.substr(start, end - start);
+                emit(line.size(), Type::Keyword); return;
+            }
+            if ((c == L'#' && end - start <= 6 && (end == line.size() || iswspace(line[end]))) ||
+                ((c == L'=' || c == L'-' || c == L'*' || c == L'_') && end - start >= 3 && nonspace(end) == line.size())) {
+                emit(line.size(), Type::Keyword); return;
+            }
+        }
+        while (i < line.size()) {
+            if (continuation()) continue;
+            wchar_t c = line[i];
+            if (at(L"<!--")) { comment(L"<!--", L"-->"); continue; }
+            if (c == L'\\' && i + 1 < line.size()) { emit(i + 2, Type::Plain); continue; }
+            if (c == L'`') {
+                size_t end = i + 1;
+                while (end < line.size() && line[end] == c) ++end;
+                View marker = line.substr(i, end - i);
+                size_t close = line.find(marker, end);
+                while (close != View::npos && ((close && line[close - 1] == c) ||
+                       (close + marker.size() < line.size() && line[close + marker.size()] == c)))
+                    close = line.find(marker, close + marker.size());
+                if (close != View::npos) { emit(close + marker.size(), Type::String); continue; }
+                emit(end, Type::Plain); continue;
+            }
+            if (at(L"](")) {
+                size_t end = i + 2, depth = 1;
+                while (end < line.size() && depth) {
+                    if (line[end] == L'\\' && end + 1 < line.size()) { end += 2; continue; }
+                    if (line[end] == L'(') ++depth;
+                    if (line[end] == L')') --depth;
+                    ++end;
+                }
+                emit(end, Type::String); continue;
+            }
+            if (c == L'*' || c == L'_') {
+                size_t end = i + 1;
+                while (end < line.size() && line[end] == c) ++end;
+                View marker = line.substr(i, end - i);
+                size_t close = line.find(marker, end);
+                if (close != View::npos && end < line.size() && !iswspace(line[end])) {
+                    emit(close + marker.size(), Type::TypeName); continue;
+                }
+            }
+            if (i == start && iswdigit(c)) {
+                size_t end = i + 1;
+                while (end < line.size() && iswdigit(line[end])) ++end;
+                if (end + 1 < line.size() && (line[end] == L'.' || line[end] == L')') && iswspace(line[end + 1])) {
+                    emit(end + 1, Type::Keyword); continue;
+                }
+            }
+            bool marker = c == L'[' || c == L']' || c == L'|' ||
+                (i == start && (c == L'>' || c == L'-' || c == L'+' || c == L'*'));
+            emit(i + 1, marker ? Type::Keyword : Type::Plain);
+        }
+    }
+};
+}
+
+std::vector<SyntaxToken> tokenizeExtendedLine(const std::wstring& line, int language, SyntaxState& state) {
+    Lexer lexer {line, state, language};
+    switch (language) {
+        case LanguageHtml:
+        case LanguageXml: lexer.markup(); break;
+        case LanguageCss: lexer.css(); break;
+        case LanguageYaml: lexer.yaml(); break;
+        case LanguageMarkdown: lexer.markdown(); break;
+        default: lexer.program(); break;
+    }
+    return std::move(lexer.tokens);
+}

--- a/tests/fixtures/syntax-languages.md
+++ b/tests/fixtures/syntax-languages.md
@@ -1,0 +1,119 @@
+# Syntax highlighting: nine new languages
+
+Issue [#207](https://github.com/oipoistar/tinta/issues/207), reported by **@hochun836**.
+Each example should show distinct syntax colours in Paper and Midnight. Resize the
+window and open Contents or the file browser; long lines should remain scrollable.
+
+| Family | Fence labels | Check |
+| :--- | :--- | :--- |
+| Data | `sql`, `yaml`, `yml` | Keys, numbers, comments |
+| Programs | `powershell`, `ps`, `pwsh`, `java`, `php` | Calls, types, control flow |
+| Documents | `html`, `htm`, `xml`, `css`, `markdown`, `md` | Tags, attributes, styles, markup |
+
+> A quote with `inline code`, **bold text**, *emphasis* and $a^2+b^2=c^2$.
+
+## SQL
+
+```sql
+-- Case-insensitive keywords and doubled quotes
+SELECT employee_id, COUNT(*) AS total FROM employees
+WHERE active = 1 AND name = 'O''Brien' GROUP BY employee_id;
+CREATE TABLE sample (id INTEGER, price DECIMAL(10, 2));
+```
+
+## PowerShell
+
+```powershell
+# Cmdlets, parameters, variables and backtick escapes
+[string] $message = "Hello `$reader"
+Get-ChildItem -Path . | Where-Object { $_.Extension -eq '.md' }
+if ($true) { Write-Output $message }
+```
+
+## Java
+
+```java
+@Override
+public String greet(String name) {
+    // Calls and control flow use existing theme keys
+    if (name == null) return "Hello";
+    return name.trim() + 42;
+}
+```
+
+## PHP
+
+```php
+<?php
+function greet(string $name): string {
+    # Variables, types, strings, numbers and calls
+    return strtoupper($name) . " visitor " . 42;
+}
+?>
+```
+
+## HTML
+
+```html
+<!-- Tags and attributes, with an entity in text -->
+<article class="card" data-count="2">
+  <a href="https://example.com/#intro">Hello &amp; welcome</a>
+</article>
+```
+
+## XML
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Namespace-qualified names -->
+<doc:item xmlns:doc="urn:tinta" id="7">
+  <![CDATA[<literal> & untouched]]>
+</doc:item>
+```
+
+## CSS
+
+```css
+/* Selectors, properties, dimensions, colours and functions */
+@media (min-width: 40rem) {
+  .card:hover { color: #c06040; padding: calc(1rem + 2px); }
+  #hero { background: url(https://example.com/img.svg#icon); }
+}
+```
+
+## YAML
+
+```yaml
+# Keys, booleans, numbers and a URL with a fragment
+defaults: &defaults {enabled: true, retries: 3}
+site: https://example.com/#intro
+message: |-
+  # This is text, not a comment.
+  Keep these lines together.
+copy: *defaults
+```
+
+## Markdown inside Markdown
+
+````markdown
+# A heading in a code block
+**Bold** and *emphasis*, with `inline code`.
+- A [link](https://example.com/path_(one))
+> A quoted line
+```sql
+SELECT 1; -- An inner fenced example
+```
+<!-- A Markdown comment -->
+````
+
+### Content after the examples
+
+1. Headings, tables, quotes and lists retain their spacing.
+2. Copy a code block and check the original indentation and newlines.
+3. Search for `employee_id` and `Keep these lines together`.
+
+$$
+\sum_{k=1}^{n} k = \frac{n(n+1)}{2}
+$$
+
+Final syntax fixture paragraph: **all surrounding content remains visible**.

--- a/tests/fixtures/syntax-legacy-control.md
+++ b/tests/fixtures/syntax-legacy-control.md
@@ -1,0 +1,63 @@
+# Existing syntax control
+
+**Bold**, *emphasis*, [link](syntax-languages.md), `inline code` and $x^2$.
+
+| Existing feature | Expected |
+| :--- | :--- |
+| All seven language families | Same colours and spacing as before #207 |
+
+> A quote between the table and the code.
+
+```cpp
+/* across
+lines */ int sum(int a, int b) { return a + b; }
+```
+
+```python
+# Existing Python rules
+def greet(name):
+    return "Hello " + name + str(42)
+```
+
+```typescript
+const count = 3;
+function greet(name: string) { return `Hello ${name}`; }
+```
+
+```rust
+fn main() { let n: i32 = 42; println!("Hello {}", n); }
+```
+
+```go
+package main
+func main() { fmt.Println("Hello", 42) }
+```
+
+```bash
+# Existing shell rules
+if test -f sample.md; then echo "Hello"; fi
+```
+
+```c#
+public string Greet(string name) {
+    if (name == null) return @"Hello";
+    return $"Hello {name}";
+}
+```
+
+```json
+{"enabled": true, "count": 42, "name": "Hello"}
+```
+
+```unknown-language
+SELECT 42; # Unrecognised fences remain entirely plain.
+```
+
+1. First item with **bold**.
+2. Second item with *emphasis*.
+
+$$
+\frac{a}{b} + c
+$$
+
+Final syntax fixture paragraph: existing rendering is unchanged.

--- a/tests/fixtures/syntax-multiline.md
+++ b/tests/fixtures/syntax-multiline.md
@@ -1,0 +1,146 @@
+# Syntax state and aliases
+
+A mixed regression document with **bold**, *emphasis*, [a link](syntax-languages.md)
+and inline math $x_i^2$. Comments and strings must stop at their real terminators.
+
+| Check | Expected |
+| :--- | :--- |
+| Separate fences | No leaked string or comment colour |
+| URLs | `//` and `#` stay part of values |
+
+> The quote and the table should retain their normal layout.
+
+## SQL strings and nested comments
+
+```SQL
+/* outer
+   /* nested */ still a comment
+*/ SELECT 'first
+second ''quoted'' line', $body$literal -- not a comment
+/* still a string */$body$, [display name] FROM records;
+```
+
+## PowerShell aliases
+
+```ps
+<# first <# nested #>
+still a comment #> Get-Date
+$text = @"
+# Not a comment: $env:PATH
+"@
+Write-Output $text
+```
+
+```pwsh
+$literal = @'
+Don't parse "these" # characters
+'@
+if ($null -ne $literal) { Write-Host $literal }
+```
+
+## Java text blocks
+
+```java
+String text = """
+    {"message": "Hello", "count": 42}
+    // inside the text block
+    """;
+int count = 0xFF + 1_000 + 2e-3;
+```
+
+## PHP heredoc and nowdoc
+
+```php
+<?php
+$text = <<<TEXT
+  # This is a string, including $name.
+  TEXT;
+$literal = <<<'RAW'
+  // These are literal contents.
+  RAW;
+#[Example]
+echo strlen($text);
+```
+
+## Markup spanning lines
+
+```htm
+<!-- first line
+still a comment --> <a
+  title="A title
+on two lines">Link &amp; text</a>
+<script>if (a < b) { run(); }</script><br />
+```
+
+```xml
+<root><![CDATA[first line
+<not-a-tag> & not-an-entity
+]]><item count="2" /></root>
+```
+
+## CSS comments and strings
+
+```css
+/* first line
+   still a comment */
+.card { --gap: 1.5rem; padding: var(--gap); }
+a { background: url("https://example.com/#part"); }
+```
+
+## YAML alias, indentation and quoted values
+
+```yml
+---
+message: >2-
+  # block content
+  second line
+"quoted key": 'one
+  two'
+next: false # real comment
+flow: {url: https://example.com/#part, count: -2.5e+3}
+```
+
+## Markdown alias and longer fences
+
+`````md
+## Example
+````js
+``` is shorter than the opener
+# This stays code
+````
+1. Back to Markdown with **emphasis**.
+<!-- comment
+still a comment --> [link](https://example.com)
+`````
+
+## Fresh state in the next fence
+
+```sql
+/* deliberately unfinished comment
+```
+
+```sql
+SELECT 42;
+```
+
+```yaml
+message: |
+  deliberately unfinished scalar
+```
+
+```yaml
+enabled: true
+```
+
+```unknown-language
+SELECT 42; /* This whole block stays plain. */
+```
+
+- One list item with `inline code`.
+- A second with $a+b$.
+
+$$
+\int_0^1 x\,dx = \frac{1}{2}
+$$
+
+Final syntax fixture paragraph: no syntax state reaches this paragraph.

--- a/tests/render_syntax_fixtures.ps1
+++ b/tests/render_syntax_fixtures.ps1
@@ -1,0 +1,51 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/issue-207/fixed'
+)
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskOutput = Join-Path $taskRepo $Output
+$taskBinary = if ([IO.Path]::IsPathRooted($Binary)) { $Binary } else { Join-Path $taskRepo $Binary }
+foreach ($taskTheme in @(0, 5)) {
+    $taskThemeOutput = Join-Path $taskOutput "theme-$taskTheme"
+    New-Item -ItemType Directory -Force "$taskThemeOutput/runner" | Out-Null
+    $taskExe = Join-Path $taskThemeOutput 'runner/tinta.exe'
+    Copy-Item -LiteralPath $taskBinary -Destination $taskExe -Force
+    @"
+[Settings]
+themeIndex=$taskTheme
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+"@ | Set-Content -LiteralPath "$taskThemeOutput/runner/settings.ini"
+    foreach ($taskName in @('syntax-languages', 'syntax-multiline', 'syntax-legacy-control', 'markdown-regression-control')) {
+        $taskSource = Join-Path $PSScriptRoot "fixtures/$taskName.md"
+        $taskBefore = (Get-FileHash -LiteralPath $taskSource).Hash
+        $taskDest = Join-Path $taskThemeOutput $taskName
+        New-Item -ItemType Directory -Force $taskDest | Out-Null
+        foreach ($taskMode in @('printpages', 'exporthtml', 'exportdocx')) {
+            $taskTarget = switch ($taskMode) {
+                'printpages' { "$taskDest/pages" }
+                'exporthtml' { "$taskDest/document.html" }
+                'exportdocx' { "$taskDest/document.docx" }
+            }
+            $taskProcess = Start-Process -FilePath $taskExe -ArgumentList @(('"'+$taskSource+'"'), "--$taskMode", ('"'+$taskTarget+'"')) -WindowStyle Hidden -PassThru
+            if (!$taskProcess.WaitForExit(30000)) {
+                Stop-Process -Id $taskProcess.Id -Force
+                $taskProcess.WaitForExit()
+                throw "$taskName $taskMode timed out"
+            }
+            if ($taskProcess.ExitCode -ne 0 -or !(Test-Path -LiteralPath $taskTarget)) { throw "$taskName $taskMode failed" }
+        }
+        $taskHtml = Get-Content -LiteralPath "$taskDest/document.html" -Raw -Encoding UTF8
+        foreach ($taskElement in @('<blockquote', '<table>', '<h1', '<pre', '<strong>', '<em>')) {
+            if (!$taskHtml.Contains($taskElement)) { throw "$taskName lost $taskElement in HTML export" }
+        }
+        if ((Get-FileHash -LiteralPath $taskSource).Hash -ne $taskBefore) { throw "$taskName source changed" }
+        $taskPages = @(Get-ChildItem -LiteralPath "$taskDest/pages" -Filter 'page-*.png')
+        if (!$taskPages.Count) { throw "$taskName produced no print pages" }
+        "theme $taskTheme, $taskName : $($taskPages.Count) native pages, HTML and DOCX"
+    }
+}

--- a/tests/syntax-validation.md
+++ b/tests/syntax-validation.md
@@ -1,0 +1,58 @@
+# Syntax highlighting extension (#207)
+
+Implemented for [@hochun836's request](https://github.com/oipoistar/tinta/issues/207).
+Validated on Windows on 2026-09-10, against the preceding build at `76e6916`.
+
+## Coverage
+
+- SQL, PowerShell, Java, PHP, HTML, XML, CSS, YAML and Markdown, including the
+  requested `ps`, `pwsh`, `htm`, `yml` and `md` aliases and case-insensitive labels.
+- Language-specific comments, strings, keyword/type/control-flow categories,
+  calls, numbers, tags/attributes/entities, CSS properties/values, YAML keys and
+  block values, and Markdown markers. Stateful constructs end at their real
+  delimiters and never carry over to another outer fenced block.
+- Existing language rules, unknown-language fallback and theme keys retained.
+  The built-in feature list and `docs/syntax-highlighting.md` describe support.
+
+## Automated and native checks
+
+- Release build and all **18 CTests passed**. The `syntax_highlighting` test covers
+  exact token categories, aliases, case handling, escaped/doubled quotes, nested
+  comments, multiline delimiters, URLs/fragments, PHP attributes, YAML dedents,
+  shorter inner Markdown fences and state reset between separate code blocks.
+- 10,800 deterministic malformed/random UTF-16 fragments exercise source-slice
+  continuity, nonempty tokens, termination and state across lines.
+- Native DirectWrite layout checks use Paper, Midnight and a custom seven-colour
+  palette, at 100/150% content scale and 1050/650-pixel document widths. They verify
+  actual theme colours, original copy/search text, code row heights, non-overlap,
+  surrounding Markdown/math, and matching full/incremental layout results.
+- Runnable fixtures: `syntax-languages.md`, `syntax-multiline.md` and
+  `syntax-legacy-control.md`. Every fixture mixes code with headings, tables,
+  quotes, lists, emphasis, links and inline/display math.
+- `tests/render_syntax_fixtures.ps1` exported those three fixtures and the existing
+  `markdown-regression-control.md` from both builds with Paper/Midnight settings:
+  **24 native PNG pages, 8 HTML files and 8 DOCX files per build**. Printing uses
+  Tinta's fixed print palette; the dark/custom palettes are checked by native
+  layout tests, not inferred from printed pages.
+- All 16 HTML/DOCX exports and all 8 existing-language/Markdown control PNG pages
+  are byte-identical. Four trailing new-fixture PNG pages are also identical;
+  the only 12 changed artifacts are print pages containing newly coloured code.
+  Fixture source hashes remain unchanged.
+- Visually inspected pages 1-3 of both new-language and multiline fixtures:
+  all nine languages, aliases, multiline terminators, independent fences and
+  surrounding headings/tables/quotes/math render. No interactive mouse checks
+  were needed for this tokenizer change.
+
+Generated files and the preceding executable are ignored under `out/issue-207/`.
+Reproduce with a Release build, `ctest --test-dir build -C Release
+--output-on-failure`, and `tests/render_syntax_fixtures.ps1`.
+
+## Limits
+
+The extension uses lexical heuristics, with no added fonts or external runtime.
+It does not fully parse every dialect, colour interpolations independently, or
+recursively highlight embedded HTML script/style bodies and inner Markdown code
+fences. HTML/DOCX syntax-colour export remains outside this change; those exports
+keep their previous plain-code formatting. See `docs/syntax-highlighting.md`.
+
+No issue reply has been posted. Provide a maintainer-reviewable draft with the PR.

--- a/tests/syntax_tests.cpp
+++ b/tests/syntax_tests.cpp
@@ -1,0 +1,326 @@
+#include "syntax.h"
+#include "d2d_init.h"
+#include "render.h"
+#include "utils.h"
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <random>
+
+namespace {
+using Type = SyntaxTokenType;
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { if (failures < 40) std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+std::vector<SyntaxToken> lex(const std::wstring& line, int language, SyntaxState& state) {
+    auto tokens = tokenizeLine(line, language, state);
+    size_t offset = 0;
+    for (const auto& token : tokens) {
+        check(!token.text.empty(), "tokens are nonempty");
+        check(token.text.data() == line.data() + offset, "token views are contiguous slices of original source");
+        offset += token.text.size();
+    }
+    check(offset == line.size(), "tokenization preserves every source character");
+    return tokens;
+}
+void expect(int language, SyntaxState& state, const std::wstring& line,
+            const std::wstring& text, Type type) {
+    auto tokens = lex(line, language, state);
+    size_t start = line.find(text);
+    check(start != std::wstring::npos, "expected text exists in case");
+    size_t end = start + text.size(), offset = 0, covered = 0;
+    for (const auto& token : tokens) {
+        size_t next = offset + token.text.size();
+        if (offset < end && next > start) {
+            if (token.tokenType != type && failures < 40)
+                std::wcerr << L"  language " << language << L", text [" << text << L"], token [" << token.text << L"]\n";
+            check(token.tokenType == type, "requested span has expected category");
+            covered += std::min(end, next) - std::max(start, offset);
+        }
+        offset = next;
+    }
+    check(covered == text.size(), "expected span is fully covered");
+}
+void single(int language, const std::wstring& line, const std::wstring& text, Type type) {
+    SyntaxState state;
+    expect(language, state, line, text, type);
+}
+
+void tokenTests() {
+    struct Alias { const wchar_t* name; int id; };
+    for (auto a : {Alias{L"SQL", LanguageSql}, {L"powershell", LanguagePowerShell},
+                  {L"PS", LanguagePowerShell}, {L"pwsh", LanguagePowerShell}, {L"java", LanguageJava},
+                  {L"php", LanguagePhp}, {L"html", LanguageHtml}, {L"htm", LanguageHtml},
+                  {L"XML", LanguageXml}, {L"CSS", LanguageCss}, {L"yaml", LanguageYaml},
+                  {L"yml", LanguageYaml}, {L"markdown", LanguageMarkdown}, {L"MD", LanguageMarkdown},
+                  {L"c++", 1}, {L"py", 2}, {L"tsx", 3}, {L"json", 3}, {L"rs", 4},
+                  {L"golang", 5}, {L"zsh", 6}, {L"c#", 7}, {L"unknown-language", 0}, {L"", 0}})
+        check(detectLanguage(a.name) == a.id, "language label / alias maps correctly");
+
+    single(LanguageSql, L"sElEcT id FROM records", L"sElEcT", Type::Keyword);
+    single(LanguageSql, L"CASE WHEN x = 1 THEN 2 END", L"WHEN", Type::ControlFlow);
+    single(LanguageSql, L"price DECIMAL(10, 2)", L"DECIMAL", Type::TypeName);
+    single(LanguageSql, L"COUNT(*)", L"COUNT", Type::Function);
+    single(LanguageSql, L"1.25e-3 + 7", L"1.25e-3", Type::Number);
+    single(LanguageSql, L"'O''Brien' -- real comment", L"'O''Brien'", Type::String);
+    single(LanguageSql, L"'O''Brien' -- real comment", L"-- real comment", Type::Comment);
+    single(LanguageSql, L"[a]]b]", L"[a]]b]", Type::String);
+    single(LanguageSql, L"SELECT 1 // 2", L"//", Type::Operator);
+    SyntaxState sql;
+    expect(LanguageSql, sql, L"/* outer /* inner */", L"/* outer /* inner */", Type::Comment);
+    expect(LanguageSql, sql, L"still comment */ SELECT 1", L"still comment */", Type::Comment);
+    expect(LanguageSql, sql, L"SELECT 'first", L"'first", Type::String);
+    expect(LanguageSql, sql, L"second'; SELECT 2", L"second'", Type::String);
+    expect(LanguageSql, sql, L"$tag$ -- literal", L"$tag$ -- literal", Type::String);
+    expect(LanguageSql, sql, L"/* literal */$tag$ SELECT 3", L"SELECT", Type::Keyword);
+
+    single(LanguagePowerShell, L"Get-ChildItem -Path .", L"Get-ChildItem", Type::Function);
+    single(LanguagePowerShell, L"Get-ChildItem -Path .", L"-Path", Type::Keyword);
+    single(LanguagePowerShell, L"$env:Path", L"$env:Path", Type::TypeName);
+    single(LanguagePowerShell, L"${my value}", L"${my value}", Type::TypeName);
+    single(LanguagePowerShell, L"$TRUE", L"$TRUE", Type::Keyword);
+    single(LanguagePowerShell, L"[System.String] $s", L"[System.String]", Type::TypeName);
+    single(LanguagePowerShell, L"IF ($true) {}", L"IF", Type::ControlFlow);
+    single(LanguagePowerShell, L"'don''t'", L"'don''t'", Type::String);
+    single(LanguagePowerShell, L"\"say `\"hi`\"\" # end", L"# end", Type::Comment);
+    SyntaxState ps;
+    expect(LanguagePowerShell, ps, L"<# outer <# inner #>", L"<# outer <# inner #>", Type::Comment);
+    expect(LanguagePowerShell, ps, L"#> Get-Date", L"Get-Date", Type::Function);
+    expect(LanguagePowerShell, ps, L"$s = @\"", L"@\"", Type::String);
+    expect(LanguagePowerShell, ps, L"  \"@ # not a terminator", L"  \"@ # not a terminator", Type::String);
+    expect(LanguagePowerShell, ps, L"\"@; Get-Date", L"Get-Date", Type::Function);
+    expect(LanguagePowerShell, ps, L"'ordinary", L"'ordinary", Type::String);
+    expect(LanguagePowerShell, ps, L"multiline'; Get-Date", L"multiline'", Type::String);
+
+    single(LanguageJava, L"@Override", L"@Override", Type::TypeName);
+    single(LanguageJava, L"int x = 0xFF + 1_000L;", L"int", Type::TypeName);
+    single(LanguageJava, L"int x = 0xFF + 1_000L;", L"1_000L", Type::Number);
+    single(LanguageJava, L"return greet(name);", L"greet", Type::Function);
+    single(LanguageJava, L"RETURN", L"RETURN", Type::TypeName); // Java is case-sensitive.
+    SyntaxState java;
+    expect(LanguageJava, java, L"String text = \"\"\"", L"\"\"\"", Type::String);
+    expect(LanguageJava, java, L"// not a comment", L"// not a comment", Type::String);
+    expect(LanguageJava, java, L"\"\"\"; return text;", L"return", Type::ControlFlow);
+    expect(LanguageJava, java, L"\"unterminated", L"\"unterminated", Type::String);
+    expect(LanguageJava, java, L"return 1;", L"return", Type::ControlFlow);
+
+    single(LanguagePhp, L"<?php echo strlen($name); ?>", L"<?php", Type::Keyword);
+    single(LanguagePhp, L"<?php echo strlen($name); ?>", L"strlen", Type::Function);
+    single(LanguagePhp, L"<?php echo strlen($name); ?>", L"$name", Type::TypeName);
+    single(LanguagePhp, L"#[Example]", L"Example", Type::TypeName);
+    single(LanguagePhp, L"function run(string $s)", L"string", Type::TypeName);
+    SyntaxState php;
+    expect(LanguagePhp, php, L"$s = <<<'TEXT'", L"<<<'TEXT'", Type::String);
+    expect(LanguagePhp, php, L"TEXT_more # not a terminator", L"TEXT_more # not a terminator", Type::String);
+    expect(LanguagePhp, php, L"  TEXT; echo 1;", L"echo", Type::Keyword);
+    expect(LanguagePhp, php, L"\"multiline", L"\"multiline", Type::String);
+    expect(LanguagePhp, php, L"string\"; return 1;", L"return", Type::ControlFlow);
+
+    for (int language : {LanguageHtml, LanguageXml}) {
+        single(language, L"<doc:item id=\"2\">&amp;</doc:item>", L"doc:item", Type::Keyword);
+        single(language, L"<doc:item id=\"2\">&amp;</doc:item>", L"id", Type::TypeName);
+        single(language, L"<doc:item id=\"2\">&amp;</doc:item>", L"\"2\"", Type::String);
+        single(language, L"<doc:item id=\"2\">&amp;</doc:item>", L"&amp;", Type::Number);
+        SyntaxState markup;
+        expect(language, markup, L"<!-- comment", L"<!-- comment", Type::Comment);
+        expect(language, markup, L"end --> <a title=\"first", L"\"first", Type::String);
+        expect(language, markup, L"second\">text</a>", L"second\"", Type::String);
+        expect(language, markup, L"<![CDATA[<raw>", L"<![CDATA[<raw>", Type::String);
+        expect(language, markup, L"raw]]><b/>", L"b", Type::Keyword);
+    }
+    single(LanguageHtml, L"<script>if (a < b) run();</script><b/>", L"if (a < b) run();", Type::Plain);
+    single(LanguageHtml, L"<script>if (a < b) run();</script><b/>", L"<b/>", Type::Keyword);
+
+    single(LanguageCss, L".card { color: #ffaa00; }", L"color", Type::TypeName);
+    single(LanguageCss, L".card { color: #ffaa00; }", L"#ffaa00", Type::Number);
+    single(LanguageCss, L"a { padding: calc(1.5rem + 2px); }", L"calc", Type::Function);
+    single(LanguageCss, L"a { padding: calc(1.5rem + 2px); }", L"1.5rem", Type::Number);
+    single(LanguageCss, L"@media (min-width: 40rem)", L"@media", Type::Keyword);
+    single(LanguageCss, L"a { background: url(https://host/#x); }", L"https://host/#x", Type::String);
+    single(LanguageCss, L"a { background: url(\"https://host/#x\"); }", L"\"https://host/#x\"", Type::String);
+
+    single(LanguageYaml, L"site: https://host/#part # comment", L"https://host/#part", Type::Plain);
+    single(LanguageYaml, L"site: https://host/#part # comment", L"# comment", Type::Comment);
+    single(LanguageYaml, L"enabled: true", L"enabled", Type::TypeName);
+    single(LanguageYaml, L"enabled: true", L"true", Type::Keyword);
+    single(LanguageYaml, L"count: -2.5e+3", L"-2.5e+3", Type::Number);
+    single(LanguageYaml, L"copy: *defaults", L"*defaults", Type::TypeName);
+    single(LanguageYaml, L"\"key\": 'don''t'", L"\"key\"", Type::TypeName);
+    SyntaxState yaml;
+    expect(LanguageYaml, yaml, L"message: |2- # header", L"# header", Type::Comment);
+    expect(LanguageYaml, yaml, L"  # literal text", L"  # literal text", Type::String);
+    expect(LanguageYaml, yaml, L"next: true", L"next", Type::TypeName);
+    expect(LanguageYaml, yaml, L"quoted: 'first", L"'first", Type::String);
+    expect(LanguageYaml, yaml, L"  second'", L"  second'", Type::String);
+    expect(LanguageYaml, yaml, L"- message: |", L"|", Type::Keyword);
+    expect(LanguageYaml, yaml, L"    scalar contents", L"    scalar contents", Type::String);
+    expect(LanguageYaml, yaml, L"  sibling: true", L"sibling", Type::TypeName);
+    expect(LanguageYaml, yaml, L"- message: |2", L"|2", Type::Keyword);
+    expect(LanguageYaml, yaml, L"    scalar contents", L"    scalar contents", Type::String);
+    expect(LanguageYaml, yaml, L"  sibling: true", L"sibling", Type::TypeName);
+    expect(LanguageYaml, yaml, L"- |2", L"|2", Type::Keyword);
+    expect(LanguageYaml, yaml, L"  sequence scalar", L"  sequence scalar", Type::String);
+    expect(LanguageYaml, yaml, L"- true", L"true", Type::Keyword);
+
+    single(LanguageMarkdown, L"## Heading", L"## Heading", Type::Keyword);
+    single(LanguageMarkdown, L"**bold** and `code`", L"**bold**", Type::TypeName);
+    single(LanguageMarkdown, L"**bold** and `code`", L"`code`", Type::String);
+    single(LanguageMarkdown, L"[link](https://host/path_(one))", L"https://host/path_(one)", Type::String);
+    single(LanguageMarkdown, L"1. Item", L"1.", Type::Keyword);
+    SyntaxState md;
+    expect(LanguageMarkdown, md, L"````sql", L"````sql", Type::Keyword);
+    expect(LanguageMarkdown, md, L"```", L"```", Type::String);
+    expect(LanguageMarkdown, md, L"# inside", L"# inside", Type::String);
+    expect(LanguageMarkdown, md, L"````", L"````", Type::Keyword);
+    expect(LanguageMarkdown, md, L"## outside", L"## outside", Type::Keyword);
+
+    single(1, L"int sum(int x) { return x; }", L"int", Type::Keyword);
+    single(2, L"def greet(name):", L"def", Type::Keyword);
+    single(3, L"const count = 42;", L"const", Type::Keyword);
+    single(4, L"fn main() {}", L"fn", Type::Keyword);
+    single(5, L"func main() {}", L"func", Type::Keyword);
+    single(6, L"if test -f file; then", L"if", Type::Keyword);
+    single(7, L"if (true) return;", L"if", Type::ControlFlow);
+
+    // Malformed fragments must always terminate and preserve UTF-16 source,
+    // including when a prior line left the scanner inside a string/comment.
+    std::mt19937 random(207);
+    std::wstring alphabet = L"ab09 _-+/$'\"`#<>[]{}():;.!&*\\\t\u03bb\u4e2d";
+    for (int language = LanguageSql; language <= LanguageMarkdown; ++language) {
+        SyntaxState state;
+        for (int n = 0; n < 1200; ++n) {
+            if (n % 20 == 0) state = {};
+            std::wstring line;
+            size_t length = random() % 120;
+            while (line.size() < length) line += alphabet[random() % alphabet.size()];
+            lex(line, language, state);
+        }
+    }
+}
+
+bool sameColor(D2D1_COLOR_F a, D2D1_COLOR_F b) {
+    return a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a;
+}
+void layoutTests(App& app) {
+    // Native layout must use the existing seven configurable theme colours.
+    struct Sample { const char* language; const char* text; Type type; };
+    for (auto sample : {Sample{"sql", "SELECT", Type::Keyword}, {"ps", "Get-Date", Type::Function},
+                       {"java", "return", Type::ControlFlow}, {"php", "string", Type::TypeName},
+                       {"html", "<!-- comment -->", Type::Comment}, {"xml", "<![CDATA[text]]>", Type::String},
+                       {"css", "1.5rem", Type::Number}, {"yml", "true", Type::Keyword},
+                       {"md", "# Heading", Type::Keyword}, {"unknown-language", "SELECT 42;", Type::Plain}}) {
+        std::string source = "```" + std::string(sample.language) + "\n" + sample.text + "\n```\n";
+        app.root = app.parser.parse(source).root;
+        layoutDocument(app);
+        check(!app.layoutTextRuns.empty(), "native syntax sample creates text runs");
+        for (const auto& run : app.layoutTextRuns)
+            check(sameColor(run.color, getTokenColor(app.theme, sample.type)), "native layout uses requested theme category");
+        check(app.codeBlocks.size() == 1 && app.codeBlocks[0].codeText == toWide(std::string(sample.text) + "\n"),
+              "native highlighting preserves copy source");
+    }
+    // Unfinished constructs must not colour the next independent fence.
+    for (auto sample : {Sample{"sql", "/* unfinished", Type::Keyword}, {"ps", "$s = @'", Type::Function},
+                       {"yaml", "message: |\n  text", Type::Keyword}, {"html", "<!-- unfinished", Type::Keyword}}) {
+        const char* next = std::string(sample.language) == "ps" ? "Get-Date" :
+                           std::string(sample.language) == "yaml" ? "true" :
+                           std::string(sample.language) == "html" ? "<b/>" : "SELECT";
+        std::string source = "```" + std::string(sample.language) + "\n" + sample.text + "\n```\n\n```" + sample.language + "\n" + next + "\n```\n";
+        app.root = app.parser.parse(source).root;
+        layoutDocument(app);
+        check(app.codeBlocks.size() == 2, "adjacent independent fences render");
+        if (app.codeBlocks.size() == 2)
+            for (const auto& run : app.layoutTextRuns)
+                if (run.pos.y >= app.codeBlocks[1].bounds.top)
+                    check(sameColor(run.color, getTokenColor(app.theme, sample.type)), "syntax state resets between fenced blocks");
+    }
+
+    for (const char* fixture : {"syntax-languages", "syntax-multiline", "syntax-legacy-control"}) {
+        std::ifstream file(std::string(TINTA_SYNTAX_FIXTURES) + "/" + fixture + ".md", std::ios::binary);
+        check(file.good(), "runnable syntax fixture is available");
+        std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+        auto doc = app.parser.parse(source);
+        check(doc.success, "mixed fixture parses");
+        std::map<qmd::ElementType, int> counts;
+        std::vector<std::wstring> code;
+        std::function<void(const qmd::ElementPtr&)> visit = [&](const qmd::ElementPtr& e) {
+            ++counts[e->type];
+            if (e->type == qmd::ElementType::CodeBlock) {
+                std::string contents;
+                for (const auto& child : e->children) contents += child->text;
+                code.push_back(toWide(contents));
+            }
+            for (const auto& child : e->children) visit(child);
+        };
+        visit(doc.root);
+        for (auto type : {qmd::ElementType::Heading, qmd::ElementType::Table, qmd::ElementType::ListItem,
+                         qmd::ElementType::Strong, qmd::ElementType::Emphasis, qmd::ElementType::Link,
+                         qmd::ElementType::BlockQuote, qmd::ElementType::MathInline, qmd::ElementType::MathDisplay})
+            check(counts[type] > 0, "surrounding Markdown and math survive parsing");
+        app.root = doc.root;
+        layoutDocument(app);
+        check(app.codeBlocks.size() == code.size(), "every mixed code block renders");
+        float scale = app.contentScale * app.zoomFactor;
+        for (size_t b = 0; b < code.size() && b < app.codeBlocks.size(); ++b) {
+            const auto& block = app.codeBlocks[b];
+            check(block.codeText == code[b], "all mixed code copy text is unchanged");
+            check(app.docText.find(code[b]) != std::wstring::npos, "mixed code remains searchable/selectable");
+            size_t rows = std::count(code[b].begin(), code[b].end(), L'\n');
+            if (!code[b].empty() && code[b].back() != L'\n') ++rows;
+            float height = (std::max(size_t(1), rows) * 20.0f + 24.0f) * scale;
+            check(std::abs(block.bounds.bottom - block.bounds.top - height) < .1f, "syntax colours do not change row heights");
+            if (b) check(block.bounds.top > app.codeBlocks[b - 1].bounds.bottom, "mixed code blocks do not overlap");
+        }
+        check(!app.tableRects.empty(), "mixed table still lays out");
+        check(app.docText.find(L"Final syntax fixture paragraph") != std::wstring::npos, "content after fences renders");
+        auto completeText = app.docText;
+        auto completeBlocks = app.codeBlocks;
+        std::vector<D2D1_COLOR_F> completeColors;
+        for (const auto& run : app.layoutTextRuns) completeColors.push_back(run.color);
+        layoutDocumentViewportFirst(app);
+        ensureLayoutComplete(app);
+        check(app.docText == completeText, "incremental layout preserves the complete document text");
+        check(app.codeBlocks.size() == completeBlocks.size(), "incremental layout retains every code block");
+        check(app.layoutTextRuns.size() == completeColors.size(), "incremental syntax run count matches full layout");
+        for (size_t r = 0; r < app.layoutTextRuns.size() && r < completeColors.size(); ++r)
+            check(sameColor(app.layoutTextRuns[r].color, completeColors[r]), "incremental and full syntax colours match");
+    }
+}
+}
+
+int main() {
+    tokenTests();
+    {
+        auto app = std::make_unique<App>();
+        if (!initD2D(*app)) return 2;
+        app->height = 900;
+        app->readingWidthPct = 100;
+        for (int theme : {0, 5, -1}) {
+            applyTheme(*app, theme < 0 ? 0 : theme);
+            if (theme == -1) {
+                app->theme.syntaxKeyword = D2D1::ColorF(.11f, .12f, .13f);
+                app->theme.syntaxString = D2D1::ColorF(.21f, .22f, .23f);
+                app->theme.syntaxComment = D2D1::ColorF(.31f, .32f, .33f);
+                app->theme.syntaxNumber = D2D1::ColorF(.41f, .42f, .43f);
+                app->theme.syntaxFunction = D2D1::ColorF(.51f, .52f, .53f);
+                app->theme.syntaxType = D2D1::ColorF(.61f, .62f, .63f);
+                app->theme.syntaxControlFlow = D2D1::ColorF(.71f, .72f, .73f);
+            }
+            for (float scale : {1.0f, 1.5f}) {
+                app->contentScale = scale;
+                updateTextFormats(*app);
+                for (int width : {1050, 650}) {
+                    app->width = width;
+                    layoutTests(*app);
+                }
+            }
+        }
+    }
+    CoUninitialize();
+    std::cout << "Syntax highlighting: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Fences labelled SQL, PowerShell, Java, PHP, HTML, XML, CSS, YAML or Markdown previously displayed as plain code. Add native language-specific colours, the requested aliases, and block-local state for multiline comments, strings, markup, YAML values and inner Markdown fences. Existing languages, unknown-label fallback and theme keys retain their behaviour.

Requested by @hochun836. Closes #207.

The built-in feature list and syntax documentation now describe support and lexical limits. No fonts or external runtime are added. HTML/DOCX exports retain their existing plain-code formatting.

Validation: Release build and 18/18 CTests pass. Native layout checks cover Paper/Midnight/custom colours, two widths, two scales, full/incremental layout, copy/search source and mixed Markdown/math. Three runnable fixtures and an export runner are included. Comparing 40 exported artifacts with the preceding build changes only the 12 PNG pages containing newly highlighted code; all HTML/DOCX files and existing-language control pages are byte-identical. Six native pages were visually inspected. Details: `tests/syntax-validation.md`.

This draft is stacked on #213 (`toc-sidebar-visual-prototype-210`) so the diff contains only #207. No reporter reply has been posted.
