### PR TITLE
Add native Markdown footnotes and text return links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ FetchContent_MakeAvailable(md4c)
 # Source files
 set(SOURCES
     src/main_d2d.cpp
-    src/markdown.cpp
+    src/markdown.cpp src/footnotes.cpp
     src/themes.cpp
     src/settings.cpp
     src/keymap.cpp
@@ -195,6 +195,13 @@ if(BUILD_TESTING)
         TINTA_SYNTAX_FIXTURES="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures")
     add_test(NAME syntax_highlighting COMMAND syntax_tests)
 
+    add_executable(footnote_tests tests/footnote_tests.cpp ${INPUT_TEST_SOURCES})
+    target_include_directories(footnote_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
+    target_link_libraries(footnote_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
+    target_compile_definitions(footnote_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
+        TINTA_FOOTNOTE_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/footnotes.md")
+    add_test(NAME footnotes COMMAND footnote_tests)
+
     add_executable(blockquote_layout_tests tests/blockquote_layout_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(blockquote_layout_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
     target_link_libraries(blockquote_layout_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
@@ -213,7 +220,7 @@ if(BUILD_TESTING)
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_portable_test.cmake)
 
     add_executable(context_menu_tests tests/context_menu_tests.cpp src/context_menu.cpp
-        src/markdown.cpp src/themes.cpp src/config_dir.cpp)
+        src/markdown.cpp src/footnotes.cpp src/themes.cpp src/config_dir.cpp)
     target_include_directories(context_menu_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
     target_link_libraries(context_menu_tests PRIVATE md4c shell32)
     target_compile_definitions(context_menu_tests PRIVATE UNICODE _UNICODE)
@@ -224,7 +231,7 @@ if(BUILD_TESTING)
     add_test(NAME math_parser COMMAND math_parser_tests)
 
     add_executable(math_layout_tests tests/math_layout_tests.cpp
-        src/math_parser.cpp src/math_macros.cpp src/math_render.cpp src/markdown.cpp src/themes.cpp src/config_dir.cpp)
+        src/math_parser.cpp src/math_macros.cpp src/math_render.cpp src/markdown.cpp src/footnotes.cpp src/themes.cpp src/config_dir.cpp)
     target_include_directories(math_layout_tests PRIVATE include src ${md4c_SOURCE_DIR}/src)
     target_link_libraries(math_layout_tests PRIVATE md4c d2d1 dwrite windowscodecs shell32 ole32)
     target_compile_definitions(math_layout_tests PRIVATE UNICODE _UNICODE
@@ -255,7 +262,7 @@ if(BUILD_TESTING)
     add_executable(document_tests
         tests/document_tests.cpp
         src/document.cpp
-        src/markdown.cpp
+        src/markdown.cpp src/footnotes.cpp
     )
     target_include_directories(document_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/include
@@ -267,7 +274,7 @@ if(BUILD_TESTING)
     add_executable(inline_style_tests
         tests/inline_style_tests.cpp
         src/inline_style.cpp
-        src/markdown.cpp
+        src/markdown.cpp src/footnotes.cpp
         src/themes.cpp
         src/config_dir.cpp
     )

--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ HTML and DOCX exports. Native printing keeps Tinta's existing light print palett
 
 For supported code-fence languages and aliases, including SQL, PowerShell, Java,
 PHP, HTML/XML, CSS, YAML and Markdown, see [Syntax highlighting](docs/syntax-highlighting.md).
+Named, repeated and multiline [footnotes](docs/footnotes.md) include native navigation and HTML/DOCX export.
+
 Individual H1-H6 and marked-text overrides are described in [Heading and highlight colours](docs/theme-colours.md).
 
 ## Dependencies

--- a/docs/footnotes.md
+++ b/docs/footnotes.md
@@ -1,0 +1,25 @@
+# Footnotes
+
+Tinta supports named and numbered Markdown footnotes:
+
+```markdown
+A reference[^note], and the same reference again[^note].
+
+[^note]: A note with **formatting**, links and math.
+
+    A second paragraph, indented by four spaces.
+```
+
+Notes are numbered by their first reference and collected after the document.
+Click a superscript number to visit its note. Small text links return to the
+reference; repeated references each have their own numbered return link.
+Definitions may contain paragraphs, lists, tables and fenced code. Two-space
+continuations are also accepted. Unresolved and escaped references, inline code,
+and fenced examples remain literal. The first duplicate definition wins.
+
+HTML exports retain navigation and accessible note roles. DOCX exports use real
+Word footnotes; repeated occurrences use NOTEREF cross-reference fields. Native
+printing lists notes after the document. Nested footnotes and Obsidian's inline
+`^[note]` extension are not supported in this version.
+
+Try [the mixed sample](../tests/fixtures/footnotes.md).

--- a/include/app.h
+++ b/include/app.h
@@ -803,6 +803,7 @@ struct App {
     };
     std::vector<HeadingInfo> headings;
     std::unordered_map<std::string, int> headingSlugCounts;
+    std::unordered_map<std::string, float> footnoteAnchors;
     int hoveredTocIndex = -1;
     float tocScroll = 0.0f;
     // Typed while the panel is open: case-insensitive substring filter
@@ -1288,6 +1289,7 @@ struct App {
         docTextLower.clear();
         headings.clear();
         headingSlugCounts.clear();
+        footnoteAnchors.clear();
         fileRefCache.clear();
         for (auto& a : annotations) {
             a.docStart = a.docEnd = (size_t)-1;

--- a/include/footnotes.h
+++ b/include/footnotes.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "markdown.h"
+#include <unordered_map>
+
+namespace qmd {
+struct FootnoteSource {
+    std::string label, body;
+    std::vector<size_t> offsets;
+    size_t sourceOffset = 0;
+    int number = 0, references = 0;
+};
+struct FootnoteData {
+    std::string source;
+    std::vector<FootnoteSource> definitions;
+    std::unordered_map<std::string, size_t> byLabel;
+    std::vector<size_t> order;
+};
+FootnoteData extractFootnotes(const std::string& source);
+void appendFootnoteText(Element* parent, const std::string& text,
+                        const std::vector<size_t>& literalBrackets, FootnoteData& notes);
+void appendFootnotes(const ElementPtr& root, FootnoteData& notes,
+                     const std::function<ParseResult(const std::string&)>& parseBody);
+}

--- a/include/inline_style.h
+++ b/include/inline_style.h
@@ -17,6 +17,7 @@ struct InlineStyle {
     IDWriteTextFormat* format = nullptr;
     D2D1_COLOR_F color{};
     std::string linkUrl;
+    std::string anchorId;
     bool isLink = false;
     bool hasBg = false;
     D2D1_COLOR_F bgColor{};

--- a/include/markdown.h
+++ b/include/markdown.h
@@ -38,6 +38,7 @@ enum class ElementType {
     RubyText,
     // Synthetic first block built from YAML frontmatter (title + tags)
     Properties,
+    Footnotes, FootnoteDefinition, FootnoteReference, FootnoteBacklink,
     // Obsidian/Typora inline extensions (parsed in a post-pass)
     Highlight,     // ==text==
     Superscript,   // ^text^

--- a/src/export_docx.cpp
+++ b/src/export_docx.cpp
@@ -5,6 +5,7 @@
 // same primitives the viewer draws, and land as embedded pictures.
 
 #include "export.h"
+#include <set>
 
 #include "editor.h"
 #include "math_render.h"
@@ -588,6 +589,8 @@ struct RunProps {
 struct DocxCtx {
     App& app;
     std::string body;
+    std::vector<ElementPtr> footnotes;
+    std::set<int> emittedFootnotes;
     std::vector<std::pair<std::string, std::string>> media;  // name, bytes
     std::vector<std::string> relationships;   // xml lines, rId4 onward
     int nextRelId = 4;  // 1 = styles, 2 = numbering, 3 = settings
@@ -762,6 +765,23 @@ void walkInline(DocxCtx& ctx, const ElementPtr& elem, RunProps props,
             bold.bold = true;
             for (const auto& child : elem->children) {
                 walkInline(ctx, child, bold, out);
+            }
+            break;
+        }
+        case ElementType::FootnoteBacklink:
+            break;
+        case ElementType::FootnoteReference: {
+            std::string number = std::to_string(elem->level);
+            std::string bookmark = "_tinta_fn_" + number;
+            RunProps ref = props; ref.superScript = true; ref.color = ctx.linkHex;
+            if (ctx.emittedFootnotes.insert(elem->level).second) {
+                out += "<w:bookmarkStart w:id=\"" + number + "\" w:name=\"" + bookmark + "\"/>";
+                out += "<w:r>" + runPropsXml(ctx, ref) + "<w:footnoteReference w:id=\"" + number + "\"/></w:r>";
+                out += "<w:bookmarkEnd w:id=\"" + number + "\"/>";
+            } else {
+                out += "<w:fldSimple w:instr=\" NOTEREF " + bookmark + " \\h \" >";
+                emitTextRun(ctx, number, ref, out);
+                out += "</w:fldSimple>";
             }
             break;
         }
@@ -1000,6 +1020,9 @@ void walkBlocks(DocxCtx& ctx, const ElementPtr& elem, ParaProps props,
             for (const auto& child : elem->children) {
                 walkBlocks(ctx, child, props, listDepth);
             }
+            break;
+        case ElementType::Footnotes:
+            ctx.footnotes = elem->children;
             break;
         case ElementType::Properties:
             break;
@@ -1351,6 +1374,33 @@ bool exportDocxFile(App& app, const std::wstring& path) {
 
     ParaProps rootProps;
     walkBlocks(ctx, app.root, rootProps, 0);
+    std::string footnoteXml;
+    if (!ctx.footnotes.empty()) {
+        footnoteXml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+            "<w:footnotes xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" "
+            "xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" "
+            "xmlns:wp=\"http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing\">"
+            "<w:footnote w:type=\"separator\" w:id=\"-1\"><w:p><w:r><w:separator/></w:r></w:p></w:footnote>"
+            "<w:footnote w:type=\"continuationSeparator\" w:id=\"0\"><w:p><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>";
+        std::string body = std::move(ctx.body);
+        for (const auto& note : ctx.footnotes) {
+            ctx.body.clear();
+            for (const auto& child : note->children) {
+                bool backlink = std::any_of(child->children.begin(), child->children.end(),
+                    [](const ElementPtr& e) { return e->type == ElementType::FootnoteBacklink; });
+                if (!backlink) walkBlocks(ctx, child, rootProps, 0);
+            }
+            std::string mark = "<w:r><w:rPr><w:vertAlign w:val=\"superscript\"/></w:rPr><w:footnoteRef/></w:r>";
+            // Put the reference mark at the start of the first paragraph.
+            if (ctx.body.rfind("<w:p>", 0) == 0) {
+                size_t position = ctx.body.compare(5, 7, "<w:pPr>") == 0 ? ctx.body.find("</w:pPr>") + 8 : 5;
+                ctx.body.insert(position, mark);
+            } else ctx.body = "<w:p>" + mark + "</w:p>" + ctx.body;
+            footnoteXml += "<w:footnote w:id=\"" + std::to_string(note->level) + "\">" + ctx.body + "</w:footnote>";
+        }
+        ctx.body = std::move(body);
+        footnoteXml += "</w:footnotes>";
+    }
 
     std::string document =
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
@@ -1393,6 +1443,9 @@ bool exportDocxFile(App& app, const std::wstring& path) {
         "wordprocessingml.settings+xml\"/>"
         "</Types>";
 
+    if (!footnoteXml.empty()) contentTypes.insert(contentTypes.find("</Types>"),
+        "<Override PartName=\"/word/footnotes.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml\"/>");
+
     std::string rootRels =
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
         "<Relationships "
@@ -1418,6 +1471,12 @@ bool exportDocxFile(App& app, const std::wstring& path) {
         "Type=\"http://schemas.openxmlformats.org/officeDocument/2006/"
         "relationships/settings\" Target=\"settings.xml\"/>";
     for (const auto& rel : ctx.relationships) documentRels += rel;
+    std::string footnoteRels = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>"
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">";
+    for (const auto& rel : ctx.relationships) footnoteRels += rel;
+    footnoteRels += "</Relationships>";
+    if (!footnoteXml.empty()) documentRels += "<Relationship Id=\"rId" + std::to_string(ctx.nextRelId++) +
+        "\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes\" Target=\"footnotes.xml\"/>";
     documentRels += "</Relationships>";
 
     // Without a settings part Word opens the file in Compatibility Mode
@@ -1433,6 +1492,10 @@ bool exportDocxFile(App& app, const std::wstring& path) {
     zip.add("[Content_Types].xml", contentTypes);
     zip.add("_rels/.rels", rootRels);
     zip.add("word/document.xml", document);
+    if (!footnoteXml.empty()) {
+        zip.add("word/footnotes.xml", footnoteXml);
+        zip.add("word/_rels/footnotes.xml.rels", footnoteRels);
+    }
     zip.add("word/_rels/document.xml.rels", documentRels);
     zip.add("word/styles.xml", stylesXml(ctx));
     zip.add("word/numbering.xml", numberingXml(ctx));

--- a/src/export_html.cpp
+++ b/src/export_html.cpp
@@ -1077,10 +1077,27 @@ void walk(ExportCtx& ctx, const ElementPtr& elem) {
         case ElementType::Document:
             walkChildren(ctx, elem);
             break;
+        case ElementType::Footnotes:
+            ctx.out += "<section class=\"footnotes\" role=\"doc-endnotes\"><hr/>";
+            walkChildren(ctx, elem);
+            ctx.out += "</section>";
+            break;
+        case ElementType::FootnoteDefinition:
+            ctx.out += "<div id=\"" + htmlEscape(elem->url) + "\" class=\"footnote\"><span>" + std::to_string(elem->level) + ".</span>";
+            walkChildren(ctx, elem); ctx.out += "</div>";
+            break;
+        case ElementType::FootnoteReference:
+            ctx.out += "<sup id=\"" + htmlEscape(elem->title) + "\"><a role=\"doc-noteref\" href=\"" + htmlEscape(elem->url) + "\">";
+            walkChildren(ctx, elem); ctx.out += "</a></sup>";
+            break;
+        case ElementType::FootnoteBacklink:
+            ctx.out += "<a role=\"doc-backlink\" aria-label=\"Back to reference\" href=\"" + htmlEscape(elem->url) + "\">";
+            walkChildren(ctx, elem); ctx.out += "</a>";
+            break;
         case ElementType::Properties:
             break;  // frontmatter stays out of the export, like print
         case ElementType::Paragraph:
-            ctx.out += "<p>";
+            ctx.out += elem->language == "footnote-backlinks" ? "<p class=\"footnote-backlinks\">" : "<p>";
             walkChildren(ctx, elem);
             ctx.out += "</p>\n";
             break;
@@ -1422,6 +1439,8 @@ bool exportHtmlFile(App& app, const std::wstring& path) {
                "initial-scale=1\"/>\n";
     ctx.out += "<title>" + htmlEscape(title) + "</title>\n";
     ctx.out += "<style>" + themeCss(app, bodyFont, monoFont) + "</style>\n";
+    if (std::any_of(app.root->children.begin(), app.root->children.end(), [](const ElementPtr& e) { return e->type == ElementType::Footnotes; }))
+        ctx.out += "<style>.footnote{position:relative;padding-left:2em}.footnote>span{position:absolute;left:0}.footnote>p:first-of-type{margin-top:0}.footnote-backlinks{font-size:.8em}</style>\n";
     ctx.out += "</head>\n<body>\n";
     walk(ctx, app.root);
     ctx.out += "</body>\n</html>\n";

--- a/src/footnotes.cpp
+++ b/src/footnotes.cpp
@@ -1,0 +1,155 @@
+#include "footnotes.h"
+#include <algorithm>
+#include <cctype>
+
+namespace qmd {
+namespace {
+std::string fold(std::string text) {
+    for(auto& c:text) if(static_cast<unsigned char>(c)<128) c=static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return text;
+}
+ElementPtr node(ElementType type, Element* parent, const std::string& text={}) {
+    auto e=std::make_shared<Element>(type); e->parent=parent; e->text=text; return e;
+}
+bool labelAt(const std::string& text,size_t start,size_t& end) {
+    if(text.compare(start,2,"[^")!=0) return false;
+    end=text.find(']',start+2);
+    if(end==std::string::npos || end==start+2 || end-start>1000) return false;
+    for(size_t i=start+2;i<end;++i)
+        if(std::isspace(static_cast<unsigned char>(text[i])) || text[i]=='[') return false;
+    return true;
+}
+}
+
+FootnoteData extractFootnotes(const std::string& source) {
+    FootnoteData notes; notes.source=source;
+    struct Line { size_t begin,end,next,indent; };
+    std::vector<Line> lines;
+    for(size_t pos=0;pos<source.size();) {
+        size_t eol=source.find('\n',pos), next=eol==std::string::npos ? source.size() : eol+1;
+        size_t end=eol==std::string::npos ? source.size() : eol;
+        if(end>pos && source[end-1]=='\r')--end;
+        size_t first=pos; while(first<end && source[first]==' ')++first;
+        lines.push_back({pos,end,next,first-pos}); pos=next;
+    }
+    char fence=0; size_t fenceLength=0;
+    std::string rawEnd;
+    for(size_t row=0;row<lines.size();++row) {
+        const auto line=lines[row]; size_t first=line.begin+line.indent;
+        std::string text=source.substr(first,line.end-first), lowered=fold(text);
+        if(!rawEnd.empty()) { if(lowered.find(rawEnd)!=std::string::npos)rawEnd.clear(); continue; }
+        if(fence) {
+            size_t n=0;while(n<text.size()&&text[n]==fence)++n;
+            if(line.indent<=3 && n>=fenceLength && text.find_first_not_of(" \t",n)==std::string::npos) fence=0;
+            continue;
+        }
+        if(line.indent<=3 && !text.empty() && (text[0]=='`'||text[0]=='~')) {
+            size_t n=0;while(n<text.size()&&text[n]==text[0])++n;
+            if(n>=3) { fence=text[0];fenceLength=n;continue; }
+        }
+        for(const char* tag: {"pre","script","style","textarea"})
+            if(lowered.rfind(std::string("<")+tag,0)==0)rawEnd=std::string("</")+tag+">";
+        if(lowered.rfind("<!--",0)==0)rawEnd="-->";
+        if(!rawEnd.empty()) { if(lowered.find(rawEnd)!=std::string::npos)rawEnd.clear();continue; }
+        size_t close;
+        if(line.indent>3 || !labelAt(source,first,close) || close>=line.end || source[close+1]!=':')continue;
+        auto label=fold(source.substr(first+2,close-first-2));
+        bool duplicate = notes.byLabel.count(label) != 0; // First definition wins.
+        FootnoteSource def; def.label=label;def.sourceOffset=first;
+        auto addLine=[&](size_t start,const Line& item) {
+            for(size_t p=start;p<item.end;++p) { def.body+=source[p];def.offsets.push_back(p); }
+            def.body+='\n';def.offsets.push_back(item.end);
+        };
+        size_t bodyStart=close+2;
+        if(bodyStart<line.end && source[bodyStart]==' ')++bodyStart;
+        addLine(bodyStart,line);
+        size_t last=row;
+        for(size_t n=row+1;n<lines.size();) {
+            auto next=lines[n];
+            size_t nextClose;
+            if(next.indent<=3 && labelAt(source,next.begin+next.indent,nextClose) &&
+               nextClose<next.end && source[nextClose+1]==':')break;
+            if(next.begin+next.indent==next.end) {
+                size_t look=n+1;
+                while(look<lines.size() && lines[look].begin+lines[look].indent==lines[look].end)++look;
+                if(look==lines.size() || (lines[look].indent<2 && source[lines[look].begin]!='\t'))break;
+                addLine(next.end,next);last=n++;continue;
+            }
+            size_t strip=next.indent>=4 ? 4 : next.indent>=2 ? 2 : source[next.begin]=='\t' ? 1 : 0;
+            if(!strip)break;
+            addLine(next.begin+strip,next);last=n++;
+        }
+        // Blanking preserves byte offsets for editor/preview synchronization.
+        for(size_t p=line.begin;p<lines[last].next;++p)
+            if(notes.source[p]!='\n'&&notes.source[p]!='\r')notes.source[p]=' ';
+        if (!duplicate) {
+            notes.byLabel[label]=notes.definitions.size();notes.definitions.push_back(std::move(def));
+        }
+        row=last;
+    }
+    return notes;
+}
+
+void appendFootnoteText(Element* parent,const std::string& text,
+                        const std::vector<size_t>& literalBrackets,FootnoteData& notes) {
+    for(auto p=parent;p;p=p->parent)
+        if(p->type==ElementType::Code || p->type==ElementType::CodeBlock || p->type==ElementType::Link || p->type==ElementType::HtmlBlock) {
+            parent->children.push_back(node(ElementType::Text,parent,text));return;
+        }
+    size_t cursor=0;
+    for(size_t i=0;i<text.size();++i) {
+        size_t end;
+        if(!labelAt(text,i,end) || std::binary_search(literalBrackets.begin(),literalBrackets.end(),i))continue;
+        auto found=notes.byLabel.find(fold(text.substr(i+2,end-i-2)));
+        if(found==notes.byLabel.end())continue;
+        auto& def=notes.definitions[found->second];
+        if(!def.number) { notes.order.push_back(found->second);def.number=static_cast<int>(notes.order.size()); }
+        ++def.references;
+        if(i>cursor)parent->children.push_back(node(ElementType::Text,parent,text.substr(cursor,i-cursor)));
+        auto ref=node(ElementType::FootnoteReference,parent);
+        ref->level=def.number;
+        ref->url="#tinta-fn-"+std::to_string(def.number);
+        ref->title="tinta-fnref-"+std::to_string(def.number)+"-"+std::to_string(def.references);
+        ref->children.push_back(node(ElementType::Text,ref.get(),std::to_string(def.number)));
+        parent->children.push_back(ref);cursor=end+1;i=end;
+    }
+    if(cursor<text.size())parent->children.push_back(node(ElementType::Text,parent,text.substr(cursor)));
+}
+
+void appendFootnotes(const ElementPtr& root,FootnoteData& notes,
+                     const std::function<ParseResult(const std::string&)>& parseBody) {
+    if(notes.order.empty())return;
+    auto section=node(ElementType::Footnotes,root.get());
+    // Definitions render once, in the order of their first document reference.
+    for(size_t i=0;i<notes.order.size();++i) {
+        auto& def=notes.definitions[notes.order[i]];
+        auto parsed=parseBody(def.body);
+        auto note=node(ElementType::FootnoteDefinition,section.get());
+        note->level=def.number;note->url="tinta-fn-"+std::to_string(def.number);
+        note->sourceOffset=def.sourceOffset;
+        if(parsed.root) {
+            std::function<void(const ElementPtr&)> map=[&](const ElementPtr& e) {
+                if(e->sourceOffset<def.offsets.size())e->sourceOffset=def.offsets[e->sourceOffset];
+                for(auto& child:e->children)map(child);
+            };
+            for(auto& child:parsed.root->children) { map(child);child->parent=note.get();note->children.push_back(child); }
+        }
+        section->children.push_back(note);
+    }
+    for(size_t i=0;i<section->children.size();++i) {
+        auto& note=section->children[i];auto& def=notes.definitions[notes.order[i]];
+        auto back=node(ElementType::Paragraph,note.get());
+        back->language="footnote-backlinks";
+        if(def.references>1) back->children.push_back(node(ElementType::Text,back.get(),"Back to references: "));
+        for(int r=1;r<=def.references;++r) {
+            if(r>1)back->children.push_back(node(ElementType::Text,back.get(),", "));
+            auto link=node(ElementType::FootnoteBacklink,back.get());
+            link->url="#tinta-fnref-"+std::to_string(def.number)+"-"+std::to_string(r);
+            link->children.push_back(node(ElementType::Text,link.get(),def.references==1 ? "Back to reference" : std::to_string(r)));
+            back->children.push_back(link);
+        }
+        note->children.push_back(back);
+    }
+    root->children.push_back(section);
+}
+}

--- a/src/inline_style.cpp
+++ b/src/inline_style.cpp
@@ -146,6 +146,11 @@ void flattenInline(App& app, const std::vector<ElementPtr>& elements,
                 if (elem->type == ElementType::Subscript) st.drawYOffset = lineHeight * 0.38f;
                 break;
 
+            case ElementType::FootnoteReference:
+                st.anchorId = elem->title;
+                if (app.supSubFormat) { st.format = app.supSubFormat; st.fixedSize = true; }
+                [[fallthrough]];
+            case ElementType::FootnoteBacklink:
             case ElementType::Link: {
                 st.color = app.theme.link;
                 st.linkUrl = elem->url;

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1,4 +1,6 @@
 #include "markdown.h"
+#include "footnotes.h"
+#include <cstdint>
 #include <md4c.h>
 #include <fstream>
 #include <sstream>
@@ -43,6 +45,9 @@ struct ParserContext {
     ElementPtr root;
     std::stack<Element*> elementStack;
     std::string currentText;
+    std::vector<size_t> literalBrackets;
+    FootnoteData* notes = nullptr;
+    size_t inputLength = 0;
     const char* inputStart = nullptr;  // start of markdown source for offset tracking
 
     ParserContext() {
@@ -73,6 +78,8 @@ struct ParserContext {
             // For HTML blocks, accumulate raw HTML in the element's text field
             if (current()->type == ElementType::HtmlBlock) {
                 current()->text += currentText;
+            } else if (notes && !notes->definitions.empty()) {
+                appendFootnoteText(current(), currentText, literalBrackets, *notes);
             } else {
                 auto textElem = std::make_shared<Element>(ElementType::Text);
                 textElem->text = currentText;
@@ -80,10 +87,23 @@ struct ParserContext {
                 current()->children.push_back(textElem);
             }
             currentText.clear();
+            literalBrackets.clear();
         }
     }
 
     void addText(const char* text, MD_SIZE size) {
+        if (notes && inputStart) {
+            auto start = reinterpret_cast<uintptr_t>(inputStart);
+            auto pointer = reinterpret_cast<uintptr_t>(text);
+            if (pointer >= start && pointer - start < inputLength) {
+                size_t offset = pointer - start;
+                for (size_t i = 0; i < size; ++i) if (text[i] == '[') {
+                    size_t slashes = 0, p = offset + i;
+                    while (p && inputStart[--p] == '\\') ++slashes;
+                    if (slashes % 2) literalBrackets.push_back(currentText.size() + i);
+                }
+            }
+        }
         currentText.append(text, size);
     }
 };
@@ -456,6 +476,7 @@ static bool findExtensionSpan(const std::string& text, size_t from, ExtensionMat
             i++;  // retry from the second tilde as a potential single opener
             continue;
         } else if (c == '^' || c == '~') {
+            if (c == '^' && i && text[i - 1] == '[') continue;
             size_t close = text.find(c, i + 1);
             if (close == std::string::npos || close == i + 1) continue;
             // Typora rule: no whitespace inside sup/sub spans
@@ -1001,13 +1022,15 @@ static void splitFileRefs(const ElementPtr& parent) {
 MarkdownParser::MarkdownParser() = default;
 MarkdownParser::~MarkdownParser() = default;
 
-ParseResult MarkdownParser::parse(const std::string& markdown) {
+static ParseResult parseCore(const std::string& markdown, FootnoteData* notes) {
     ParseResult result;
 
     auto startTime = std::chrono::high_resolution_clock::now();
 
     ParserContext ctx;
     ctx.inputStart = markdown.c_str();
+    ctx.inputLength = markdown.size();
+    ctx.notes = notes;
 
     MD_PARSER parser = {
         0, // abi_version
@@ -1054,6 +1077,15 @@ ParseResult MarkdownParser::parse(const std::string& markdown) {
     detectGitHubAlerts(ctx.root);
     result.root = ctx.root;
     result.success = true;
+    return result;
+}
+
+ParseResult MarkdownParser::parse(const std::string& markdown) {
+    auto notes = extractFootnotes(markdown);
+    auto result = parseCore(notes.source, &notes);
+    if (result.success) appendFootnotes(result.root, notes, [&](const std::string& body) {
+        return parseCore(body, nullptr); // Nested footnote references stay literal.
+    });
     return result;
 }
 

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -401,9 +401,11 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
     float maxX = startX + maxWidth;
     float spaceWidth = getSpaceWidth(app, baseFormat);
 
+    std::string inlineAnchor;
     auto addLinkSegment = [&](float lineStartX, float lineEndX, float lineY,
                               const std::string& linkUrl, D2D1_COLOR_F color) {
         if (lineEndX <= lineStartX) return;
+        if (!inlineAnchor.empty()) app.footnoteAnchors.emplace(inlineAnchor, lineY);
         bool refLive = linkUrl.rfind("fileref-ok:", 0) == 0;
         bool refMissing = linkUrl.rfind("fileref-missing:", 0) == 0;
         float underlineY = lineY + mathTextOffset + normalLineHeight - 2;
@@ -421,7 +423,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
                                            D2D1::Point2F(ex, underlineY),
                                            dashColor, 1.0f});
             }
-        } else {
+        } else if (inlineAnchor.empty()) {
             app.layoutLines.push_back({D2D1::Point2F(lineStartX, underlineY),
                                        D2D1::Point2F(lineEndX, underlineY),
                                        color, 1.0f});
@@ -476,6 +478,7 @@ static void layoutInlineContent(App& app, const std::vector<ElementPtr>& element
         IDWriteTextFormat* format = run.style.format;
         D2D1_COLOR_F color = run.style.color;
         const std::string& linkUrl = run.style.linkUrl;
+        inlineAnchor = run.style.anchorId;
         bool isLink = run.style.isLink;
         bool hasBg = run.style.hasBg;
         bool hasStrike = run.style.hasStrike;
@@ -934,7 +937,8 @@ static void layoutParagraph(App& app, const ElementPtr& elem, float& y, float in
         layoutMathBlock(app, *math, y, indent, maxWidth);
         return;
     }
-    layoutInlineContent(app, elem->children, indent, y, maxWidth, app.textFormat, app.theme.text);
+    auto format = elem->language == "footnote-backlinks" && app.supSubFormat ? app.supSubFormat : app.textFormat;
+    layoutInlineContent(app, elem->children, indent, y, maxWidth, format, app.theme.text);
     app.docText += L"\n\n";
     float scale = app.contentScale * app.zoomFactor;
     y += 14 * scale;
@@ -3138,6 +3142,20 @@ static void layoutElement(App& app, const ElementPtr& elem, float& y, float inde
         case ElementType::Paragraph:
             layoutParagraph(app, elem, y, indent, maxWidth);
             break;
+        case ElementType::Footnotes:
+            layoutHorizontalRule(app, y, indent, maxWidth);
+            for (const auto& child : elem->children) layoutElement(app, child, y, indent, maxWidth);
+            break;
+        case ElementType::FootnoteDefinition: {
+            app.footnoteAnchors[elem->url] = y;
+            auto label = std::make_shared<Element>(ElementType::Text);
+            label->text = std::to_string(elem->level) + ".";
+            float labelY = y;
+            float inset = 32 * app.contentScale * app.zoomFactor;
+            layoutInlineContent(app, {label}, indent, labelY, inset, app.textFormat, app.theme.text);
+            for (const auto& child : elem->children) layoutElement(app, child, y, indent + inset, maxWidth - inset);
+            break;
+        }
         case ElementType::Heading:
             layoutHeading(app, elem, y, indent, maxWidth);
             break;
@@ -3308,7 +3326,10 @@ bool layoutStep(App& app, float targetY, int64_t budgetUs) {
         const auto& child = children[app.layoutNextBlock];
         // Record scroll anchor from source offset
         size_t offset = findFirstSourceOffset(child);
-        if (offset != SIZE_MAX) {
+        // Endnotes can move definitions ahead of their source order. Keep the
+        // editor/preview mapping ordered; note jumps use their explicit anchors.
+        if (offset != SIZE_MAX && child->type != ElementType::Footnotes &&
+            (app.scrollAnchors.empty() || app.scrollAnchors.back().sourceOffset < offset)) {
             app.scrollAnchors.push_back({offset, y});
         }
         layoutElement(app, child, y, app.layoutIndent, app.layoutMaxWidth);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -177,6 +177,11 @@ bool scrollToHeadingId(App& app, const std::string& id) {
     // early click on an anchor into a not-yet-laid-out section would miss.
     // Finish the layout synchronously before declaring the target absent.
     for (int attempt = 0; attempt < 2; attempt++) {
+        auto note = app.footnoteAnchors.find(id);
+        if (note != app.footnoteAnchors.end()) {
+            scrollToHeadingY(app, note->second);
+            return true;
+        }
         for (const auto& h : app.headings) {
             if (h.id == id) {
                 scrollToHeadingY(app, h.y);

--- a/tests/fixtures/footnotes.md
+++ b/tests/fixtures/footnotes.md
@@ -1,0 +1,55 @@
+---
+title: Footnote compatibility
+tags: [notes, regression]
+---
+
+# Footnotes with mixed Markdown
+
+A named reference[^detail], a short note[^1], and the named reference again[^detail].
+This keeps **bold**, *emphasis*, ==highlight==, H~2~O and x^2^ alongside $a^2+b^2=c^2$.
+
+## Notes in other structures
+
+| Item | Explanation |
+| :--- | :--- |
+| Table reference[^1] | A table with `inline code` |
+| Another[^detail] | **Bold** and $\frac{1}{2}$ |
+
+> A quote with a note[^1] and [an external link](https://example.com).
+
+- A list reference[^detail].
+- Another item with *emphasis*.
+
+## Literal and unresolved references
+
+Missing[^missing], escaped \[^1], inline code `[^detail]`, and a link [literal[^1]](https://example.com).
+
+```markdown
+[^fake]: This is an example, not a definition.
+Literal reference: [^1]
+```
+
+$$
+\sum_{k=1}^{n} k = \frac{n(n+1)}{2}
+$$
+
+Final body paragraph. Notes should appear after this paragraph.
+
+[^1]: Short note with **bold** and a [link](https://example.com/notes).
+
+[^detail]: A longer note with *emphasis*, ==highlight== and $x_i^2$.
+
+    A second paragraph in the same note.
+
+    - A nested list item.
+    - A second item with `code`.
+
+    | Note table | Value |
+    | :--- | ---: |
+    | Preserved | 42 |
+
+    ```sql
+    SELECT 42; -- syntax remains available inside a note
+    ```
+
+[^unused]: This unreferenced definition remains in the source.

--- a/tests/footnote_tests.cpp
+++ b/tests/footnote_tests.cpp
@@ -1,0 +1,104 @@
+#include "document.h"
+#include "d2d_init.h"
+#include "export.h"
+#include "render.h"
+#include "utils.h"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <set>
+
+namespace {
+int failures=0;
+void check(bool value,const char* message) { if(!value) { std::cerr<<"FAIL: "<<message<<'\n';++failures; } }
+std::string read(const std::filesystem::path& path) {
+    std::ifstream f(path,std::ios::binary);return {(std::istreambuf_iterator<char>(f)),std::istreambuf_iterator<char>()};
+}
+std::vector<ElementPtr> find(const ElementPtr& root,ElementType type) {
+    std::vector<ElementPtr> result;
+    std::function<void(const ElementPtr&)> walk=[&](const ElementPtr& e) {
+        if(e->type==type)result.push_back(e);
+        for(const auto& c:e->children) { check(c->parent==e.get(),"AST parent links remain valid");walk(c); }
+    };walk(root);return result;
+}
+void parserTests(App& app) {
+    auto parse=[&](std::string s){auto p=app.parser.parse(s);check(p.success,"footnote sample parses");return p.root;};
+    auto root=parse("First[^b], second[^a], again[^b].\n\n[^a]: Alpha\n[^b]: Beta\n");
+    auto refs=find(root,ElementType::FootnoteReference),defs=find(root,ElementType::FootnoteDefinition);
+    check(refs.size()==3 && defs.size()==2,"named, numeric and repeated notes resolve");
+    if(refs.size()==3)check(refs[0]->level==1&&refs[1]->level==2&&refs[2]->level==1,"first reference determines numbering");
+    check(find(root,ElementType::FootnoteBacklink).size()==3,"every occurrence has a return link");
+    root=parse("Literal \\[^a], `[^a]`, [label[^a]](https://host), missing[^none].\n\n[^a]: note\n");
+    check(find(root,ElementType::FootnoteReference).empty(),"escaped/code/link/missing references remain literal");
+    root=parse("```md\n[^a]: fake\n```\n\n[^a]\n");
+    check(find(root,ElementType::FootnoteDefinition).empty(),"fenced definitions remain literal");
+    root=parse("<pre>\n[^a]: fake\n</pre>\n\n[^a]\n");
+    check(find(root,ElementType::FootnoteDefinition).empty(),"raw preformatted definitions remain literal");
+    root=parse("A[^n].\n\n[^n]: first\n\n  second\n\n    - list\n    - item\n\nAfter.\n");
+    defs=find(root,ElementType::FootnoteDefinition);
+    check(defs.size()==1,"multiline note resolves");
+    if(!defs.empty())check(find(defs[0],ElementType::Paragraph).size()>=3 && !find(defs[0],ElementType::List).empty(),"multiline paragraphs and lists survive");
+    root=parse("A[^n], x^2^ and H~2~O.\r\n\r\n[^n]: note\r\n");
+    check(find(root,ElementType::FootnoteReference).size()==1 && find(root,ElementType::Superscript).size()==1 && find(root,ElementType::Subscript).size()==1,"CRLF, footnotes and script extensions coexist");
+    root=parse("[^a]\n\n[^a]: first\n\n[^a]: duplicate\n");
+    check(find(root,ElementType::FootnoteDefinition).size()==1,"duplicate definitions do not create duplicate IDs");
+    root=parse("[^a]\n\n[^a]: Nested [^b] stays literal.\n[^b]: Nested [^a] stays literal.\n");
+    check(find(root,ElementType::FootnoteDefinition).size()==1,"nested/circular references do not recurse");
+    root=parse("A[^a], B[^b].\n\n  [^a]: first\n  [^b]: second\n");
+    check(find(root,ElementType::FootnoteDefinition).size()==2,"indented sibling definitions remain separate");
+    root=parse("[^missing][^other]");
+    check(find(root,ElementType::Superscript).empty(),"unresolved adjacent references never become superscript spans");
+}
+}
+int main() {
+    namespace fs=std::filesystem;
+    auto state=std::make_unique<App>();auto& app=*state;
+    if(!initD2D(app))return 2;
+    // A message-only window gives native anchor navigation an isolated repaint target.
+    app.hwnd=CreateWindowExW(0,L"STATIC",L"Footnote tests",0,0,0,0,0,HWND_MESSAGE,nullptr,GetModuleHandleW(nullptr),nullptr);
+    parserTests(app);
+    auto source=read(TINTA_FOOTNOTE_FIXTURE);
+    auto parsed=parseDocument(app.parser,source,"footnotes.md");check(parsed.success,"mixed footnote fixture parses");
+    auto refs=find(parsed.root,ElementType::FootnoteReference),defs=find(parsed.root,ElementType::FootnoteDefinition);
+    check(refs.size()==7 && defs.size()==2,"all mixed references and both notes render");
+    for(auto type:{ElementType::Heading,ElementType::Table,ElementType::BlockQuote,ElementType::List,ElementType::Strong,ElementType::Emphasis,ElementType::Highlight,ElementType::MathInline,ElementType::MathDisplay,ElementType::CodeBlock})
+        check(!find(parsed.root,type).empty(),"mixed structures survive footnote parsing");
+    app.height=650;app.readingWidthPct=100;
+    for(int theme:{0,5}) {
+        applyTheme(app,theme);
+        for(float scale:{1.0f,1.5f}) {
+            app.contentScale=scale;updateTextFormats(app);
+            for(int width:{1050,650}) {
+                app.width=width;app.root=parsed.root;layoutDocument(app);
+                check(app.footnoteAnchors.size()==refs.size()+defs.size(),"native reference/definition anchors are complete");
+                check(app.docText.find(L"Final body paragraph")<app.docText.find(L"A longer note"),"notes render after body");
+                check(app.docText.find(L"[^missing]")!=std::wstring::npos,"unresolved references stay visible");
+                check(app.docText.find(L"A second paragraph in the same note")!=std::wstring::npos,"multiline note text is selectable/searchable");
+                check(app.codeBlocks.size()==2,"literal and note SQL blocks remain intact");
+                std::set<std::string> links;
+                for(const auto& link:app.linkRects)links.insert(link.url);
+                for(const auto& ref:refs) {
+                    check(links.count(ref->url)>0 && links.count("#"+ref->title)>0,"both directions have native click targets");
+                    check(scrollToHeadingId(app,ref->url.substr(1)),"native jump to footnote resolves");
+                    check(scrollToHeadingId(app,ref->title),"native return to reference resolves");
+                }
+                auto text=app.docText;auto anchors=app.footnoteAnchors;
+                app.scrollY=app.targetScrollY=0;
+                layoutDocumentViewportFirst(app);ensureLayoutComplete(app);
+                check(text==app.docText && anchors==app.footnoteAnchors,"full and incremental footnote layouts match");
+            }
+        }
+    }
+    fs::path output=fs::current_path()/"footnote-test-output";fs::create_directories(output);
+    check(exportHtmlFile(app,(output/"footnotes.html").wstring()),"HTML footnote export succeeds");
+    auto html=read(output/"footnotes.html");
+    for(const auto& ref:refs)check(html.find("id=\""+ref->title+"\"")!=std::string::npos && html.find("href=\"#"+ref->title+"\"")!=std::string::npos,"HTML IDs and return links pair");
+    check(exportDocxFile(app,(output/"footnotes.docx").wstring()),"Word footnote export succeeds");
+    auto zip=read(output/"footnotes.docx");
+    check(zip.find("word/footnotes.xml")!=std::string::npos && zip.find("relationships/footnotes")!=std::string::npos,"Word footnote part and relationship exist");
+    check(zip.find("<w:footnoteReference w:id=\"1\"/>")!=std::string::npos && zip.find("<w:footnote w:id=\"1\">")!=std::string::npos,"Word native reference targets real footnote");
+    check(zip.find("NOTEREF _tinta_fn_1")!=std::string::npos,"repeated Word references use a cross-reference field");
+    DestroyWindow(app.hwnd);app.hwnd=nullptr;state.reset();CoUninitialize();
+    std::cout<<"Footnotes: "<<failures<<" failures\n";return failures?1:0;
+}

--- a/tests/wish-list-validation.md
+++ b/tests/wish-list-validation.md
@@ -26,3 +26,27 @@ exports honour overrides; native printing retains its existing light palette.
   not claimed as manually verified; narrow document layout is checked natively.
 
 No issue comments are posted automatically. Draft replies are supplied for review.
+## Footnotes
+
+Validated on Windows, 2026-09-10. The mixed `footnotes.md` fixture combines named,
+numbered, repeated, unresolved and escaped references with frontmatter, headings,
+tables, quotes, lists, emphasis, highlights, code and math. Notes themselves
+contain paragraphs, a list, a table and a SQL block.
+
+- All 19 CTests passed after the parser/navigation/export additions. The footnote
+  target also passes after replacing the return icon with small text links.
+- Native layout covers Paper/Midnight, 1050/650 widths, 100/150% scale, all
+  reference and return targets, selectable note text, and equal full/incremental
+  layouts. Literal examples, first-use numbering, duplicate definitions,
+  two-space continuations and CRLF are checked.
+- Native print pages were visually inspected. Superscript references no longer
+  carry a stray baseline underline; the emoji-like return glyph is replaced by
+  `Back to reference` / `Back to references: 1, 2, ...`.
+- HTML IDs/links and actual DOCX ZIP parts are checked. Every XML part parses;
+  Word has two native footnotes, five repeated-reference NOTEREF fields, note
+  tables and hyperlinks, and no illegal nested footnote references. Word itself
+  has not been used for visual validation.
+- Computer Use was interrupted with Escape before interactive footnote testing;
+  native navigation and renderer checks above were used instead.
+
+Nested footnotes and inline `^[note]` syntax are outside this implementation.


### PR DESCRIPTION
Adds named and numeric Markdown footnotes, numbered by first use, with repeated references, multiline rich bodies and native jump/return navigation. Return links use small text instead of an emoji-like arrow. HTML retains navigation; DOCX creates real footnotes and NOTEREF fields for repeated references.

Addresses the footnote request from @Ra0EL in #208. Stacked on #215; the remaining frontmatter work follows separately.

Validation: 19 CTests passed; the footnote target passed again after the return-link cleanup. Mixed Markdown fixture covers tables, headings, lists, quotes, code, math, literal examples and repeated notes across two themes, widths and scales. Native print pages inspected; HTML targets and DOCX XML/relationships checked. All 40 existing control artifacts remain byte-identical. Word itself has not been used for visual validation. Nested notes and inline `^[note]` syntax are deferred.
