### PR TITLE
Fix large-image crashes and clean compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(SOURCES
     src/utils.cpp
     src/search.cpp
     src/render.cpp
+    src/image_loader.cpp
     src/file_utils.cpp
     src/overlays.cpp
     src/frontmatter_ui.cpp
@@ -97,6 +98,7 @@ set(HEADERS
     include/utils.h
     include/search.h
     include/render.h
+    include/image_loader.h
     include/file_utils.h
     include/overlays.h
     include/input.h
@@ -154,14 +156,19 @@ if(BUILD_TESTING)
     # window, including layout-dependent character sequences (#195).
     set(INPUT_TEST_SOURCES ${SOURCES})
     list(REMOVE_ITEM INPUT_TEST_SOURCES src/main_d2d.cpp)
-    add_executable(input_tests tests/input_tests.cpp tests/tab_drop_tests.cpp tests/superscript_tests.cpp tests/sidepanel_tests.cpp ${INPUT_TEST_SOURCES})
+    add_executable(input_tests tests/input_tests.cpp tests/tab_drop_tests.cpp tests/superscript_tests.cpp tests/sidepanel_tests.cpp tests/image_tests.cpp ${INPUT_TEST_SOURCES})
     target_include_directories(input_tests PRIVATE include ${md4c_SOURCE_DIR}/src)
     target_link_libraries(input_tests PRIVATE $<TARGET_PROPERTY:tinta,LINK_LIBRARIES>)
     target_compile_definitions(input_tests PRIVATE $<TARGET_PROPERTY:tinta,COMPILE_DEFINITIONS>
         TINTA_SHORTCUT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/shortcuts-layouts.md"
         TINTA_TAB_DROP_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/tab-drop-position.md"
         TINTA_SUPERSCRIPT_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/superscript-subscript.md"
-        TINTA_PANEL_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/toc-browser-resize.md")
+        TINTA_PANEL_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/toc-browser-resize.md"
+        TINTA_IMAGE_FIXTURE="${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/image-cache-large.md")
+    add_test(NAME image_cache_and_decode COMMAND ${CMAKE_COMMAND}
+        -DTEST_BINARY=$<TARGET_FILE:input_tests>
+        -DTEST_DIR=${CMAKE_CURRENT_BINARY_DIR}/image-test-$<CONFIG>
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_image_tests.cmake)
     add_test(NAME input_shortcuts COMMAND input_tests)
     add_test(NAME contents_and_panel_resize COMMAND ${CMAKE_COMMAND}
         -DTEST_BINARY=$<TARGET_FILE:input_tests>

--- a/include/app.h
+++ b/include/app.h
@@ -11,6 +11,7 @@
 #include <dwrite.h>
 #include <dwrite_2.h>
 #include <wincodec.h>
+#include <wrl/client.h>
 
 #include <string>
 #include <vector>
@@ -294,7 +295,7 @@ struct App {
 
     // Image cache
     struct ImageEntry {
-        ID2D1Bitmap* bitmap = nullptr;
+        Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
         int width = 0;
         int height = 0;
         bool failed = false;
@@ -313,14 +314,12 @@ struct App {
     }
 
     void storeImageCacheEntry(const std::string& key, ImageEntry entry) {
-        entry.bytes = entry.bitmap && entry.width > 0 && entry.height > 0
-            ? (size_t)entry.width * (size_t)entry.height * 4
-            : 0;
+        const auto pixels = entry.bitmap ? entry.bitmap->GetPixelSize() : D2D1_SIZE_U{};
+        entry.bytes = static_cast<size_t>(pixels.width) * pixels.height * 4;
         touchImageCacheEntry(entry);
 
         auto it = imageCache.find(key);
         if (it != imageCache.end()) {
-            if (it->second.bitmap) it->second.bitmap->Release();
             imageCacheBytes -= it->second.bytes;
             it->second = std::move(entry);
             imageCacheBytes += it->second.bytes;
@@ -342,7 +341,6 @@ struct App {
                 }
             }
             if (victim == imageCache.end()) break;
-            if (victim->second.bitmap) victim->second.bitmap->Release();
             imageCacheBytes -= victim->second.bytes;
             imageCache.erase(victim);
         }
@@ -350,7 +348,9 @@ struct App {
 
     // Layout bitmaps (document coordinates)
     struct LayoutBitmap {
-        ID2D1Bitmap* bitmap = nullptr;
+        // Layout owns a reference independently of the LRU cache (#220).
+        // Copies, measurement rollback and relayout all release via RAII.
+        Microsoft::WRL::ComPtr<ID2D1Bitmap> bitmap;
         D2D1_RECT_F destRect{};
     };
     std::vector<LayoutBitmap> layoutBitmaps;
@@ -1329,9 +1329,6 @@ struct App {
     }
 
     void releaseImageCache() {
-        for (auto& [key, entry] : imageCache) {
-            if (entry.bitmap) { entry.bitmap->Release(); entry.bitmap = nullptr; }
-        }
         imageCache.clear();
         imageCacheBytes = 0;
         imageCacheUseClock = 0;

--- a/include/image_loader.h
+++ b/include/image_loader.h
@@ -1,0 +1,30 @@
+#ifndef TINTA_IMAGE_LOADER_H
+#define TINTA_IMAGE_LOADER_H
+
+#include <windows.h>
+#include <wincodec.h>
+#include <cstdint>
+#include <vector>
+
+// Bound the display copy, independently of compressed file size. Originals
+// remain untouched for HTML/DOCX export. Also reject extreme source dimensions
+// before asking a codec to allocate its internal decoding buffers (#220).
+constexpr uint64_t IMAGE_DECODE_MAX_PIXELS = 16ull * 1024 * 1024;
+constexpr uint64_t IMAGE_SOURCE_MAX_PIXELS = 100000000;
+constexpr UINT IMAGE_SOURCE_MAX_DIMENSION = 65535;
+constexpr UINT IMAGE_DECODE_MAX_DIMENSION = 8192;
+
+struct ImageDecodeSize { UINT width = 0, height = 0; };
+ImageDecodeSize boundedImageSize(UINT width, UINT height, UINT maxDimension);
+
+struct DecodedImage {
+    UINT width = 0, height = 0;
+    float dpiX = 96.0f, dpiY = 96.0f;
+    std::vector<uint8_t> pixels;  // premultiplied BGRA
+};
+
+// No partially decoded pixels escape on failure, including allocation failure.
+HRESULT decodeImageFile(IWICImagingFactory* factory, const wchar_t* path,
+                       UINT maxDimension, DecodedImage& output) noexcept;
+
+#endif

--- a/include/render.h
+++ b/include/render.h
@@ -21,6 +21,7 @@ void ensureLayoutComplete(App& app);
 // UI-thread completion for WM_APP_IMAGE_READY: takes ownership of the
 // AsyncImageResult, updates the image cache, and triggers a reflow
 void completeAsyncImage(App& app, void* asyncResult);
+void discardAsyncImage(void* asyncResult);
 
 // Theme color for a diagram primitive's role (shared with the exporters)
 D2D1_COLOR_F resolveDiagramRole(const App& app, const mermaidext::Prim& prim,

--- a/src/d2d_init.cpp
+++ b/src/d2d_init.cpp
@@ -494,6 +494,16 @@ void createTypography(App& app) {
 }
 
 bool createRenderTarget(App& app) {
+    // Layout and the lightbox now retain their own image references. Drop
+    // every old-target drawing before recreating device resources (#220).
+    app.clearLayoutCache();
+    app.layoutDirty = true;
+    if (app.lightboxBitmap) {
+        app.lightboxBitmap->Release();
+        app.lightboxBitmap = nullptr;
+    }
+    app.showLightbox = false;
+    app.lightboxDragging = false;
     if (app.renderTarget) {
         app.renderTarget->Release();
         app.renderTarget = nullptr;
@@ -511,7 +521,7 @@ bool createRenderTarget(App& app) {
     // on whatever target exists then.
     app.imageCacheBytes = 0;
     for (auto it = app.imageCache.begin(); it != app.imageCache.end();) {
-        if (it->second.bitmap) { it->second.bitmap->Release(); it->second.bitmap = nullptr; }
+        it->second.bitmap.Reset();
         it->second.bytes = 0;
         if (it->second.pending) { ++it; }
         else { it = app.imageCache.erase(it); }

--- a/src/editor.cpp
+++ b/src/editor.cpp
@@ -2700,7 +2700,7 @@ void handleEditorMouseDown(App& app, HWND hwnd, int x, int y) {
     InvalidateRect(hwnd, nullptr, FALSE);
 }
 
-void handleEditorMouseUp(App& app, HWND hwnd, int x, int y) {
+void handleEditorMouseUp(App& app, HWND, int, int) {
     if (app.editorScrollbarDragging) {
         app.editorScrollbarDragging = false;
         ReleaseCapture();

--- a/src/image_loader.cpp
+++ b/src/image_loader.cpp
@@ -1,0 +1,84 @@
+#include "image_loader.h"
+
+#include <wrl/client.h>
+#include <algorithm>
+#include <cmath>
+#include <new>
+#include <stdexcept>
+#include <utility>
+
+using Microsoft::WRL::ComPtr;
+
+ImageDecodeSize boundedImageSize(UINT width, UINT height, UINT maxDimension) {
+    if (!width || !height || !maxDimension) return {};
+    const double limit = std::min(maxDimension, IMAGE_DECODE_MAX_DIMENSION);
+    const double scale = std::min({1.0, limit / width, limit / height,
+        std::sqrt(static_cast<double>(IMAGE_DECODE_MAX_PIXELS) /
+                  (static_cast<double>(width) * height))});
+    return {std::max(1u, static_cast<UINT>(std::floor(width * scale))),
+            std::max(1u, static_cast<UINT>(std::floor(height * scale)))};
+}
+
+HRESULT decodeImageFile(IWICImagingFactory* factory, const wchar_t* path,
+                       UINT maxDimension, DecodedImage& output) noexcept {
+    output = {};
+    if (!factory || !path || !maxDimension) return E_INVALIDARG;
+    try {
+        ComPtr<IWICBitmapDecoder> decoder;
+        HRESULT hr = factory->CreateDecoderFromFilename(path, nullptr, GENERIC_READ,
+            WICDecodeMetadataCacheOnDemand, decoder.GetAddressOf());
+        if (FAILED(hr)) return hr;
+        ComPtr<IWICBitmapFrameDecode> frame;
+        hr = decoder->GetFrame(0, frame.GetAddressOf());
+        if (FAILED(hr)) return hr;
+        UINT sourceW = 0, sourceH = 0;
+        hr = frame->GetSize(&sourceW, &sourceH);
+        if (FAILED(hr)) return hr;
+        if (!sourceW || !sourceH || sourceW > IMAGE_SOURCE_MAX_DIMENSION ||
+            sourceH > IMAGE_SOURCE_MAX_DIMENSION ||
+            static_cast<uint64_t>(sourceW) * sourceH > IMAGE_SOURCE_MAX_PIXELS)
+            return WINCODEC_ERR_IMAGESIZEOUTOFRANGE;
+
+        const auto size = boundedImageSize(sourceW, sourceH, maxDimension);
+        ComPtr<IWICBitmapSource> source = frame;
+        ComPtr<IWICBitmapScaler> scaler;
+        if (size.width != sourceW || size.height != sourceH) {
+            hr = factory->CreateBitmapScaler(scaler.GetAddressOf());
+            if (FAILED(hr)) return hr;
+            // Scale before format conversion/CopyPixels; never request an
+            // unbounded full-resolution BGRA buffer from WIC.
+            hr = scaler->Initialize(frame.Get(), size.width, size.height,
+                                    WICBitmapInterpolationModeFant);
+            if (FAILED(hr)) return hr;
+            source = scaler;
+        }
+        ComPtr<IWICFormatConverter> converter;
+        hr = factory->CreateFormatConverter(converter.GetAddressOf());
+        if (FAILED(hr)) return hr;
+        hr = converter->Initialize(source.Get(), GUID_WICPixelFormat32bppPBGRA,
+            WICBitmapDitherTypeNone, nullptr, 0.0, WICBitmapPaletteTypeCustom);
+        if (FAILED(hr)) return hr;
+
+        DecodedImage decoded;
+        decoded.width = size.width;
+        decoded.height = size.height;
+        double dpiX = 96.0, dpiY = 96.0;
+        if (FAILED(frame->GetResolution(&dpiX, &dpiY))) dpiX = dpiY = 96.0;
+        if (!std::isfinite(dpiX) || dpiX < 1.0 || dpiX > 9600.0) dpiX = 96.0;
+        if (!std::isfinite(dpiY) || dpiY < 1.0 || dpiY > 9600.0) dpiY = 96.0;
+        // Preserve the intrinsic size in DIPs even when the pixel copy shrinks.
+        decoded.dpiX = static_cast<float>(dpiX * size.width / sourceW);
+        decoded.dpiY = static_cast<float>(dpiY * size.height / sourceH);
+        const UINT stride = size.width * 4;
+        const UINT bytes = stride * size.height;  // bounded to 64 MiB above
+        decoded.pixels.resize(bytes);
+        hr = converter->CopyPixels(nullptr, stride, bytes, decoded.pixels.data());
+        if (FAILED(hr)) return hr;
+        output = std::move(decoded);
+        return S_OK;
+    } catch (const std::bad_alloc&) {
+        return E_OUTOFMEMORY;
+    } catch (const std::length_error&) {
+        return E_OUTOFMEMORY;
+    }
+}

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -774,7 +774,7 @@ static void settingsAction(App& app, HWND hwnd, int action) {
     InvalidateRect(hwnd, nullptr, FALSE);
 }
 
-void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM) {
     // Lightbox: the wheel zooms the image
     if (app.showLightbox) {
         float delta = (float)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA;
@@ -926,7 +926,7 @@ void handleMouseWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
     InvalidateRect(hwnd, nullptr, FALSE);
 }
 
-void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+void handleMouseHWheel(App& app, HWND hwnd, WPARAM wParam, LPARAM) {
     // Horizontal scroll
     float delta = (float)GET_WHEEL_DELTA_WPARAM(wParam) / WHEEL_DELTA * dpi(app, 60.0f);
     app.targetScrollX += delta;
@@ -1420,7 +1420,6 @@ void handleMouseMove(App& app, HWND hwnd, LPARAM lParam) {
     }
 
     // Check if over text
-    bool wasOverText = app.overText;
     app.overText = (findTextRectAt(app, (int)docX, (int)docY) != nullptr);
 
     // Check if hovering over any code block (show copy button on whole block)
@@ -1782,7 +1781,7 @@ static void toggleApplicationMenu(App& app, HWND hwnd, bool keyboard = false) {
     InvalidateRect(hwnd, nullptr, FALSE);
 }
 
-void handleMouseDown(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+void handleMouseDown(App& app, HWND hwnd, WPARAM, LPARAM lParam) {
     // A fresh press is a new gesture, even if a cancelled drag released elsewhere.
     app.swallowNextMouseUp = false;
     // Settings owns the entire click, including the title strip behind it.
@@ -2665,7 +2664,7 @@ static void toggleFitBlock(App& app, HWND hwnd, unsigned key) {
     InvalidateRect(hwnd, nullptr, FALSE);
 }
 
-void handleMouseUp(App& app, HWND hwnd, WPARAM wParam, LPARAM lParam) {
+void handleMouseUp(App& app, HWND hwnd, WPARAM, LPARAM lParam) {
     if (app.scrollbarDragging || app.hScrollbarDragging) {
         app.mouseX = GET_X_LPARAM(lParam);
         app.mouseY = GET_Y_LPARAM(lParam);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -3293,7 +3293,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM, LPARAM lParam) {
             } else if (const App::LayoutBitmap* img =
                            layoutBitmapAt(app, docX, docY)) {
                 // Inline image: view it full size
-                openLightbox(app, img->bitmap);
+                openLightbox(app, img->bitmap.Get());
                 app.hasSelection = false;
             } else {
                 app.hasSelection = false;
@@ -3320,7 +3320,7 @@ void handleMouseUp(App& app, HWND hwnd, WPARAM, LPARAM lParam) {
             annotationOpenEditor(app, annotHit);
         } else if (const App::LayoutBitmap* img =
                        layoutBitmapAt(app, docX, docY)) {
-            openLightbox(app, img->bitmap);
+            openLightbox(app, img->bitmap.Get());
         }
     }
 

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -823,14 +823,14 @@ render_document:
     // Draw vertical scrollbar
     if (needsVScroll) {
         float scrollExtent = std::max((float)app.height, app.scrollbarContentHeight);
-        float maxScrollY = std::max(0.0f, scrollExtent - app.height);
+        float scrollbarMaxY = std::max(0.0f, scrollExtent - app.height);
         float trackTop = chromeTopHeight(app);
         float trackHeight =
             app.height - trackTop - (needsHScroll ? scrollbarSize : 0);
         float sbHeight = trackHeight / scrollExtent * trackHeight;
         sbHeight = std::max(sbHeight, dpi(app, 30.0f));
         float sbY = trackTop +
-            ((maxScrollY > 0) ? (app.scrollY / maxScrollY * (trackHeight - sbHeight)) : 0);
+            ((scrollbarMaxY > 0) ? (app.scrollY / scrollbarMaxY * (trackHeight - sbHeight)) : 0);
 
         float sbWidth = quietScrollbars ? dpi(app, 4.0f) :
             ((app.scrollbarHovered || app.scrollbarDragging) ? dpi(app, 10.0f) : dpi(app, 6.0f));
@@ -898,11 +898,11 @@ render_document:
 
     // Draw horizontal scrollbar
     if (needsHScroll) {
-        float maxScrollX = std::max(0.0f, app.contentWidth - documentWidth);
+        float scrollbarMaxX = std::max(0.0f, app.contentWidth - documentWidth);
         float trackWidth = documentWidth - (needsVScroll ? scrollbarSize : 0);
         float sbWidth = trackWidth / app.contentWidth * trackWidth;
         sbWidth = std::max(sbWidth, dpi(app, 30.0f));
-        float sbX = (maxScrollX > 0) ? (app.scrollX / maxScrollX * (trackWidth - sbWidth)) : 0;
+        float sbX = (scrollbarMaxX > 0) ? (app.scrollX / scrollbarMaxX * (trackWidth - sbWidth)) : 0;
 
         float sbHeight = quietScrollbars ? dpi(app, 4.0f) :
             ((app.hScrollbarHovered || app.hScrollbarDragging) ? dpi(app, 10.0f) : dpi(app, 6.0f));
@@ -1865,7 +1865,7 @@ static LONG WINAPI writeCrashDump(EXCEPTION_POINTERS* exceptionInfo) {
     return EXCEPTION_CONTINUE_SEARCH;
 }
 
-int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR lpCmdLine, int nCmdShow) {
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow) {
     SetUnhandledExceptionFilter(writeCrashDump);
     // Enable per-monitor DPI V2 awareness
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);

--- a/src/main_d2d.cpp
+++ b/src/main_d2d.cpp
@@ -556,7 +556,7 @@ render_document:
             bmp.destRect.top > viewportBottom + cullMargin) continue;
         if (bmp.destRect.right < viewportLeft - cullMargin ||
             bmp.destRect.left > viewportRight + cullMargin) continue;
-        app.renderTarget->DrawBitmap(bmp.bitmap,
+        app.renderTarget->DrawBitmap(bmp.bitmap.Get(),
             D2D1::RectF(bmp.destRect.left - app.scrollX,
                          bmp.destRect.top - app.scrollY,
                          bmp.destRect.right - app.scrollX,
@@ -1673,6 +1673,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             // A background image download finished: swap it into the cache
             // and reflow (handler takes ownership of the result)
             if (app) completeAsyncImage(*app, (void*)lParam);
+            else discardAsyncImage((void*)lParam);
             return 0;
 
         case WM_CONTEXTMENU:

--- a/src/markdown.cpp
+++ b/src/markdown.cpp
@@ -1174,7 +1174,7 @@ struct HtmlTag {
 static std::string toLower(const std::string& s) {
     std::string result = s;
     std::transform(result.begin(), result.end(), result.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
     return result;
 }
 

--- a/src/mermaid.cpp
+++ b/src/mermaid.cpp
@@ -775,13 +775,13 @@ ParseResult parse(std::string_view source) {
                     std::string label = configName;
                     size_t labelKey = line.find("label");
                     if (labelKey != std::string_view::npos) {
-                        size_t quote = line.find('"', labelKey);
-                        size_t close = quote == std::string_view::npos
+                        size_t quoteStart = line.find('"', labelKey);
+                        size_t quoteEnd = quoteStart == std::string_view::npos
                             ? std::string_view::npos
-                            : line.find('"', quote + 1);
-                        if (close != std::string_view::npos) {
+                            : line.find('"', quoteStart + 1);
+                        if (quoteEnd != std::string_view::npos) {
                             label = decodeLabel(
-                                line.substr(quote + 1, close - quote - 1));
+                                line.substr(quoteStart + 1, quoteEnd - quoteStart - 1));
                         }
                     }
                     size_t nodesBefore = result.diagram.nodes.size();

--- a/src/mermaid_block.cpp
+++ b/src/mermaid_block.cpp
@@ -312,9 +312,9 @@ struct BlockEmitCtx {
 
 void emitLeaf(BlockEmitCtx& ctx, BlockItem& item);
 
-// Lays out a container's children into the given content rect
+// Lays out a container's children from the top-left within the available width
 void emitContainer(BlockEmitCtx& ctx, BlockItem& container, float x1,
-                   float y1, float x2, float y2) {
+                   float y1, float x2) {
     BlockMeasureCtx& mctx = *ctx.measure;
     float scale = mctx.scale;
     ContainerMetrics metrics = measureContainer(mctx, container);
@@ -358,8 +358,7 @@ void emitContainer(BlockEmitCtx& ctx, BlockItem& container, float x1,
                 panel.strokeWidth = 1.2f * scale;
                 ctx.shapes->push_back(panel);
                 float pad = kBlockPad * scale;
-                emitContainer(ctx, child, cx1 + pad, cy1 + pad, cx2 - pad,
-                              cy2 - pad);
+                emitContainer(ctx, child, cx1 + pad, cy1 + pad, cx2 - pad);
             } else {
                 emitLeaf(ctx, child);
             }
@@ -662,8 +661,7 @@ Built buildBlock(std::string_view source, const Measure& measure,
     std::map<std::string, BlockItem*> index;
     BlockEmitCtx ectx{&mctx, &shapes, &texts, &index};
     float top = 4.0f * scale;
-    emitContainer(ectx, root, 0.0f, top, metrics.width(),
-                  top + metrics.height());
+    emitContainer(ectx, root, 0.0f, top, metrics.width());
 
     result.prims = std::move(shapes);
 

--- a/src/mermaid_narrative.cpp
+++ b/src/mermaid_narrative.cpp
@@ -750,7 +750,6 @@ Built buildJourney(std::string_view source, const Measure& measure,
 
     // Score lane: higher score = higher dot, 1..7
     float laneHeight = 110.0f * scale;
-    float laneTop = y;
     float laneBottom = y + laneHeight;
     auto scoreY = [&](float score) {
         float clamped = std::max(1.0f, std::min(7.0f, score));

--- a/src/overlays.cpp
+++ b/src/overlays.cpp
@@ -425,8 +425,6 @@ void renderFolderBrowser(App& app) {
 
     // A docked surface shares one divider with the neighbouring pane.
     FolderBrowserMetrics g = folderBrowserMetrics(app);
-    float panelWidth = g.panelWidth;
-    float panelX = g.panelX;
     D2D1_RECT_F card = D2D1::RectF(g.cardLeft, g.cardTop, g.cardRight, g.cardBottom);
     D2D1_COLOR_F panelBg = promptChipSurface(app);
     panelBg.a = 1;
@@ -4046,22 +4044,22 @@ void renderThemeEditor(App& app) {
             D2D1::RoundedRect(list, dpi(app, 6.0f), dpi(app, 6.0f)), app.brush, 1.0f);
         app.renderTarget->PushAxisAlignedClip(list, D2D1_ANTIALIAS_MODE_ALIASED);
 
-        float rowH = dpi(app, 26.0f);
+        float fontRowHeight = dpi(app, 26.0f);
         float maxScroll = std::max(0.0f,
-            (float)app.systemFontFamilies.size() * rowH - (list.bottom - list.top));
+            (float)app.systemFontFamilies.size() * fontRowHeight - (list.bottom - list.top));
         app.themeEditorFontScroll = std::max(0.0f, std::min(app.themeEditorFontScroll, maxScroll));
-        int first = (int)(app.themeEditorFontScroll / rowH);
-        int visible = (int)((list.bottom - list.top) / rowH) + 2;
+        int first = (int)(app.themeEditorFontScroll / fontRowHeight);
+        int visible = (int)((list.bottom - list.top) / fontRowHeight) + 2;
         for (int i = first; i < first + visible &&
                             i < (int)app.systemFontFamilies.size(); i++) {
-            float ry = list.top + i * rowH - app.themeEditorFontScroll;
+            float ry = list.top + i * fontRowHeight - app.themeEditorFontScroll;
             const std::wstring& fam = app.systemFontFamilies[i];
             bool selected = (_wcsicmp(fam.c_str(), app.themeEditorFont.c_str()) == 0);
             if (selected) {
                 D2D1_COLOR_F hl = base.accent; hl.a = 0.18f;
                 app.brush->SetColor(hl);
                 app.renderTarget->FillRectangle(
-                    D2D1::RectF(list.left + 1, ry, list.right - 1, ry + rowH), app.brush);
+                    D2D1::RectF(list.left + 1, ry, list.right - 1, ry + fontRowHeight), app.brush);
             }
             IDWriteTextFormat* ff = nullptr;
             app.dwriteFactory->CreateTextFormat(fam.c_str(), nullptr,
@@ -4072,13 +4070,13 @@ void renderThemeEditor(App& app) {
             if (ff) {
                 app.renderTarget->DrawText(fam.c_str(), (UINT32)fam.size(), ff,
                     D2D1::RectF(list.left + dpi(app, 12.0f), ry + dpi(app, 3.0f),
-                                list.right - dpi(app, 8.0f), ry + rowH), app.brush);
+                                list.right - dpi(app, 8.0f), ry + fontRowHeight), app.brush);
                 ff->Release();
             }
             // Clamp the hit rect to the visible list: rows drawn under the
             // clip must not steal clicks from the buttons below
             D2D1_RECT_F hr = D2D1::RectF(list.left, std::max(ry, list.top),
-                                         list.right, std::min(ry + rowH, list.bottom));
+                                         list.right, std::min(ry + fontRowHeight, list.bottom));
             if (hr.bottom > hr.top) {
                 app.themeEditorHits.push_back({hr, TE_FONT_BASE + i});
             }

--- a/src/print.cpp
+++ b/src/print.cpp
@@ -395,7 +395,7 @@ void drawDocumentRange(App& app, ID2D1DeviceContext* dc,
         if (!bmp.bitmap) continue;
         if (!inRange(bmp.destRect.top, bmp.destRect.bottom)) continue;
         bool banded = applyBand(bmp.destRect.top, bmp.destRect.bottom);
-        dc->DrawBitmap(bmp.bitmap,
+        dc->DrawBitmap(bmp.bitmap.Get(),
             D2D1::RectF(bmp.destRect.left + dx, bmp.destRect.top + dy,
                         bmp.destRect.right + dx, bmp.destRect.bottom + dy),
             1.0f, D2D1_BITMAP_INTERPOLATION_MODE_LINEAR);

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -7,6 +7,7 @@
 #include "mermaid.h"
 #include "mermaid_ext.h"
 #include "math_render.h"
+#include "image_loader.h"
 
 #include <algorithm>
 #include <cctype>
@@ -14,6 +15,8 @@
 #include <functional>
 #include <limits>
 #include <map>
+#include <memory>
+#include <exception>
 #include <string_view>
 #include <filesystem>
 #include <fstream>
@@ -2393,62 +2396,54 @@ static void layoutList(App& app, const ElementPtr& elem, float& y, float indent,
 // via WM_APP_IMAGE_READY. Pixels are premultiplied BGRA.
 struct AsyncImageResult {
     std::string src;
-    UINT width = 0;
-    UINT height = 0;
-    std::vector<uint8_t> pixels;
+    DecodedImage image;
     bool ok = false;
 };
 
-// Runs on a worker thread: blocking download + WIC decode never touch the
-// UI thread, so dead links can't stall layout (#44). The worker owns its own
-// COM apartment and WIC factory; only plain pixel bytes cross the thread
-// boundary.
-static void asyncImageWorker(HWND hwnd, std::string src) {
-    CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-    auto* result = new AsyncImageResult();
-    result->src = src;
+static bool createDecodedBitmap(App& app, const DecodedImage& image,
+                                App::ImageEntry& entry) {
+    if (!app.renderTarget || image.pixels.empty()) return false;
+    const auto props = D2D1::BitmapProperties(
+        D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED),
+        image.dpiX, image.dpiY);
+    if (FAILED(app.renderTarget->CreateBitmap(D2D1::SizeU(image.width, image.height),
+            image.pixels.data(), image.width * 4, props, entry.bitmap.GetAddressOf())))
+        return false;
+    const auto size = entry.bitmap->GetSize();
+    entry.width = std::max(1, static_cast<int>(size.width));
+    entry.height = std::max(1, static_cast<int>(size.height));
+    entry.failed = false;
+    return true;
+}
 
-    wchar_t tempPath[MAX_PATH] = {};
-    std::wstring wideSrc = toWide(src);
-    if (SUCCEEDED(URLDownloadToCacheFileW(nullptr, wideSrc.c_str(), tempPath, MAX_PATH, 0, nullptr))) {
-        IWICImagingFactory* wic = nullptr;
-        if (SUCCEEDED(CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER,
-                                       IID_PPV_ARGS(&wic))) && wic) {
-            IWICBitmapDecoder* decoder = nullptr;
-            if (SUCCEEDED(wic->CreateDecoderFromFilename(tempPath, nullptr, GENERIC_READ,
-                                                         WICDecodeMetadataCacheOnDemand, &decoder)) && decoder) {
-                IWICBitmapFrameDecode* frame = nullptr;
-                if (SUCCEEDED(decoder->GetFrame(0, &frame)) && frame) {
-                    IWICFormatConverter* converter = nullptr;
-                    if (SUCCEEDED(wic->CreateFormatConverter(&converter)) && converter) {
-                        if (SUCCEEDED(converter->Initialize(frame, GUID_WICPixelFormat32bppPBGRA,
-                                WICBitmapDitherTypeNone, nullptr, 0.0, WICBitmapPaletteTypeCustom))) {
-                            UINT w = 0, h = 0;
-                            converter->GetSize(&w, &h);
-                            if (w > 0 && h > 0 && w < 16384 && h < 16384) {
-                                result->pixels.resize((size_t)w * h * 4);
-                                if (SUCCEEDED(converter->CopyPixels(nullptr, w * 4,
-                                        (UINT)result->pixels.size(), result->pixels.data()))) {
-                                    result->width = w;
-                                    result->height = h;
-                                    result->ok = true;
-                                }
-                            }
-                        }
-                        converter->Release();
-                    }
-                    frame->Release();
+// Only pixel bytes cross the thread boundary. The UI allocates the result
+// before launching so even download/decode allocation failures can complete
+// the pending cache entry without an exception terminating the process.
+static void asyncImageWorker(HWND hwnd, UINT maxDimension,
+                             std::unique_ptr<AsyncImageResult> result) {
+    const HRESULT apartment = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    try {
+        if (SUCCEEDED(apartment)) {
+            wchar_t tempPath[MAX_PATH] = {};
+            const std::wstring wideSrc = toWide(result->src);
+            if (SUCCEEDED(URLDownloadToCacheFileW(nullptr, wideSrc.c_str(), tempPath,
+                                                  MAX_PATH, 0, nullptr))) {
+                Microsoft::WRL::ComPtr<IWICImagingFactory> wic;
+                if (SUCCEEDED(CoCreateInstance(CLSID_WICImagingFactory, nullptr,
+                        CLSCTX_INPROC_SERVER, IID_PPV_ARGS(wic.GetAddressOf())))) {
+                    result->ok = SUCCEEDED(decodeImageFile(wic.Get(), tempPath,
+                                                          maxDimension, result->image));
                 }
-                decoder->Release();
             }
-            wic->Release();
         }
+    } catch (const std::exception&) {
+        result->ok = false;
     }
-
-    if (!PostMessageW(hwnd, WM_APP_IMAGE_READY, 0, (LPARAM)result)) {
-        delete result;  // window already gone
-    }
-    CoUninitialize();
+    if (SUCCEEDED(apartment)) CoUninitialize();
+    // Transfer ownership before posting: the UI can consume immediately.
+    auto* delivered = result.release();
+    if (!PostMessageW(hwnd, WM_APP_IMAGE_READY, 0, reinterpret_cast<LPARAM>(delivered)))
+        delete delivered;
 }
 
 // SVG images rasterize at 2x through the Direct2D SVG renderer
@@ -2579,7 +2574,7 @@ static bool loadSvgBitmap(App& app, const std::wstring& path,
         if (SUCCEEDED(app.renderTarget->CreateBitmapFromWicBitmap(
                 wicBitmap, &bp, &bitmap)) &&
             bitmap) {
-            entry.bitmap = bitmap;
+            entry.bitmap.Attach(bitmap);
             entry.width = (int)svgW;
             entry.height = (int)svgH;
             entry.failed = false;
@@ -2613,7 +2608,16 @@ static App::ImageEntry& getOrLoadImage(App& app, const std::string& src) {
         entry.failed = false;
         entry.pending = true;
         app.storeImageCacheEntry(src, std::move(entry));
-        std::thread(asyncImageWorker, app.hwnd, src).detach();
+        try {
+            auto result = std::make_unique<AsyncImageResult>();
+            result->src = src;
+            std::thread(asyncImageWorker, app.hwnd,
+                        app.renderTarget->GetMaximumBitmapSize(), std::move(result)).detach();
+        } catch (const std::exception&) {
+            auto& failed = app.imageCache.at(src);
+            failed.pending = false;
+            failed.failed = true;
+        }
         return app.imageCache[src];
     } else {
         // Resolve relative to the current file's directory. Both strings are
@@ -2641,55 +2645,10 @@ static App::ImageEntry& getOrLoadImage(App& app, const std::string& src) {
         }
     }
 
-    // Load via WIC
-    IWICBitmapDecoder* decoder = nullptr;
-    HRESULT hr = app.wicFactory->CreateDecoderFromFilename(widePath.c_str(), nullptr,
-        GENERIC_READ, WICDecodeMetadataCacheOnDemand, &decoder);
-    if (FAILED(hr) || !decoder) {
-        app.storeImageCacheEntry(src, std::move(entry));
-        return app.imageCache[src];
-    }
-
-    IWICBitmapFrameDecode* frame = nullptr;
-    hr = decoder->GetFrame(0, &frame);
-    if (FAILED(hr) || !frame) {
-        decoder->Release();
-        app.storeImageCacheEntry(src, std::move(entry));
-        return app.imageCache[src];
-    }
-
-    IWICFormatConverter* converter = nullptr;
-    hr = app.wicFactory->CreateFormatConverter(&converter);
-    if (FAILED(hr) || !converter) {
-        frame->Release();
-        decoder->Release();
-        app.storeImageCacheEntry(src, std::move(entry));
-        return app.imageCache[src];
-    }
-
-    hr = converter->Initialize(frame, GUID_WICPixelFormat32bppPBGRA,
-        WICBitmapDitherTypeNone, nullptr, 0.0, WICBitmapPaletteTypeCustom);
-    if (FAILED(hr)) {
-        converter->Release();
-        frame->Release();
-        decoder->Release();
-        app.storeImageCacheEntry(src, std::move(entry));
-        return app.imageCache[src];
-    }
-
-    ID2D1Bitmap* bitmap = nullptr;
-    hr = app.renderTarget->CreateBitmapFromWicBitmap(converter, nullptr, &bitmap);
-    converter->Release();
-    frame->Release();
-    decoder->Release();
-
-    if (SUCCEEDED(hr) && bitmap) {
-        D2D1_SIZE_F size = bitmap->GetSize();
-        entry.bitmap = bitmap;
-        entry.width = (int)size.width;
-        entry.height = (int)size.height;
-        entry.failed = false;
-    }
+    DecodedImage image;
+    if (SUCCEEDED(decodeImageFile(app.wicFactory, widePath.c_str(),
+                                 app.renderTarget->GetMaximumBitmapSize(), image)))
+        createDecodedBitmap(app, image, entry);
 
     app.storeImageCacheEntry(src, std::move(entry));
     return app.imageCache[src];
@@ -3351,32 +3310,23 @@ bool layoutDocumentContinue(App& app, int64_t budgetUs) {
     return done;
 }
 
+void discardAsyncImage(void* asyncResult) {
+    delete static_cast<AsyncImageResult*>(asyncResult);
+}
+
 void completeAsyncImage(App& app, void* asyncResult) {
-    auto* result = static_cast<AsyncImageResult*>(asyncResult);
+    std::unique_ptr<AsyncImageResult> result(static_cast<AsyncImageResult*>(asyncResult));
     if (!result) return;
+    // A document/cache reset can make an in-flight download irrelevant.
+    const auto pending = app.imageCache.find(result->src);
+    if (pending == app.imageCache.end() || !pending->second.pending) return;
 
     App::ImageEntry entry;
     entry.failed = true;
-    if (result->ok && app.renderTarget) {
-        D2D1_BITMAP_PROPERTIES props = D2D1::BitmapProperties(
-            D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED));
-        ID2D1Bitmap* bitmap = nullptr;
-        if (SUCCEEDED(app.renderTarget->CreateBitmap(
-                D2D1::SizeU(result->width, result->height),
-                result->pixels.data(), result->width * 4, props, &bitmap)) && bitmap) {
-            entry.bitmap = bitmap;
-            entry.width = (int)result->width;
-            entry.height = (int)result->height;
-            entry.failed = false;
-        }
-    }
-
+    if (result->ok) createDecodedBitmap(app, result->image, entry);
     app.storeImageCacheEntry(result->src, std::move(entry));
-    delete result;
 
-    // Reflow with the real image dimensions — but coalesced: several images
-    // finishing close together (the common case when a document loads) get
-    // one relayout on the timer instead of a full document layout each
+    // Coalesce several completions into one reflow.
     if (app.hwnd) SetTimer(app.hwnd, TIMER_IMAGE_REFLOW, 60, nullptr);
 }
 

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -3228,7 +3228,7 @@ bool layoutBegin(App& app) {
 
     if (!app.root) {
         app.contentHeight = 0;
-        app.contentWidth = app.width;
+        app.contentWidth = static_cast<float>(app.width);
         app.layoutComplete = true;
         return false;
     }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -93,8 +93,8 @@ void saveSettings(const Settings& settings) {
         // Open tabs from the last session, restored on the next plain launch
         file << "[Session]\n";
         file << "sessionActive=" << settings.sessionActive << "\n";
-        for (const auto& path : settings.sessionTabs) {
-            file << "tab=" << path << "\n";
+        for (const auto& tabPath : settings.sessionTabs) {
+            file << "tab=" << tabPath << "\n";
         }
     }
 
@@ -360,14 +360,14 @@ Settings loadSettings() {
                 try {
                     float y = std::stof(value.substr(0, sep));
                     float zoom = 0.0f;
-                    std::string path = value.substr(sep + 1);
-                    size_t sep2 = path.find('|');
-                    if (sep2 != std::string::npos && sep2 + 1 < path.size()) {
-                        zoom = std::stof(path.substr(0, sep2));
-                        path = path.substr(sep2 + 1);
+                    std::string documentPath = value.substr(sep + 1);
+                    size_t sep2 = documentPath.find('|');
+                    if (sep2 != std::string::npos && sep2 + 1 < documentPath.size()) {
+                        zoom = std::stof(documentPath.substr(0, sep2));
+                        documentPath = documentPath.substr(sep2 + 1);
                     }
-                    if (y >= 0.0f && !path.empty()) {
-                        settings.readingPositions.push_back({path, y, zoom});
+                    if (y >= 0.0f && !documentPath.empty()) {
+                        settings.readingPositions.push_back({documentPath, y, zoom});
                     }
                 } catch (...) {}
             }

--- a/tests/compiler-warning-cleanup-validation.md
+++ b/tests/compiler-warning-cleanup-validation.md
@@ -1,0 +1,50 @@
+# Compiler warning cleanup validation
+
+The cleanup removes unused locals and an unused internal block-layout argument,
+leaves unused callback parameters unnamed, gives shadowed locals distinct names,
+and makes existing character/pixel conversions explicit. Public function
+signatures and runtime behavior are preserved. `/W4` remains enabled; no warning
+suppression or compiler-policy changes were added.
+
+## Build and tests
+
+Validated locally on Windows with MSVC 14.44.35207:
+
+```powershell
+cmake --build build --config Release --clean-first --parallel 4
+ctest --test-dir build -C Release --output-on-failure
+```
+
+- Clean rebuild of all targets: **zero warning lines**, zero errors.
+- All **20 CTests passed**, including native input, theme, side-panel, font,
+  frontmatter, footnote, Markdown and Mermaid checks; total 5.24 seconds.
+- `git diff --check` passed. Original CRLF line endings were restored after
+  validation without changing the compiled source text.
+- Logs: `out/warning-cleanup/build.log` and `out/warning-cleanup/ctest.log`.
+- Remote CI has not been run. These changes are deliberately uncommitted for
+  maintainer review.
+
+## Markdown and export comparison
+
+`tests/fixtures/compiler-warning-cleanup.md` mixes configured flowchart labels,
+nested block diagrams and journey scores with frontmatter, H1-H6, tables,
+quotes, emphasis, lists, links, code, superscripts/subscripts, footnotes and
+LaTeX. The existing frontmatter-settings and markdown-regression-control
+fixtures are included as controls.
+
+```powershell
+./tests/render_warning_cleanup_fixtures.ps1 -Binary out/warning-cleanup/baseline/tinta.exe -Output out/warning-cleanup/before
+./tests/render_warning_cleanup_fixtures.ps1 -Output out/warning-cleanup/after
+```
+
+Paper and Midnight source themes produced **14 native PNG pages, six HTML
+files and six DOCX files**. Every PNG/HTML file is byte-identical before and
+after; every DOCX archive member has identical contents. The runner also checks
+that source documents remain unchanged and surrounding Markdown is exported.
+Generated files are under the ignored `out/warning-cleanup/` directory.
+
+All three Paper pages of the new fixture were visually inspected. The baseline
+already renders its uppercase inline HTML tags literally and emits a blank
+last print page; both behaviors are preserved by this cleanup. No new live UI
+session was performed; the existing native test suite covers normal/narrow
+windows, DPI scales and the affected interaction paths.

--- a/tests/file_path_tests.cpp
+++ b/tests/file_path_tests.cpp
@@ -41,7 +41,8 @@ void clickTabCopy(App& app) {
     // Copy file path follows the four close actions and their separator.
     int x = static_cast<int>(app.tabMenuX + 20);
     int y = static_cast<int>(app.tabMenuY + dpi(app, 6+4*30+9+15));
-    check(tabMenuItemAt(app, x, y) == 4, "tab Copy file path remains next to Reveal");
+    check(tabMenuItemAt(app, static_cast<float>(x), static_cast<float>(y)) == 4,
+          "tab Copy file path remains next to Reveal");
     check(tabMenuMouseDown(app, app.hwnd, x, y), "tab path action consumes its click");
     check(!app.showTabMenu, "tab Copy file path closes the menu");
 }
@@ -100,7 +101,7 @@ void titleMenuCases(bool testClipboard) {
                         }
                         app.tabs.resize(1);  // last companion closed
                         renderStrip(app);
-                        int x = (int)dpi(app, edit ? 60 : 48);
+                        int x = (int)dpi(app, edit ? 60.0f : 48.0f);
                         int y = (int)dpi(app, 20);
                         check(!tabStripVisible(app) && tabContextMenuIndexAt(app, (float)x, (float)y) == 0,
                               "the lone title has a tab context target after closing a companion");

--- a/tests/fixtures/compiler-warning-cleanup.md
+++ b/tests/fixtures/compiler-warning-cleanup.md
@@ -1,0 +1,74 @@
+---
+title: Compiler warning cleanup
+tags: [regression, layout, diagrams, math]
+created: "2026-09-11T00:00:00Z"
+---
+
+# Mixed Markdown control
+
+This **bold** paragraph combines *emphasis*, `inline code`, ==highlighting==,
+x^2^, H~2~O and inline math $a^2 + b^2 = c^2$ with a footnote.[^note]
+
+> A quote containing <STRONG>uppercase HTML</STRONG>, <EM>emphasis</EM>,
+> and an <A HREF="https://tinta.cc">uppercase link tag</A>.
+
+## Table and source
+
+| Item | Example | Result |
+| --- | --- | --- |
+| Script | x^2^ and H~2~O | Keep the baseline |
+| Math | $\frac{a}{b}$ | Keep cell height |
+| Text | **bold** and `code` | Keep formatting |
+
+```sql
+SELECT title, updated FROM documents WHERE active = 1;
+```
+
+- Preserve list indentation and [links](https://tinta.cc).
+- Preserve **emphasis** beside $E=mc^2$.
+
+### Configured flowchart labels
+
+```mermaid
+flowchart LR
+  Source@{ shape: rect, label: "Quoted; input" }
+  Source --> Save["Save & keep"]
+```
+
+### Nested block layout
+
+```mermaid
+block-beta
+  columns 2
+  block:group:2
+    A["First"] B["Second"]
+  end
+  C["Third"] D["Fourth"]
+  A --> C
+```
+
+### Journey score lane
+
+```mermaid
+journey
+  title Review a document
+  section Draft
+    Read the source: 3: Reader
+    Check the preview: 5: Reader, Reviewer
+  section Finish
+    Save the result: 7: Reviewer
+```
+
+#### Fourth heading
+
+$$
+\begin{pmatrix}a & b\\c & d\end{pmatrix}
+$$
+
+##### Fifth heading
+
+###### Sixth heading
+
+All six levels should remain visible in Contents.
+
+[^note]: A footnote with **bold text**, `code`, and $x^2$.

--- a/tests/fixtures/image-cache-large.md
+++ b/tests/fixtures/image-cache-large.md
@@ -1,0 +1,47 @@
+# Large images and cache eviction
+
+This regression document combines **bold**, *emphasis*, a [link](https://example.com),
+`inline code` and math $a^2+b^2=c^2$ around images.
+
+![Small PNG](image-cache-assets/small.png)
+
+![Large JPEG](image-cache-assets/large.jpg)
+
+## Images inside a table
+
+| Preview | Description |
+| --- | --- |
+| ![Second large JPEG](image-cache-assets/large-second.jpg) | Table measurement must keep images alive. |
+| ![Small PNG repeated](image-cache-assets/small.png) | Reusing a source after eviction must remain safe. |
+
+> A quote with **formatting**, $x+1$, and an image:
+>
+> ![Transparent PNG](image-cache-assets/alpha.png)
+
+## Resolution and failure cases
+
+![High DPI PNG](image-cache-assets/dpi.png)
+
+![Wide panorama](image-cache-assets/wide.png)
+
+![Broken image placeholder](image-cache-assets/broken.jpg)
+
+![Oversized image placeholder](image-cache-assets/oversized.bmp)
+
+![Missing image placeholder](image-cache-assets/missing.png)
+
+- A list after all images.
+- The original files must remain unchanged.
+
+```cpp
+// Code highlighting must survive image loading.
+const auto pixels = width * height;
+```
+
+$$
+\int_0^1 x^2\,dx = \frac{1}{3}
+$$
+
+## Final heading
+
+All surrounding content remains visible and searchable.

--- a/tests/image-cache-validation.md
+++ b/tests/image-cache-validation.md
@@ -1,0 +1,99 @@
+# Issue #220: image lifetime and decoding validation
+
+Validated on Windows on 2026-09-12, with MSVC 14.44.35207, against
+[issue #220](https://github.com/oipoistar/tinta/issues/220) reported by @glance02.
+Validation includes the preceding compiler-warning cleanup.
+
+## Fix
+
+- Cache entries and document layout each own a COM reference to their bitmap.
+  Eviction, replacement, table-measurement rollback, layout copies, clearing the
+  cache, and opening an evicted image in the lightbox no longer invalidate a
+  bitmap still needed by a drawing. Render-target recreation clears the old
+  layout and lightbox before loading images on the replacement target.
+- The cache counts allocated pixels instead of DPI-adjusted display dimensions.
+- Local and downloaded raster images use the same WIC decoder. It scales before
+  allocating the premultiplied BGRA buffer, preserves intrinsic display size,
+  and respects the render target's bitmap size limit. The display copy is at
+  most 16,777,216 pixels (64 MiB), with neither dimension above 8,192 pixels.
+- Sources above 100,000,000 pixels or 65,535 pixels on either axis are rejected
+  before pixel decoding. Bad files, WIC failures and pixel allocation failures
+  return to the existing alt-text placeholder. Worker startup/decode exceptions
+  cannot escape the remote-image worker.
+- HTML and DOCX still embed the original image files. SVG rasterization retains
+  its existing behavior, with the same corrected bitmap ownership/accounting.
+
+The 64 MiB LRU budget bounds the cache, not the whole document: displayed images
+retain references until their layout is released. Large raster images lose some
+zoom detail in the bounded display copy. WIC codecs can also use internal working
+memory beyond the output pixel buffer; the source-dimension guard bounds input
+size rather than promising a strict whole-process memory ceiling.
+
+WIC scaling reference: [Microsoft's bitmap-source scaling example](https://learn.microsoft.com/en-us/windows/win32/wic/-wic-bitmapsources-howto-scale).
+
+## Reproduction and automated checks
+
+The published v3.7.0 binary crashed with `0xC0000005` in `d2d1.dll` when a
+6000 x 4000 JPEG appeared alongside a small image, in either order. A flat JPEG
+at the same dimensions also crashed despite being only 375,629 bytes. The noisy
+JPEG is 11,354,106 bytes. Each JPEG expands to 96,000,000 BGRA bytes without
+downsampling. Single-image controls succeeded. Original reproduction artifacts
+are retained under `out/issue-220/`.
+
+```powershell
+cmake --build build --config Release --parallel 4
+ctest --test-dir build -C Release --output-on-failure
+python tests/validate_large_images.py
+```
+
+- All application/test targets built with zero compiler warnings and errors.
+- **21/21 CTests passed**, including the new `image_cache_and_decode` test.
+- Native tests explicitly force both byte-budget and entry-count eviction,
+  replacement, layout rollback/copy, cache release, lightbox ownership and
+  render-target recreation. They check oversized/corrupt/missing data, alpha
+  premultiplication, DPI accounting, panorama sizing and integer-overflow guards.
+- Mixed layout runs at widths 1050 and 650, themes Paper and Midnight, scales 1
+  and 1.5, using both incremental and complete layout. Images in a table and
+  quote, final headings, code blocks, math and failure placeholders survive.
+- Seven generated image-order/failure cases all render to native print pages;
+  the previously crashing cases finish in 0.25–0.44 seconds on this machine.
+- The mixed document produces three native pages, HTML, DOCX and PDF. HTML and
+  DOCX are checked for byte-for-byte preservation of the original JPEG/PNG
+  assets; source Markdown and images are unchanged after all exports.
+- A localhost HTTP server exercises real asynchronous download, decoding,
+  completion, failure placeholders and relayout with the 11 MB JPEG.
+- The small-image control page is byte-identical to published v3.7.0 when both
+  binaries use the same isolated settings.
+
+Native CTest generates its own assets with WIC and needs no Python packages.
+The broader validation script requires Pillow and NumPy and generates all
+images under ignored `out/issue-220/fixed/`. It copies the runnable fixture from
+`tests/fixtures/image-cache-large.md` beside those assets. No large images need
+to be checked into Git. Executables use isolated portable settings and child
+crash-dump directories.
+
+## Visual checks and review files
+
+Computer Use verified the real app in Paper at 1050 x 900 and Midnight at
+650 x 900: inline images, large-image lightbox and Escape dismissal, scrolling,
+the narrow table containing two images, quote transparency, high-DPI sizing,
+failure placeholders, highlighted code, math and the final paragraph. Native
+print pages were also visually inspected. The file-dialog helper initially
+failed to target its filename field, so the fixture was opened through an
+isolated saved session instead.
+
+- Ready-to-open fixture: `out/issue-220/fixed/image-cache-large.md`
+- Structured results: `out/issue-220/fixed/results.json`
+- Build log: `out/issue-220/build-final.log`
+- CTest log: `out/issue-220/ctest-final.log`
+- Export/download log: `out/issue-220/validation.log`
+- Unposted reporter reply: `out/issue-220/reply-draft.md`
+- Review executables refreshed: `build-meta/tinta.exe` and
+  `build-meta/Release/tinta.exe`, identical to `build/Release/tinta.exe`.
+
+Validated executable: 2,543,616 bytes, SHA-256
+`A4FB56784C733E35D09BF3C22E1E860568D30C59F01AEEB5F8E7B1F1606CB5C7`.
+
+The reporter's original JPEG was not attached, so its exact case remains
+unverified. The independently reproduced cache lifetime crash is fixed; a
+forced whole-process out-of-memory condition was not tested.

--- a/tests/image_tests.cpp
+++ b/tests/image_tests.cpp
@@ -1,0 +1,243 @@
+#include "d2d_init.h"
+#include "image_loader.h"
+#include "overlays.h"
+#include "print.h"
+#include "render.h"
+
+#include <filesystem>
+#include <climits>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+namespace {
+using Microsoft::WRL::ComPtr;
+int failures = 0;
+void check(bool value, const char* message) {
+    if (!value) { std::cerr << "FAIL: " << message << '\n'; ++failures; }
+}
+
+bool writeImage(App& app, const wchar_t* path, UINT width, UINT height,
+                bool jpeg = false, double dpiValue = 96.0, bool alpha = false) {
+    ComPtr<IWICStream> stream;
+    ComPtr<IWICBitmapEncoder> encoder;
+    ComPtr<IWICBitmapFrameEncode> frame;
+    if (FAILED(app.wicFactory->CreateStream(stream.GetAddressOf())) ||
+        FAILED(stream->InitializeFromFilename(path, GENERIC_WRITE)) ||
+        FAILED(app.wicFactory->CreateEncoder(jpeg ? GUID_ContainerFormatJpeg : GUID_ContainerFormatPng,
+                                             nullptr, encoder.GetAddressOf())) ||
+        FAILED(encoder->Initialize(stream.Get(), WICBitmapEncoderNoCache)) ||
+        FAILED(encoder->CreateNewFrame(frame.GetAddressOf(), nullptr)) ||
+        FAILED(frame->Initialize(nullptr)) || FAILED(frame->SetSize(width, height)) ||
+        FAILED(frame->SetResolution(dpiValue, dpiValue))) return false;
+    WICPixelFormatGUID format = alpha ? GUID_WICPixelFormat32bppBGRA : GUID_WICPixelFormat24bppBGR;
+    const auto requested = format;
+    if (FAILED(frame->SetPixelFormat(&format)) || format != requested) return false;
+    const UINT channels = alpha ? 4 : 3;
+    std::vector<BYTE> row(static_cast<size_t>(width) * channels);
+    for (UINT x = 0; x < width; ++x) {
+        row[x * channels] = 100;
+        row[x * channels + 1] = 50;
+        row[x * channels + 2] = 20;
+        if (alpha) row[x * channels + 3] = 128;
+    }
+    for (UINT y = 0; y < height; ++y)
+        if (FAILED(frame->WritePixels(1, width * channels, static_cast<UINT>(row.size()), row.data())))
+            return false;
+    return SUCCEEDED(frame->Commit()) && SUCCEEDED(encoder->Commit());
+}
+
+void generateAssets(App& app) {
+    std::filesystem::create_directories("image-cache-assets");
+    check(writeImage(app, L"image-cache-assets/small.png", 256, 128), "write small PNG");
+    check(writeImage(app, L"image-cache-assets/large.jpg", 6000, 4000, true), "write large JPEG");
+    std::filesystem::copy_file("image-cache-assets/large.jpg", "image-cache-assets/large-second.jpg",
+                              std::filesystem::copy_options::overwrite_existing);
+    check(writeImage(app, L"image-cache-assets/alpha.png", 128, 64, false, 96, true), "write transparent PNG");
+    check(writeImage(app, L"image-cache-assets/dpi.png", 300, 150, false, 300), "write high-DPI PNG");
+    check(writeImage(app, L"image-cache-assets/wide.png", 12000, 12), "write panorama");
+    std::ofstream("image-cache-assets/broken.jpg", std::ios::binary) << "not an image";
+    // A tiny BMP header advertising 400 MP: reject before any pixel allocation.
+    BITMAPFILEHEADER fileHeader{};
+    fileHeader.bfType = 0x4d42;
+    fileHeader.bfOffBits = sizeof(fileHeader) + sizeof(BITMAPINFOHEADER);
+    fileHeader.bfSize = fileHeader.bfOffBits;
+    BITMAPINFOHEADER info{};
+    info.biSize = sizeof(info); info.biWidth = info.biHeight = 20000;
+    info.biPlanes = 1; info.biBitCount = 24;
+    std::ofstream oversized("image-cache-assets/oversized.bmp", std::ios::binary);
+    oversized.write(reinterpret_cast<const char*>(&fileHeader), sizeof(fileHeader));
+    oversized.write(reinterpret_cast<const char*>(&info), sizeof(info));
+    std::filesystem::copy_file(TINTA_IMAGE_FIXTURE, "image-cache-large.md",
+                              std::filesystem::copy_options::overwrite_existing);
+}
+
+void decoding(App& app) {
+    DecodedImage decoded;
+    check(SUCCEEDED(decodeImageFile(app.wicFactory, L"image-cache-assets/large.jpg", 8192, decoded)),
+          "large JPEG decodes");
+    check(decoded.width < 6000 && decoded.height < 4000 &&
+          decoded.pixels.size() <= IMAGE_DECODE_MAX_PIXELS * 4,
+          "large JPEG uses a bounded display buffer");
+    check(std::abs(static_cast<float>(decoded.width) * 96.0f / decoded.dpiX - 6000.0f) < 1.0f &&
+          std::abs(static_cast<float>(decoded.height) * 96.0f / decoded.dpiY - 4000.0f) < 1.0f,
+          "downsampling preserves the intrinsic size");
+    check(SUCCEEDED(decodeImageFile(app.wicFactory, L"image-cache-assets/wide.png", 1024, decoded)) &&
+          decoded.width == 1024 && decoded.height == 1, "panorama respects device texture limit");
+    check(SUCCEEDED(decodeImageFile(app.wicFactory, L"image-cache-assets/alpha.png", 8192, decoded)) &&
+          decoded.pixels[0] == 50 && decoded.pixels[1] == 25 && decoded.pixels[2] == 10 &&
+          decoded.pixels[3] == 128, "PNG alpha is premultiplied correctly");
+    for (const auto* path : {L"image-cache-assets/broken.jpg", L"image-cache-assets/missing.png",
+                              L"image-cache-assets/oversized.bmp"}) {
+        check(FAILED(decodeImageFile(app.wicFactory, path, 8192, decoded)) &&
+              decoded.pixels.empty() && decoded.width == 0, "bad images leave no partial result");
+    }
+    check(boundedImageSize(0, 10, 8192).width == 0, "zero dimensions rejected");
+    const auto extreme = boundedImageSize(UINT_MAX, UINT_MAX, 8192);
+    check(static_cast<uint64_t>(extreme.width) * extreme.height <= IMAGE_DECODE_MAX_PIXELS,
+          "size calculation cannot overflow for extreme dimensions");
+}
+
+App::ImageEntry bitmapEntry(App& app, UINT width, UINT height, float dpiValue = 96.0f) {
+    App::ImageEntry entry;
+    const auto props = D2D1::BitmapProperties(
+        D2D1::PixelFormat(DXGI_FORMAT_B8G8R8A8_UNORM, D2D1_ALPHA_MODE_PREMULTIPLIED),
+        dpiValue, dpiValue);
+    check(SUCCEEDED(app.renderTarget->CreateBitmap(D2D1::SizeU(width, height), nullptr, 0,
+                    props, entry.bitmap.GetAddressOf())), "native test bitmap created");
+    entry.width = static_cast<int>(static_cast<float>(width) * 96.0f / dpiValue);
+    entry.height = static_cast<int>(static_cast<float>(height) * 96.0f / dpiValue);
+    return entry;
+}
+
+void drawImages(App& app) {
+    app.renderTarget->BeginDraw();
+    for (const auto& bitmap : app.layoutBitmaps) {
+        check(bitmap.bitmap && bitmap.bitmap->GetPixelSize().width > 0, "layout bitmap is alive");
+        app.renderTarget->DrawBitmap(bitmap.bitmap.Get(), bitmap.destRect);
+    }
+    check(SUCCEEDED(app.renderTarget->EndDraw()), "native image drawing succeeds after eviction");
+}
+
+void ownership(App& app) {
+    app.clearLayoutCache();
+    app.releaseImageCache();
+    app.storeImageCacheEntry("first", bitmapEntry(app, 300, 150, 300));
+    check(app.imageCacheBytes == 300 * 150 * 4, "cache counts pixels rather than DPI-adjusted size");
+    app.layoutBitmaps.push_back({app.imageCache.at("first").bitmap, D2D1::RectF(0, 0, 96, 48)});
+    // 64 MiB plus the earlier image must evict the earlier cache entry.
+    app.storeImageCacheEntry("budget", bitmapEntry(app, 4096, 4096));
+    check(!app.imageCache.count("first"), "byte budget eviction actually occurs");
+    drawImages(app);
+    app.releaseImageCache();
+    drawImages(app);
+
+    app.storeImageCacheEntry("first", bitmapEntry(app, 8, 8));
+    app.layoutBitmaps.push_back({app.imageCache.at("first").bitmap, D2D1::RectF(0, 50, 8, 58)});
+    auto filler = bitmapEntry(app, 1, 1);
+    for (size_t i = 0; i < App::IMAGE_CACHE_MAX_ENTRIES; ++i)
+        app.storeImageCacheEntry(std::to_string(i), filler);
+    check(!app.imageCache.count("first"), "entry-count eviction actually occurs");
+    drawImages(app);
+
+    app.storeImageCacheEntry("replacement", bitmapEntry(app, 12, 12));
+    app.layoutBitmaps.push_back({app.imageCache.at("replacement").bitmap, D2D1::RectF(0, 60, 12, 72)});
+    app.storeImageCacheEntry("replacement", bitmapEntry(app, 16, 16));
+    auto savedLayout = app.layoutBitmaps;
+    app.layoutBitmaps.resize(1);  // table measurement rollback
+    app.releaseImageCache();
+    app.layoutBitmaps = std::move(savedLayout);
+    drawImages(app);
+    openLightbox(app, app.layoutBitmaps.back().bitmap.Get());
+    app.clearLayoutCache();
+    check(app.lightboxBitmap && app.lightboxBitmap->GetPixelSize().width == 12,
+          "lightbox owns its image after cache and layout reset");
+    closeLightbox(app);
+    check(createRenderTarget(app) && app.layoutBitmaps.empty() && app.imageCache.empty() &&
+          !app.showLightbox && app.layoutDirty, "target recreation invalidates old image drawings");
+}
+
+void mixedLayout(App& app) {
+    std::ifstream file("image-cache-large.md", std::ios::binary);
+    const std::string source((std::istreambuf_iterator<char>(file)), {});
+    app.currentFile = std::filesystem::absolute("image-cache-large.md").u8string();
+    app.root = app.parser.parse(source).root;
+    app.readingWidthPct = 100;
+    for (int theme : {0, 5}) {
+        applyTheme(app, theme);
+        for (int width : {1050, 650}) {
+            app.width = width;
+            app.height = 900;
+            for (float scale : {1.0f, 1.5f}) {
+                app.contentScale = scale;
+                updateTextFormats(app);
+                layoutDocumentViewportFirst(app);
+                drawImages(app);
+                ensureLayoutComplete(app);
+                check(app.layoutBitmaps.size() == 7, "all valid mixed images survive measurement and relayout");
+                check(app.tableRects.size() == 1 && app.codeBlocks.size() == 1 &&
+                      app.docText.find(L"All surrounding content") != std::wstring::npos,
+                      "surrounding headings, table, code and final paragraph survive");
+                check(app.docText.find(L"Broken image placeholder") != std::wstring::npos &&
+                      app.docText.find(L"Oversized image placeholder") != std::wstring::npos,
+                      "invalid images render their alt text");
+                drawImages(app);
+            }
+        }
+    }
+    check(printDebugPages(app, L"pages") > 0, "mixed document prints after cache eviction");
+    openLightbox(app, app.layoutBitmaps.front().bitmap.Get());
+    check(createRenderTarget(app) && !app.lightboxBitmap && !app.showLightbox &&
+          app.layoutBitmaps.empty(), "device reset clears an open lightbox and live layout");
+    ensureLayoutComplete(app);
+    check(app.layoutBitmaps.size() == 7, "images reload after target recreation");
+    drawImages(app);
+}
+
+void remoteImages(App& app, const char* base) {
+    app.clearLayoutCache();
+    app.releaseImageCache();
+    const std::string url = std::string(base) + "/large.jpg";
+    const std::string broken = std::string(base) + "/broken.jpg";
+    const std::string source = "# Remote images\n\n![Remote](" + url + ")\n\n![Broken](" + broken + ")\n";
+    app.root = app.parser.parse(source).root;
+    layoutDocument(app);
+    check(app.imageCache.at(url).pending, "remote image starts pending");
+    const auto deadline = GetTickCount64() + 15000;
+    while (GetTickCount64() < deadline && (app.imageCache.at(url).pending || app.imageCache.at(broken).pending)) {
+        MSG message{};
+        while (PeekMessageW(&message, app.hwnd, WM_APP_IMAGE_READY, WM_APP_IMAGE_READY, PM_REMOVE))
+            completeAsyncImage(app, reinterpret_cast<void*>(message.lParam));
+        MsgWaitForMultipleObjects(0, nullptr, FALSE, 10, QS_POSTMESSAGE);
+    }
+    check(!app.imageCache.at(url).pending && !app.imageCache.at(url).failed &&
+          app.imageCache.at(url).bytes <= IMAGE_DECODE_MAX_PIXELS * 4,
+          "downloaded large image completes with bounded pixels");
+    check(!app.imageCache.at(broken).pending && app.imageCache.at(broken).failed,
+          "downloaded corrupt image completes as a failure");
+    layoutDocument(app);
+    check(app.layoutBitmaps.size() == 1, "remote result relayout displays image");
+    app.releaseImageCache();
+    drawImages(app);
+}
+}
+
+int runImageTests(const char* remoteBase) {
+    SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    auto state = std::make_unique<App>();
+    App& app = *state;
+    app.hwnd = CreateWindowExW(0, L"STATIC", L"Image regression tests", WS_POPUP,
+        0, 0, 1050, 900, nullptr, nullptr, nullptr, nullptr);
+    if (!app.hwnd || !initD2D(app) || !createRenderTarget(app)) return 2;
+    generateAssets(app);
+    decoding(app);
+    ownership(app);
+    mixedLayout(app);
+    if (remoteBase) remoteImages(app, remoteBase);
+    DestroyWindow(app.hwnd);
+    app.hwnd = nullptr;
+    state.reset();
+    CoUninitialize();
+    std::cout << "Images: " << failures << " failures\n";
+    return failures ? 1 : 0;
+}

--- a/tests/input_tests.cpp
+++ b/tests/input_tests.cpp
@@ -156,9 +156,12 @@ void settingsDismissal() {
 int runTabDropTests();
 int runSuperscriptTests();
 int runSidePanelTests();
+int runImageTests(const char* remoteBase);
 int runTabDropLaunchProbe();
 
 int main(int argc, char** argv) {
+    if (argc >= 2 && std::string(argv[1]) == "--image-tests")
+        return runImageTests(argc > 2 ? argv[2] : nullptr);
     if (argc == 2 && std::string(argv[1]) == "--sidepanel-tests") return runSidePanelTests();
     if (argc == 2 && std::string(argv[1]) == "--superscript-tests") return runSuperscriptTests();
     if (argc == 2 && std::string(argv[1]) == "--tab-drop-tests") return runTabDropTests();

--- a/tests/render_warning_cleanup_fixtures.ps1
+++ b/tests/render_warning_cleanup_fixtures.ps1
@@ -1,0 +1,54 @@
+param(
+    [string]$Binary = 'build/Release/tinta.exe',
+    [string]$Output = 'out/warning-cleanup/after'
+)
+$ErrorActionPreference = 'Stop'
+$taskRepo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$taskBinary = if ([IO.Path]::IsPathRooted($Binary)) { $Binary } else { Join-Path $taskRepo $Binary }
+$taskOutput = Join-Path $taskRepo $Output
+foreach ($taskTheme in @(0, 5)) {
+    $taskThemeOutput = Join-Path $taskOutput "theme-$taskTheme"
+    $taskRunner = Join-Path $taskThemeOutput 'runner'
+    New-Item -ItemType Directory -Force $taskRunner | Out-Null
+    $taskExe = Join-Path $taskRunner 'tinta.exe'
+    Copy-Item -LiteralPath $taskBinary -Destination $taskExe -Force
+    @"
+[Settings]
+themeIndex=$taskTheme
+followSystemTheme=0
+hasAskedFileAssociation=1
+openInTabs=0
+checkUpdates=0
+language=en
+"@ | Set-Content -LiteralPath (Join-Path $taskRunner 'settings.ini')
+    foreach ($taskName in @('compiler-warning-cleanup', 'frontmatter-settings', 'markdown-regression-control')) {
+        $taskSource = Join-Path $PSScriptRoot "fixtures/$taskName.md"
+        $taskBefore = (Get-FileHash -LiteralPath $taskSource).Hash
+        $taskDest = Join-Path $taskThemeOutput $taskName
+        New-Item -ItemType Directory -Force $taskDest | Out-Null
+        foreach ($taskMode in @('printpages', 'exporthtml', 'exportdocx')) {
+            $taskTarget = Join-Path $taskDest $(switch ($taskMode) {
+                'printpages' { 'pages' }
+                'exporthtml' { 'document.html' }
+                'exportdocx' { 'document.docx' }
+            })
+            $taskProcess = Start-Process -FilePath $taskExe -ArgumentList @(('"'+$taskSource+'"'), "--$taskMode", ('"'+$taskTarget+'"')) -WindowStyle Hidden -PassThru
+            if (!$taskProcess.WaitForExit(30000)) {
+                Stop-Process -Id $taskProcess.Id -Force
+                throw "$taskName $taskMode timed out"
+            }
+            if ($taskProcess.ExitCode -ne 0 -or !(Test-Path -LiteralPath $taskTarget)) { throw "$taskName $taskMode failed" }
+        }
+        $taskHtml = Get-Content -LiteralPath "$taskDest/document.html" -Raw -Encoding UTF8
+        foreach ($taskElement in @('<blockquote', '<table>', '<h1', '<pre', '<strong>', '<em>')) {
+            if (!$taskHtml.Contains($taskElement)) { throw "$taskName lost $taskElement in HTML export" }
+        }
+        if ($taskName -eq 'compiler-warning-cleanup' -and !$taskHtml.Contains('<svg')) {
+            throw 'Mixed warning-cleanup fixture lost its math/diagrams'
+        }
+        if ((Get-FileHash -LiteralPath $taskSource).Hash -ne $taskBefore) { throw "$taskName source changed" }
+        $taskPages = @(Get-ChildItem -LiteralPath "$taskDest/pages" -Filter 'page-*.png')
+        if (!$taskPages.Count) { throw "$taskName produced no print pages" }
+        "theme $taskTheme, $taskName : $($taskPages.Count) native pages, HTML and DOCX"
+    }
+}

--- a/tests/run_image_tests.cmake
+++ b/tests/run_image_tests.cmake
@@ -1,0 +1,11 @@
+if(NOT DEFINED TEST_BINARY OR NOT DEFINED TEST_DIR)
+    message(FATAL_ERROR "TEST_BINARY and TEST_DIR are required")
+endif()
+file(MAKE_DIRECTORY "${TEST_DIR}")
+configure_file("${TEST_BINARY}" "${TEST_DIR}/input_tests.exe" COPYONLY)
+file(WRITE "${TEST_DIR}/settings.ini" "; Isolated image regression settings\n")
+execute_process(COMMAND "${TEST_DIR}/input_tests.exe" --image-tests
+    WORKING_DIRECTORY "${TEST_DIR}" RESULT_VARIABLE result TIMEOUT 90)
+if(NOT result EQUAL 0)
+    message(FATAL_ERROR "Native image tests failed: ${result}")
+endif()

--- a/tests/sidepanel_tests.cpp
+++ b/tests/sidepanel_tests.cpp
@@ -96,7 +96,7 @@ void resizeGesture(App& app, SidePanel panel, bool onLeft, bool both, float scal
     const std::string path = app.currentFile;
     const float start = sidePanelResizeEdge(app, panel);
     const float y = dpi(app, 300);
-    const float direction = panel == SidePanel::Contents && !onLeft ? -1 : 1;
+    const float direction = panel == SidePanel::Contents && !onLeft ? -1.0f : 1.0f;
     const float target = start + direction * dpi(app, 100);
     handleMouseDown(app, app.hwnd, 0, MAKELPARAM((int)start, (int)y));
     check(app.panelResize.panel == panel && GetCapture() == app.hwnd, "panel edge captures the drag");
@@ -268,7 +268,7 @@ void scrollbarAcrossPanels(App& app) {
                     for (float x : {sidePanelResizeEdge(app, SidePanel::Contents), tocCenter,
                                     browserCenter, -dpi(app, 50), app.width + dpi(app, 50), dpi(app, 20)}) {
                         const float before = horizontal ? app.scrollX : app.scrollY;
-                        const int y = (int)dpi(app, 250 + 40 * step++);
+                        const int y = (int)dpi(app, static_cast<float>(250 + 40 * step++));
                         handleMouseMove(app, app.hwnd, MAKELPARAM((int)x, y));
                         const float after = horizontal ? app.scrollX : app.scrollY;
                         if (!horizontal || (x > previousX && before < app.contentWidth - viewport - 1))

--- a/tests/validate_large_images.py
+++ b/tests/validate_large_images.py
@@ -1,0 +1,155 @@
+"""Generate #220 fixtures and exercise native rendering, exports and HTTP loading.
+
+Run from any directory with Python + Pillow + NumPy after building Release
+tinta and input_tests. All generated assets/results stay in ignored out/.
+"""
+from pathlib import Path
+import argparse
+import base64
+import ctypes
+import functools
+import hashlib
+import http.server
+import json
+import os
+import re
+import shutil
+import struct
+import subprocess
+import threading
+import time
+import zipfile
+
+import numpy as np
+from PIL import Image
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--binary', type=Path, default=REPO / 'build/Release/tinta.exe')
+    parser.add_argument('--input-tests', type=Path, default=REPO / 'build/Release/input_tests.exe')
+    parser.add_argument('--output', type=Path, default=REPO / 'out/issue-220/fixed')
+    args = parser.parse_args()
+    output = args.output.resolve()
+    assets = output / 'image-cache-assets'
+    assets.mkdir(parents=True, exist_ok=True)
+    Image.new('RGB', (256, 128), (45, 130, 190)).save(assets / 'small.png')
+    Image.new('RGB', (256, 128), (45, 130, 190)).save(assets / 'small.jpg', quality=90)
+    Image.new('RGB', (6000, 4000), (45, 130, 190)).save(assets / 'large-flat.jpg', quality=90)
+    pixels = np.random.default_rng(220).integers(0, 256, (4000, 6000, 3), dtype=np.uint8)
+    Image.fromarray(pixels).save(assets / 'large.jpg', quality=60)
+    del pixels
+    shutil.copy2(assets / 'large.jpg', assets / 'large-second.jpg')
+    Image.new('RGBA', (128, 64), (20, 50, 100, 128)).save(assets / 'alpha.png')
+    Image.new('RGB', (300, 150), (190, 130, 45)).save(assets / 'dpi.png', dpi=(300, 300))
+    Image.new('RGB', (12000, 12), (45, 130, 190)).save(assets / 'wide.png')
+    (assets / 'small.svg').write_text('<svg xmlns="http://www.w3.org/2000/svg" width="128" height="64">'
+        '<rect width="128" height="64" fill="#2d82be"/></svg>', encoding='utf-8')
+    (assets / 'broken.jpg').write_bytes(b'not an image')
+    (assets / 'truncated.jpg').write_bytes((assets / 'large.jpg').read_bytes()[:200])
+    (assets / 'oversized.bmp').write_bytes(
+        struct.pack('<2sIHHI', b'BM', 54, 0, 0, 54) +
+        struct.pack('<IiiHHIIiiII', 40, 20000, 20000, 1, 24, 0, 0, 0, 0, 0, 0))
+    fixture = output / 'image-cache-large.md'
+    shutil.copy2(REPO / 'tests/fixtures/image-cache-large.md', fixture)
+
+    runner = output / 'runner'
+    runner.mkdir(exist_ok=True)
+    executable = runner / 'tinta.exe'
+    shutil.copy2(args.binary.resolve(), executable)
+    (runner / 'settings.ini').write_text(
+        '[Settings]\nthemeIndex=0\nfollowSystemTheme=0\ncheckUpdates=0\n'
+        'hasAskedFileAssociation=1\nopenInTabs=0\nlanguage=en\n', encoding='utf-8')
+    ctypes.windll.kernel32.SetErrorMode(3)
+    startup = subprocess.STARTUPINFO()
+    startup.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+    startup.wShowWindow = 0
+    results = []
+
+    def run(label, command, cwd=None):
+        target = output / label
+        target.mkdir(exist_ok=True)
+        started = time.monotonic()
+        process = subprocess.run([str(part) for part in command], cwd=cwd,
+            env=dict(os.environ, LOCALAPPDATA=str(target)), startupinfo=startup,
+            capture_output=True, timeout=60)
+        row = dict(case=label, exit=process.returncode,
+                   seconds=round(time.monotonic() - started, 2))
+        results.append(row)
+        print(json.dumps(row), flush=True)
+        assert process.returncode == 0, process.stdout.decode(errors='replace') + process.stderr.decode(errors='replace')
+        assert not (target / 'Tinta/crash.dmp').exists()
+        return target
+
+    cases = {
+        'small-only': ['small.jpg'],
+        'large-only': ['large.jpg'],
+        'small-then-large': ['small.jpg', 'large.jpg'],
+        'large-then-small': ['large.jpg', 'small.jpg'],
+        'small-then-large-flat': ['small.jpg', 'large-flat.jpg'],
+        'truncated-then-small': ['truncated.jpg', 'small.jpg'],
+        'svg-then-large': ['small.svg', 'large.jpg'],
+    }
+    for name, images in cases.items():
+        source = output / (name + '.md')
+        source.write_text('# Image loading control\n\n**Bold**, *emphasis* and math $a+b=c$.\n\n'
+            '> A quote before the image.\n\n' + '\n\n'.join(
+                f'![{image}](image-cache-assets/{image})' for image in images) +
+            '\n\n## Content after images\n\n| Column | Value |\n| --- | --- |\n'
+            '| Test | `code` |\n\n- A list item.\n', encoding='utf-8')
+        target = run(name, [executable, source, '--printpages', output / name / 'pages'])
+        assert list((target / 'pages').glob('page-*.png'))
+
+    before = {str(p): hashlib.sha256(p.read_bytes()).hexdigest()
+              for p in [fixture, *assets.iterdir()]}
+    for mode, destination in [('printpages', 'pages'), ('exporthtml', 'document.html'),
+                              ('exportdocx', 'document.docx'), ('exportpdf', 'document.pdf')]:
+        target = output / ('mixed-' + mode)
+        run('mixed-' + mode, [executable, fixture, '--' + mode, target / destination])
+        assert (target / destination).exists()
+    html = (output / 'mixed-exporthtml/document.html').read_text(encoding='utf-8')
+    for marker in ['<h1', '<h2', '<table', '<blockquote', '<pre', '<strong>', '<em>', '<svg',
+                   'All surrounding content']:
+        assert marker in html, marker
+    expected = {(assets / name).read_bytes() for name in
+                ['small.png', 'large.jpg', 'alpha.png', 'dpi.png', 'wide.png']}
+    embedded = {base64.b64decode(value) for value in
+                re.findall(r'data:image/[^;]+;base64,([^"\s]+)', html)}
+    assert expected <= embedded, 'HTML changed/missed original images'
+    with zipfile.ZipFile(output / 'mixed-exportdocx/document.docx') as docx:
+        media = {docx.read(name) for name in docx.namelist() if name.startswith('word/media/')}
+        assert expected <= media, 'DOCX changed/missed original images'
+        assert b'All surrounding content' in docx.read('word/document.xml')
+    assert (output / 'mixed-exportpdf/document.pdf').read_bytes().startswith(b'%PDF-')
+    assert before == {name: hashlib.sha256(Path(name).read_bytes()).hexdigest() for name in before}
+
+    class QuietHandler(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, *unused):
+            pass
+
+    server = http.server.ThreadingHTTPServer(('127.0.0.1', 0),
+        functools.partial(QuietHandler, directory=str(assets)))
+    worker = threading.Thread(target=server.serve_forever, daemon=True)
+    worker.start()
+    try:
+        remote = output / 'remote-native'
+        remote.mkdir(exist_ok=True)
+        # Copy beside isolated settings so the test cannot load personal config.
+        shutil.copy2(args.input_tests.resolve(), remote / 'input_tests.exe')
+        (remote / 'settings.ini').write_text('; Isolated remote image tests\n')
+        run('remote-native', [remote / 'input_tests.exe', '--image-tests',
+            f'http://127.0.0.1:{server.server_port}'], cwd=remote)
+    finally:
+        server.shutdown()
+        server.server_close()
+        worker.join()
+    report = dict(binary_sha256=hashlib.sha256(executable.read_bytes()).hexdigest(),
+                  large_jpeg_bytes=(assets / 'large.jpg').stat().st_size, results=results)
+    (output / 'results.json').write_text(json.dumps(report, indent=2), encoding='utf-8')
+    print('Native rendering, original-image exports and localhost downloads passed.', flush=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A large image could evict a bitmap that the document still needed to draw, crashing Tinta with an access violation. I gave the layout and cache independent bitmap ownership, corrected pixel-memory accounting, and shared bounded WIC decoding between local and downloaded images. Invalid or excessive raster inputs use the existing alt-text placeholder; HTML and DOCX retain original image bytes. Reported by @glance02 in #220.

I also removed unused variables and arguments, renamed shadowed locals, and made narrowing conversions explicit without suppressing compiler warnings.

Validation: all-target Release build with zero warnings; 21/21 CTests; reproduced 3.7.0 crash cases now pass; localhost HTTP decoding, lightbox, normal/narrow Paper/Midnight views, mixed headings/tables/quotes/math/code, and HTML/DOCX/PDF exports checked. Tests generate large image assets outside Git. Details are in tests/image-cache-validation.md and tests/compiler-warning-cleanup-validation.md.

Addresses #220. The release will close the issue after v3.7.1 is published.
